### PR TITLE
eris: alert on failed systemd services

### DIFF
--- a/delft/eris.nix
+++ b/delft/eris.nix
@@ -227,6 +227,14 @@ in
                   annotations.summary = "{{ $labels.device }} mounted to {{ $labels.mountpoint }} ({{ $labels.fstype }}) on {{ $labels.instance }} has {{ $value }} GB free.";
                   annotations.grafana = "https://monitoring.nixos.org/grafana/d/5LANB9pZk/per-instance-metrics?orgId=1&refresh=30s&var-instance={{ $labels.instance }}";
                 }
+
+                {
+                  alert = "SystemdUnitFailed";
+                  expr = ''node_systemd_unit_state{state="failed"} == 1'';
+                  for = "15m";
+                  labels.severity = "warning";
+                  annotations.summary = "systemd unit {{ $labels.name }} on {{ $labels.instance }} has been down for more than 15 minutes.";
+                }
               ];
           }
 


### PR DESCRIPTION
There might be some initial flakiness due to some badly behaved services, e.g. hydra-scale-equinix-metal, but nothing that we can't silence away and properly fix later.

15m is a very conservative threshold, I'm expecting to push it down at some point once things get more under control.