### PR TITLE
Migrate nix configuration into nix.settings

### DIFF
--- a/delft/eris-physical.nix
+++ b/delft/eris-physical.nix
@@ -50,7 +50,7 @@
           boot.kernelModules = [ "kvm-intel" ];
           boot.extraModulePackages = [ ];
 
-          nix.maxJobs = lib.mkDefault 8;
+          nix.settings.max-jobs = lib.mkDefault 8;
           powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
         })
       ];

--- a/delft/haumea-physical.nix
+++ b/delft/haumea-physical.nix
@@ -36,7 +36,7 @@
           boot.kernelModules = [ "kvm-amd" ];
           boot.extraModulePackages = [ ];
 
-          nix.maxJobs = lib.mkDefault 16;
+          nix.settings.max-jobs = lib.mkDefault 16;
           powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
         })
       ];

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -10,12 +10,15 @@ with lib;
   users.extraUsers.root.openssh.authorizedKeys.keys =
     with import ../ssh-keys.nix; infra-core;
 
-  nix.useSandbox = true;
-  nix.buildCores = 0;
-  nix.extraOptions =
-    ''
-      experimental-features = nix-command flakes
-    '';
+  nix = {
+    settings = {
+      cores = 0;
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+    };
+  };
 
   environment.systemPackages =
     [ pkgs.emacs


### PR DESCRIPTION
This removes the deprecation warnings from the nix module. The sandbox config is dropped on purpose, since the sandbox is enabled by default.