### PR TITLE
makemake: Stage Hydra PR 1316

### DIFF
--- a/ngi0/makemake/flake.lock
+++ b/ngi0/makemake/flake.lock
@@ -22,15 +22,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1701446871,
-        "narHash": "sha256-ILB2BOaNY+UBs8iSMZYJI2LfV+R/+I6zU9kV1/Sz6oU=",
+        "lastModified": 1701903565,
+        "narHash": "sha256-CBiJjoReHRMPvDFHxTnrfgte/i6D2s1dmAOeAKKA7Uc=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "f216bce0e62654ab4809003ec0756ee3e40d5172",
+        "rev": "11f8030b0f4c75ed7640563d68200cf3ec59edec",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "ca-derivations-prep",
         "repo": "hydra",
         "type": "github"
       }

--- a/ngi0/makemake/flake.nix
+++ b/ngi0/makemake/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs.nixpkgs.follows = "hydra/nixpkgs";
   inputs.nix.follows = "hydra/nix";
-  inputs.hydra.url = "github:NixOS/hydra";
+  inputs.hydra.url = "github:NixOS/hydra/ca-derivations-prep";
 
   outputs = { self, nixpkgs, nix, hydra }: {
 


### PR DESCRIPTION
That is https://github.com/NixOS/hydra/pull/1316, preparation for broader CA derivations support in a way that does not require scheme changes.

---

This is already deployed, I am just ending this PR so reality and this PR stay in sync. Is there a better way?

CC @tomberek 