### PR TITLE
.github: add CODEOWNERS for core-infra owner parts of the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Every directory containing configurations impacting the core infra needs a
+# review from a member of core infra.
+.github/                  @NixOS/infra-build
+bastion/                  @NixOS/infra-build
+delft/                    @NixOS/infra-build
+hydra-packet-importer/    @NixOS/infra-build
+lib/                      @NixOS/infra-build
+macs/                     @NixOS/infra-build
+metrics/                  @NixOS/infra-build
+modules/                  @NixOS/infra-build
+terraform-iam/            @NixOS/infra-build
+terraform/                @NixOS/infra-build
+channels.nix              @NixOS/infra-build
+ssh-keys.nix              @NixOS/infra-build


### PR DESCRIPTION
A bit messy since the directory structure isn't great right now, and I have not tested to check that this actually does what I want it to. But from my reading of the branch protection settings, it should.

cc @JulienMalka - this should allow you to review and merge changes that don't touch the core infra. I kinda wanted to figure this out before we onboard more people :)

-----

Combined with branch protection, this should allow for the following:
- PRs that impact these directories will require approval from at least one core-infra member.
- PRs that do not impact these directories can be approved by anyone who has write access to the repo (incl. non-critical infra members)
- Only core-infra members can push without going through a PR.