### PR TITLE
matrix-synapse: init on caliban

### DIFF
--- a/delft/pluto/prometheus/default.nix
+++ b/delft/pluto/prometheus/default.nix
@@ -12,6 +12,7 @@
     ./exporters/github.nix
     ./exporters/hydra.nix
     ./exporters/json.nix
+    ./exporters/matrix-synapse.nix
     ./exporters/nixos.nix
     ./exporters/node.nix
     ./exporters/packet-sd.nix

--- a/delft/pluto/prometheus/exporters/matrix-synapse.nix
+++ b/delft/pluto/prometheus/exporters/matrix-synapse.nix
@@ -1,0 +1,11 @@
+{
+  services.prometheus.scrapeConfigs = [ {
+    job_name = "matrix_synapse";
+    scheme = "https";
+    static_configs = [ {
+      targets = [
+        "matrix.nixos.org:443"
+      ];
+    } ];
+  } ];
+}

--- a/non-critical-infra/flake.lock
+++ b/non-critical-infra/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713152224,
-        "narHash": "sha256-k1aV06cotPwWO3FW+ho+dEoGjxNM303+UmhiG2o6XPs=",
+        "lastModified": 1716168343,
+        "narHash": "sha256-82oT27w9smpItZ+PyN2C0PjIwZYbIocwXSM4u1igXuc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bb5ba68ebb73b5ca7996b64e1457fe885891e78e",
+        "rev": "6f01b9710bc4d3bf006eb8df928b4b15e0430901",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713013257,
-        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
+        "lastModified": 1716061101,
+        "narHash": "sha256-H0eCta7ahEgloGIwE/ihkyGstOGu+kQwAiHvwVoXaA0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
+        "rev": "e7cc61784ddf51c81487637b3031a6dd2d6673a2",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713042715,
-        "narHash": "sha256-RifMwYuKu5v6x6O65msKDTqKkQ9crGwOB7yr20qMEuE=",
+        "lastModified": 1716061101,
+        "narHash": "sha256-H0eCta7ahEgloGIwE/ihkyGstOGu+kQwAiHvwVoXaA0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c27f3b6d8e29346af16eecc0e9d54b1071eae27e",
+        "rev": "e7cc61784ddf51c81487637b3031a6dd2d6673a2",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713174909,
-        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
+        "lastModified": 1716087663,
+        "narHash": "sha256-zuSAGlx8Qk0OILGCC2GUyZ58/SJ5R3GZdeUNQ6IS0fQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
+        "rev": "0bf1808e70ce80046b0cff821c019df2b19aabf5",
         "type": "github"
       },
       "original": {
@@ -244,11 +244,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712943026,
-        "narHash": "sha256-x2PaFsoZjqm2mC8dbUbv93to8H7wAruauluOH81lzA8=",
+        "lastModified": 1716166358,
+        "narHash": "sha256-SmCc4nKUXgYb8bBGJ3+N+l/2MBROue2x9+CyJ2of24w=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "bed9cfce2adc4c72de9bc90656d5cfe66e4371f3",
+        "rev": "d368bfdc3a409482b92290a105bcacc108a49d24",
         "type": "github"
       },
       "original": {

--- a/non-critical-infra/hosts/caliban.nixos.org/default.nix
+++ b/non-critical-infra/hosts/caliban.nixos.org/default.nix
@@ -8,6 +8,7 @@
       inputs.srvos.nixosModules.hardware-hetzner-online-amd
       ../../modules/first-time-contribution-tagger.nix
       ../../modules/backup.nix
+      ../../modules/matrix-synapse.nix
       ../../modules/vaultwarden.nix
     ];
 

--- a/non-critical-infra/hosts/caliban.nixos.org/default.nix
+++ b/non-critical-infra/hosts/caliban.nixos.org/default.nix
@@ -8,6 +8,7 @@
       inputs.srvos.nixosModules.hardware-hetzner-online-amd
       ../../modules/first-time-contribution-tagger.nix
       ../../modules/backup.nix
+      ../../modules/element-web.nix
       ../../modules/matrix-synapse.nix
       ../../modules/vaultwarden.nix
     ];

--- a/non-critical-infra/modules/backup.nix
+++ b/non-critical-infra/modules/backup.nix
@@ -1,10 +1,24 @@
 { lib
 , config
+, pkgs
 , ...
 }:
 
 let
   cfg = config.services.backup;
+
+  mkZfsPreHook = mountpoint: ''
+    DATASET="$(findmnt -nr -o source "${mountpoint}")"
+    zfs snapshot -r "$DATASET@borg"
+
+    # https://github.com/borgbackup/borg/issues/6652
+    ls ${mountpoint}/.zfs/snapshot/borg/ > /dev/null
+  '';
+
+  mkZfsPostHook = mountpoint: ''
+    DATASET="$(findmnt -nr -o source "${mountpoint}")"
+    zfs destroy -r "$DATASET@borg"
+  '';
 in
 {
   options.services.backup = with lib; with types; {
@@ -71,6 +85,13 @@ in
         Paths to include in the backup.
       '';
     };
+    includesZfsDatasets = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        ZFS datasets referenced by mountpoint to snapshot and include
+      '';
+    };
 
     excludes = mkOption {
       type = listOf path;
@@ -105,7 +126,7 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.includes != []) {
+  config = lib.mkIf (cfg.includes != [] || cfg.includesZfsDatasets != []) {
     programs.ssh.knownHosts."${if cfg.port != 22 then "[${cfg.host}]:${cfg.port}" else cfg.host}" = {
       publicKey = "${cfg.hostPublicKey}";
     };
@@ -113,6 +134,11 @@ in
     systemd.services.borgbackup-job-state = {
       wants = cfg.wantedUnits;
       after = cfg.wantedUnits;
+
+      path = lib.optionals (cfg.includesZfsDatasets != []) [
+        config.boot.zfs.package
+        pkgs.util-linux
+      ];
     };
 
     systemd.timers.borgbackup-job-state.timerConfig = {
@@ -122,7 +148,8 @@ in
     };
 
     services.borgbackup.jobs.state = {
-      inherit (cfg) preHook postHook;
+      preHook = lib.concatMapStringsSep "\n" mkZfsPreHook cfg.includesZfsDatasets;
+      postHook = lib.concatMapStringsSep "\n" mkZfsPostHook cfg.includesZfsDatasets;
 
       # Create the repo
       doInit = true;
@@ -136,11 +163,12 @@ in
       };
 
       # What to backup
-      paths = cfg.includes;
+      paths = cfg.includes ++
+        (map (mp: "${mp}/.zfs/snapshot/borg") cfg.includesZfsDatasets);
       exclude = cfg.excludes;
 
       # Where to backup it to
-      repo = "${cfg.user}@${cfg.host}:${config.networking.fqdn}/repo";
+      repo = "${cfg.user}@${cfg.host}:${config.networking.fqdn}";
       environment.BORG_RSH = "ssh -p ${cfg.port} -i ${cfg.sshKey}";
 
       # Ensure we don't fill up the destination disk

--- a/non-critical-infra/modules/element-web.nix
+++ b/non-critical-infra/modules/element-web.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+let
+  domainName = "chat.nixos.org";
+
+  # https://github.com/element-hq/element-web/blob/develop/config.sample.json
+  elementWebConfig = {
+    default_server_config = {
+      "m.homeserver" = {
+        base_url = "https://matrix.nixos.org";
+        server_name = "nixos.org";
+      };
+      "m.identity_server" = {
+        base_url = "https://vector.im";
+      };
+    };
+    disable_custom_urls = false;
+    disable_guests = false;
+    disable_login_language_selector = false;
+    disable_3pid_login = false;
+    brand = "Element";
+    integrations_ui_url = "https://scalar.vector.im/";
+    integrations_rest_url = "https://scalar.vector.im/api";
+    integrations_widgets_urls = [
+      "https://scalar.vector.im/_matrix/integrations/v1"
+      "https://scalar.vector.im/api"
+      "https://scalar-staging.vector.im/_matrix/integrations/v1"
+      "https://scalar-staging.vector.im/api"
+      "https://scalar-staging.riot.im/scalar/api"
+    ];
+    integrations_jitsi_widget_url = "https://scalar.vector.im/api/widgets/jitsi.html";
+    bug_report_endpoint_url = "https://riot.im/bugreports/submit";
+    default_country_code = "GB";
+    show_labs_settings = true;
+    features = { };
+    default_federate = true;
+    default_theme = "light";
+    roomDirectory = {
+      servers = [ ];
+    };
+    settingDefaults = {
+      breadcrumbs = true;
+    };
+    jitsi = {
+      preferred_domain = "meet.element.io";
+    };
+    element_call = {
+      url = "https://call.element.io";
+      participant_limit = 8;
+      brand = "Element Call";
+    };
+    map_style_url = "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx";
+  };
+in
+{
+  security.acme.certs."${domainName}".reloadServices = [ "nginx.service" ];
+
+  services.nginx.virtualHosts."${domainName}" = {
+    enableACME = true;
+    forceSSL = true;
+
+    root = pkgs.element-web.override (old: {
+      conf = elementWebConfig;
+    });
+  };
+}

--- a/non-critical-infra/modules/matrix-synapse.nix
+++ b/non-critical-infra/modules/matrix-synapse.nix
@@ -1,0 +1,171 @@
+{ config
+, pkgs
+, ...
+}:
+
+{
+  imports = [
+    ./nginx.nix
+    ./postgresql.nix
+  ];
+
+  fileSystems."/var/lib/matrix-synapse" = {
+    device = "zroot/root/matrix-synapse";
+    fsType = "zfs";
+    options = [
+      "zfsutil"
+    ];
+  };
+
+  services.postgresql = {
+    ensureUsers = [ {
+      name = "matrix-synapse";
+      ensureDBOwnership = true;
+    } ];
+    # Insufficient to create the database with the correct collation
+    # https://github.com/element-hq/synapse/blob/develop/docs/postgres.md#set-up-database
+    ensureDatabases = [
+      "matrix-synapse"
+    ];
+  };
+
+  services.postgresqlBackup.databases = [
+    "matrix-synapse"
+  ];
+
+  services.redis.servers.matrix-synapse = {
+    enable = true;
+  };
+
+  environment.systemPackages = with pkgs; [
+    matrix-synapse-tools.synadm
+  ];
+
+  services.backup.includesZfsDatasets = [
+    "/var/lib/matrix-synapse"
+  ];
+
+  sops.secrets.matrix-synapse-signing-key = {
+    sopsFile = ../secrets/matrix-synapse-signing-key.caliban;
+    format = "binary";
+    path = "/var/lib/matrix-synapse/nixos.org.signing.key";
+    mode = "0600";
+    owner = "matrix-synapse";
+    group = "matrix-synapse";
+  };
+
+  sops.secrets.matrix-synapse-secrets = {
+    sopsFile = ../secrets/matrix-synapse-secrets.caliban;
+    format = "binary";
+    path = "/var/keys/matrix-synapse-secrets.conf";
+    mode = "0600";
+    owner = "matrix-synapse";
+    group = "matrix-synapse";
+  };
+
+  systemd.services.matrix-synapse.serviceConfig.SupplementaryGroups = [
+    "redis-matrix-synapse"
+  ];
+
+  #systemd.services.matrix-synapse.enable = false;
+
+  services.matrix-synapse = {
+    enable = true;
+    withJemalloc = true;
+
+    extraConfigFiles = [
+      config.sops.secrets.matrix-synapse-secrets.path
+    ];
+
+    # https://github.com/element-hq/synapse/blob/master/docs/usage/configuration/config_documentation.md
+    settings = {
+      enable_metrics = true;
+
+      server_name = "nixos.org";
+      signing_key_path = config.sops.secrets.matrix-synapse-signing-key.path;
+      public_baseurl = "https://matrix.nixos.org";
+      admin_contact = "infra@nixos.org";
+      web_client_location = "https://matrix.to/#/#community:nixos.org";
+
+      allow_public_rooms_over_federation = true;
+      allow_public_rooms_without_auth = true;
+
+      max_upload_size = "50M";
+
+      media_retention = {
+        local_media_lifetime = "90d";
+        remote_media_lifetime = "14d";
+      };
+
+      database = {
+        name = "psycopg2";
+        args = {
+          host = "/run/postgresql";
+        };
+      };
+
+      redis = {
+        enabled = true;
+        path = config.services.redis.servers.matrix-synapse.unixSocket;
+      };
+
+      listeners = [ {
+        type = "http";
+        # TODO: migrate to UNIX domain socket
+        #path = "/run/matrix-synapse/matrix-synapse.sock";
+        #mode = "0660";
+        port = 8008;
+        tls = false;
+        resources = [ {
+          compress = true;
+          names = [
+            "client"
+          ];
+        } {
+          compress = false;
+          names = [
+            "federation"
+          ];
+        } ];
+      } {
+        type = "http";
+        bind_addresses = [
+          "127.0.0.1"
+          "::1"
+        ];
+        port = 8090;
+        tls = false;
+        resources = [ {
+          names = [
+            "metrics"
+          ];
+        } ];
+      } ];
+    };
+  };
+
+  systemd.services.nginx.serviceConfig.SupplementaryGroups = [ "matrix-synapse" ];
+
+  services.nginx = {
+    clientMaxBodySize = config.services.matrix-synapse.settings.max_upload_size;
+    upstreams."matrix-synapse".servers = {
+      # TODO: migrate to UNIX domain socket
+      #"unix:/run/matrix-synapse/matrix-synapse.sock" = {};
+      "localhost:8008" = {};
+    }; 
+    virtualHosts."matrix.nixos.org" = {
+      forceSSL = true;
+      enableACME = true;
+
+      locations."~* ^(\/_matrix|\/_synapse)" = {
+        proxyPass = "http://matrix-synapse";
+      };
+      locations."= /metrics" = {
+        proxyPass = "http://localhost:8090/_synapse/metrics";
+      };
+      locations."= /" = {
+        return = "301 https://matrix.to/#/#community:nixos.org";
+      };
+    };
+  };
+}

--- a/non-critical-infra/modules/mjolnir.nix
+++ b/non-critical-infra/modules/mjolnir.nix
@@ -22,7 +22,7 @@
 
   services.mjolnir = {
     enable = true;
-    homeserverUrl = "https://nixos.ems.host:443";
+    homeserverUrl = "https://matrix.nixos.org:443";
 
     pantalaimon = {
       enable = true;

--- a/non-critical-infra/modules/nginx.nix
+++ b/non-critical-infra/modules/nginx.nix
@@ -1,0 +1,27 @@
+{
+  networking.firewall = {
+    allowedTCPPorts = [ 80 443 ];
+  };
+
+  # Grant nginx access to certificates
+  systemd.services.nginx.serviceConfig.SupplementaryGroup = [
+    "acme"
+  ];
+
+  # Reload nginx after certificate renewal
+  security.acme.defaults.reloadServices = [
+    "nginx.service"
+  ];
+
+  services.nginx = {
+    enable = true;
+    enableReload = true;
+
+    recommendedBrotliSettings = true;
+    recommendedGzipSettings = true;
+    recommendedOptimisation = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+    recommendedZstdSettings = true;
+  };
+}

--- a/non-critical-infra/modules/postgresql.nix
+++ b/non-critical-infra/modules/postgresql.nix
@@ -1,0 +1,39 @@
+{ config
+, pkgs
+, ...
+}:
+
+{
+  fileSystems."/var/lib/postgresql" = {
+    device = "zroot/root/postgresql";
+    fsType = "zfs";
+    options = [
+      "zfsutil"
+    ];
+  };
+
+  services.postgresql = {
+    enable = true;
+    enableJIT = true;
+    package = pkgs.postgresql_16_jit;
+  };
+
+  # create database dumps
+  services.postgresqlBackup = {
+    enable = true;
+    compression = "zstd";
+    # pulled in through the backup job
+    startAt = [];
+  };
+
+  # include postgres dumps in the backup
+  services.backup = {
+    includes = [
+      "/var/backup/postgresql"
+    ];
+    wantedUnits = if config.services.postgresqlBackup.databases == [] then
+      [ "postgresqlBackup.service" ]
+    else
+      map (db: "postgresqlBackup-${db}.service") config.services.postgresqlBackup.databases;
+  };
+}

--- a/non-critical-infra/secrets/matrix-synapse-secrets.caliban
+++ b/non-critical-infra/secrets/matrix-synapse-secrets.caliban
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:DR4VtLpBFM90uasJLqEdu7LQ0x3rof4qxuSlBtAfPVSVfKOYFx/NBYGdHIt/A45mhKIq/Rp14GK6pFX4mxt+9LhZHdaPUoiJ3OzW2Iwn0faevevvH1t9bA/rw2+UB9iGW9NtK6IsSdKzqsazlLCrM9nYlvkpMQCaWw==,iv:otJmMFZ5HvjKK4JyBbYizw0ZW2D4TWhKebY1F2Im+Bk=,tag:fcehpFiM6HMgS6bjbLRx4Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1MW1WZ1VWWWwxbnAwcHdt\nM041MCtWMm5LbDdFVEd3alVaV2tSeEErRzFRCkRzOXRCOE1jRTIvcUhXWXozS1h5\nTlEyL2E3NmFUSkhTZCszYyt0a3JVUm8KLS0tIGxUUDBYaXk2NnF2alJaaFNGWTFH\nYXloZFNIVFZET0RZTndvM1VtMGpDTGsKK5HIxpvdy1HGOlp0MGd83u0A9KPbSK+4\n15023XKE/5zuFOzWOtxyxA/A8O6MnGIrw8tOVzXp5bFRwRWa/g/a0A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbk1ORTNCVzhPWWZJcHAy\nUlFYcmwrUlE0OXJ5TDNIbTdXWm1SdHJYalZjClQvNjJQSGp1ZTlzU2htL1N5QS81\nUzRjc3NjVGovVXhaRkNVbEhhMGJLdUkKLS0tIHdibjNrRDV1UW5Qdlp6UVE1RGNv\nd1lESFZDUmVYSmd4dC8zWHU4TU1PY3MKGkdm8io6SP0oAJeOFEjB/lbZB9XI4UMa\nnfmiA9NbwovvBATiYhNpEcpQ+lxhcR59a7ZyTWexWxtMfDvhJ1HrQw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMYVhGc1F0SlN3SnpWamFF\nYkFuSUxPWmxTM3E0R0R4RlBIYVJBKzhNMEFnCkVTbW1VRWpUYUJYSHRoWTBIWFc3\nd2xxWEViNHlza1o3cEtwSUVYcDl2TW8KLS0tIGdxSmRxd2YzY0Q1b2V3aGtzMHRo\nRFNmYUVvTDljVTJnQjZsamVjSUt5QW8KZGntSWX35XlLeKkuw/BmBuWKKEasCyyP\nn+/2rokVu/DTKiTaTMJXUd2CWj7qNc7HwCMV8ibOGjkIi7KQNYwNuQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXUkdjK04wOEJZQ3hTYzI1\ncU9MTCtpT2RPSmhWOHd1emNGakorR2RPVEVnCmI3Y3ZEYkZMNEQ0QTloM2VaMXVF\nSGZvK25rV1N0R3h0Vy9VV3BUd2QxbGMKLS0tIE90YkpqQTFPVVpISC9jYzU0SHNV\nQ0JmMWx1cEp0cjRsaVk4WUEwWVJSbDgKKJGl6cv+IAz1h3XZyL/W1Q2l6nZXmEyQ\nB5nCzVY/Yr2g45eIjfTZKCo2ORxG6HvDkK8MnVpMr3dfCv7XbRi7qA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2024-05-20T18:18:09Z",
+		"mac": "ENC[AES256_GCM,data:/GTwJwCXHqE/iOpcPCU69W1nV8SUBr3rauQ7aZP8N777yQzieka8/trJuMvuaJBg0cotm7Vr5krwrZC8kOqoZcf2jIK3E4p7/Y8Eos30VZIGnkF64FFjBACbxjwox+xUsOGxV9mGF1qQcZFx4L/S98qWzeReZV60HqGWshh6+pc=,iv:C0GN3+dRiguHA5YFhw/AFWfYItVKiy7Sqz0rR+07GM8=,tag:lyGhs+8Abb1Rp+qaQ9MFSg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/non-critical-infra/secrets/matrix-synapse-signing-key.caliban
+++ b/non-critical-infra/secrets/matrix-synapse-signing-key.caliban
@@ -1,0 +1,32 @@
+{
+	"data": "ENC[AES256_GCM,data:FcqlB9tJ2ZfjhoYfvC82Ik8F120my/ZfRDg9eqEdwNkI51QaqjIhAzlAcyHmO+b2G/c9U5cy2bvMUgU=,iv:5ZsY473w3kQP4qK8CPdXCR90GTnn60I3LqGm/HMhuL4=,tag:0s/qx94SeE+580724rSgGA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQRHU0d3VjN0loVlpZTjF0\nUS9BSUF2ZHFIcHBIRTNFYkFrbkYyUDFKaGlvCld2RWpTK0ZucGk4ak1Mdk1LOGNF\nTm5zUVduaVNINUJyTzl5KzNTSEY3MmcKLS0tIEgyWjZZYVVSK2VkRlNxM29keXpz\nSTIza1lCdUhVdUFFSU9sRFJzVXQ1NzQKyN8JSEWuGxibgdozgcoEEfXTjlHV0Lro\n9LysFUn88RjHDvYX7c5V41NOQUESJcPK3DI78yxHWzsHpmWMjNtsBA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpM2dEcnJ2MG81bkdtbGFk\nNXZaSTdGZUNOVXQ0dWNvMXFFSGlZcTBwN1JNCm5YOVpjU3dOY3pGNG5XdUhxcFhN\nMzJjK1JOSExmeW5nL001WHhyYmhzUkkKLS0tIDEyR1VrcjdOa01IbEhBZ3lSTUdn\nZlRXRjFUVTMyNmN0eFBJaXdKVTVOVzQKvcpNDONcstOtRzu++3Odt9F0IhG/FB0t\nmPHw6zfYSjmpSv+nVXSOUpNnk9pcGWWtQojHukhXLMIAXssGH0hggg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1qlwzeg37fwwn2l6fm3quvkn787nn0m89xrjtrhgf9uedtfv2kqlqnec976",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVcFN1OUJvbXFKNHVIRk8r\nNTFkK3BaYUpmaGxIRWROaW1WQjQyN1FXZm1VCkh5YVVocExJYjQ4eUNuSVNvY0ww\nZlVnWlJJQUQwSHlGeUJDQ1ducEE0Qm8KLS0tIHdSdTRjRFMvZkN6VSszTlk4ZjN5\nUHdQRjh5NG84eDRzMkxqaWd4OGRDZTAKc01sHFNXUbi29RtvdKe4AOsVagqj7GDT\nfeiKgMhn5kEz3Rex75gDKa7nZf4bfWOlQrKrnC6L5t4G684qoChf6A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbWZTTnJ6V0hMZEIvWWRY\nMDJZTFJtVnJqTEJrVGZhUGRyRThZRUVlblNJCmRMUTFhMEZmY2xOTzgwdkZqRVht\naUVWd2IxY0M1YU11TEhCQnhJQzVRQm8KLS0tIGFxNnp0S0dobVJiL1pxMlFSTkNQ\na3JvN0xEUFROcUVXUDVKSndhSjQ1cXcKNHzS6W8Kbvo67rICS0w5HSTcEgztBpzP\nvL8yeNh1iAcWs3YtVnmitl5dwDMxNQFiWsbOxPr/vhHN64bS4J+MHA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2024-05-20T19:05:40Z",
+		"mac": "ENC[AES256_GCM,data:tM0GE88qNSKpy/QUJDl4okf5eMbJKSiiCZrAfbJtz8V+nqiwqSTx0PYUjLcd2TIXHIicNg8bGovAp21Pm4YtOXMgLygFfNxWnGVXe2w9RcinUDOtXE1MwhJrDV3dvGWQg8C58LgzDWiq+kqgrR4m5YOk3mZUPU4dvj8HQcQ8C4s=,iv:w3nI1jPi+ObeHz32qhiXR/Zf9cRvYXJCMixkPTE+JBw=,tag:lGVfIjwKUgtez//4Uh94hg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -152,11 +152,6 @@ locals {
       value    = "dualstack.v2.shared.global.fastly.net"
     },
     {
-      hostname = "chat.nixos.org"
-      type     = "CNAME"
-      value    = "nixos.element.io."
-    },
-    {
       hostname = "conf.nixos.org"
       type     = "CNAME"
       value    = "nixconberlin.github.io"
@@ -275,6 +270,16 @@ locals {
       hostname = "caliban.nixos.org"
       type     = "A"
       value    = "65.109.26.213"
+    },
+    {
+      hostname = "chat.nixos.org"
+      type     = "CNAME"
+      value    = "caliban.nixos.org."
+    },
+    {
+      hostname = "matrix.nixos.org"
+      type     = "CNAME"
+      value    = "caliban.nixos.org."
     },
     {
       hostname = "vault.nixos.org"


### PR DESCRIPTION
Draft of the matrix-synapse deployment.

Does not yet build, because I'm waiting on UDS support for the synapse listeners, which people are currently actively working on.

- Generic nginx module
- Generic PostgreSQL module with backup integration
- Matrix Synapse module
- Promtheus scraping for Synapse

Depends on
- #345
- https://github.com/NixOS/nixpkgs/pull/286172

Follow-up:
- https://github.com/NixOS/nixos-homepage/pull/1218