### PR TITLE
pluto: configure backups

### DIFF
--- a/delft/pluto/default.nix
+++ b/delft/pluto/default.nix
@@ -1,3 +1,7 @@
+{ config
+, ...
+}:
+
 {
   imports = [
     ../common.nix
@@ -20,6 +24,18 @@
     hostName = "pluto";
     domain = "nixos.org";
     hostId = "e4c9bd10";
+  };
+
+  age.secrets.pluto-backup-ssh-key.file = ../secrets/pluto-backup-ssh-key.age;
+  age.secrets.pluto-backup-secret.file = ../secrets/pluto-backup-secret.age;
+
+  services.backup = {
+    user = "u391032-sub2";
+    host = "u391032.your-storagebox.de";
+    hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIICf9svRenC/PLKIL9nk6K/pxQgoiFC41wTNvoIncOxs";
+    port = 23;
+    sshKey = config.age.secrets.pluto-backup-ssh-key.path;
+    secretPath = config.age.secrets.pluto-backup-secret.path;
   };
 
   nixpkgs.hostPlatform = "x86_64-linux";

--- a/delft/pluto/disko.nix
+++ b/delft/pluto/disko.nix
@@ -83,6 +83,14 @@
             type = "zfs_fs";
             mountpoint = "/";
           };
+          "root/prometheus" = {
+            type = "zfs_fs";
+            mountpoint = "/var/lib/prometheus2";
+          };
+          "root/victoriametrics" = {
+            type = "zfs_fs";
+            mountpoint = "/var/lib/victoriametrics";
+          };
         };
       };
     };

--- a/delft/pluto/grafana.nix
+++ b/delft/pluto/grafana.nix
@@ -1,4 +1,8 @@
 {
+  services.backup.includes = [
+    "/var/lib/grafana"
+  ];
+
   services.grafana = {
     enable = true;
     auth.anonymous.enable = true;

--- a/delft/pluto/nixos-metrics.nix
+++ b/delft/pluto/nixos-metrics.nix
@@ -30,6 +30,10 @@
     timerConfig.OnCalendar = "12:00:00";
   };
 
+  services.backup.includesZfsDatasets = [
+    "/var/lib/victoriametrics"
+  ];
+
   services.victoriametrics = {
     enable = true;
     retentionPeriod = 1200; # 100 years

--- a/delft/pluto/prometheus/default.nix
+++ b/delft/pluto/prometheus/default.nix
@@ -1,3 +1,7 @@
+{ config
+, ...
+}:
+
 {
   imports = [
     ./alertmanager.nix
@@ -28,6 +32,10 @@
 
   networking.firewall.allowedTCPPorts = [
     9090
+  ];
+
+  services.backup.includesZfsDatasets = [
+    "/var/lib/prometheus2"
   ];
 
   services.prometheus = {

--- a/delft/secrets.nix
+++ b/delft/secrets.nix
@@ -7,6 +7,8 @@ let
     hydra-mirror-aws-credentials = [ machines.pluto ];
     hydra-mirror-git-credentials = [ machines.pluto ];
     packet-sd-env = [ machines.pluto ];
+    pluto-backup-secret = [ machines.pluto ];
+    pluto-backup-ssh-key = [ machines.pluto ];
     prometheus-packet-spot-market-price-exporter = [ machines.pluto ];
     rfc39-credentials = [ machines.pluto ];
     rfc39-github = [ machines.pluto ];

--- a/delft/secrets/pluto-backup-secret.age
+++ b/delft/secrets/pluto-backup-secret.age
@@ -1,0 +1,33 @@
+age-encryption.org/v1
+-> ssh-ed25519 s9hT2g iiqAVBIhC7vXmxEAgrzYWXOYGbs4L0ayT72YMC0MQRQ
+J4o6rL2z4685NRll1EXMVGqmblUSxqBCUIYYUUNoB3E
+-> ssh-ed25519 UnbSJQ 7cyyemPmnKRxXtaxkyiow+c4Faf4G4irZ4pc5VNuEnM
+/eU3lpb2Xe2r6+VnPa4g1UDUJQSpK16PeXu6IzglSok
+-> ssh-ed25519 Srtq2A aenMWRJTY5LzQqLa2wZpzjhkIZaQOvS1qZLKwmoYUTw
+BC0ty1E/0kjzVgDjdEB4VvfQowCqbOh5aZ8UNXekEBU
+-> ssh-ed25519 KdJNLg Qeli+hf2nj4jP824rEOD2EQB0WGMXucbUd/ijC7CSFc
+aiclFpnZXyXRoT4sqGNRjxDP+EY8Hnx4OE4IzE5KS1o
+-> ssh-ed25519 92bXiA 5FYsuCVeKM70p2+OhWEW6fAFPZInJbhzZmvd/Ezsr18
+hIUn4Mp1y188LIe/aIl2yPY0Exh+VHK4wdYPVN7akso
+-> ssh-rsa ytBgrw
+N3+N5DZyWWb8cZXM7f6kZaoE5q56PZLtDZAik69oCnnqzqcpJArv+jsiUktV6n6C
+2IzXhnugqfvhHsCEgvo/mfIg49Pk8l+qrgdgCLtx3tNl3haLDI5zqLVETrH8d2v+
+Z+aXIVwzi/sT/z9oqj6Up8oWrnEhmdugVdkQgNpndFQ2O+ZFEaexg85/9km/Joz4
+6qMrvr21FkX+BXqhtB01h0f44OSPD7nJdzeiyz3f7AGKQB4EYBcb7DgLFSMrrsU9
+RQF/VBwHmJ0b4kMu5k8ozNWnFhaPGWhXsn2bi+QAh5526wwoZ3+bnZfEvCzf5OKK
+hqFAFP+j9Fef5Im5pxmPRA
+-> ssh-rsa MuWD+w
+qL/PkS75WkFRkoQ18caMysXAWl4hF2TGZ65HDThuS+npmumdIZP1c9Zq2/nbTeO3
+Xj6SPHcQowD3HRqfZXNpsGmaSUBjufjd0sTZfQ9rauGxGSBmajxkHMNKupsk553D
+BoCfGzzKp7f5GD6hcisVf9+qXwMVo9oEBjyUxzDw0sjmGOt03Ri6OJVqxniwsawE
+aVIioeZrJxjaiQKotDF3UdYrbjmVipO2EBgl4bha88lAn2m/OjynnDSp7IS+gX81
+PORIh+0lXA0no2pQpZfcwBv7+P2oGV68IeQ34kuzBEoAwMVCxifnBaLxAOL7Jfj7
+4G5bzH3Pu3UvBzan5tJCMg
+-> ssh-ed25519 K3b7BA 4b9hz+nQHQDVT1BohPTavJD1iuwRZDayobLQ9rxCzjM
+hxrYeUV2WF3rSuNhZ8jkpOyK42/2+zOT2JXG9RnoqdQ
+-> ssh-ed25519 Gr9EaQ jEec7HKm8thPxkgHBDfZP1hFcM4XZkzmek47N75fZDg
+zPKVEwBE+ewrlgva1dBQxZep08i9fQNffvukadXZVCM
+-> ssh-ed25519 3ENwVg BByWp1z2wuuiVKRGO9AZw16+AaQ1c0CvoZQxbpxP/g4
+jljWkocfKTcFZT/MdFLTd5OS/ZXGzvgHOYhxUPqFEzo
+--- 4iVYGxgzCUMuxyglrZeXMcFH/NjG6iFD2f+CAZDn6R8
+ÒâË D„ÝøyÍ}|ÚiE¶Û%óÕÕª£ÓŒ²›¤ü¬žYX=Õ˜è¸ç±X ñRj´b¸ƒ¤\€¨×$T&6[ë©Ï°f÷AÞÒ"wF¡¥{F®ÐJJo¬è÷ê

--- a/delft/secrets/pluto-backup-ssh-key.age
+++ b/delft/secrets/pluto-backup-ssh-key.age
@@ -1,0 +1,34 @@
+age-encryption.org/v1
+-> ssh-ed25519 s9hT2g aesN54yE6iRtjWrvbZxECjtcQZ0mMhAwqiwZfLdfPhs
+BQFLoKIgsBecodxmXwZjzac1z7HuAmuAY5G3MG7oOr0
+-> ssh-ed25519 UnbSJQ HremC9/1t4/B2Efw+HYYr2anxH3w/yqkSfaZa9rZwjI
+8uHFcGmzAj1jBLNqNb9pjaYTv4g/x2ygcoTCrbBQ8mY
+-> ssh-ed25519 Srtq2A ig7wnZImKOx0PDsrvQ83WCAsNhYkCSoi/ZwipAz9rwc
+bKN00+zXr9mSkWsEU6p7Ky6hTi/sT/HOHZgi/57XIfk
+-> ssh-ed25519 KdJNLg ThVw8+COZC0RIeQ8q/hNNkUf5hIdqFBsbnvFk8W2zks
+UxBVIqhvNfpFL5SaiI+1CxNOn/TqScQ8n5kRQDbwxeA
+-> ssh-ed25519 92bXiA QNZI7LkoxGNwbaMNVg0Py+i8x0IwO6JPTS7IjuO1R0o
+lvenB/DsMpkN4u+PBIqx5DZQ8ljOBr1MLzieEZip8n0
+-> ssh-rsa ytBgrw
+AJjoczzWt3df+wSHqbmBjBAlehHNUTKP5Y3AZcnvDnT/M4UjakbgGhfPlgqzaaE4
+LbnyLu5916DmSAgy82d6B8WCflGq9YcCn9XJkMqLJZdldvFYeX1qZaJj7GzIRQp8
+jUq62BbY759tP5vWmYDm84lXMJ3XFXwmSo0mTsT3V11W0ktLnBp5qVAov7zOdFrL
+hpOX9wlM5sKnRmGyorlhKqFmPCD3zipmT/uq6qWM6HwT0LmwCiUZnY25sy1KVd9R
+f7Kvb9HGz+685tGR4xo9KvB0CTaJE9d/ZqArTt86T46JZhoKcGLmSW4EP2Tb4S/i
+KtEEdN6IfCHYbkghPsCGMg
+-> ssh-rsa MuWD+w
+FiqVtEobIRHrtRtXC/hDmxtOlFnsJhI6w2sdUGTMthxamveGMuEBjcUdBQQNW2ss
+IvwKYXd3rAlUgDImRSJqsYnvjpZG02hky3J6bQd47CWPxZZkznOm/+aLbDI8KhmB
+xIHFA6Qy6h0zC4XS0+riQZWI8G879Duyh5LW0a16Yuxy+cnwgxLZhfGrq72j4wAK
+MmMt9dFcPN2j0kDc34kjUZfZ62JxI1yWM6IP5Gkt/WtjY6ktdH5lTbMba3wdJvZI
+5vTFAM/6fwY8rYTXl9lFwBslLkL4dAsb/ZXvQPYiWT5QvoJ2GW6aaENzXDaEuxD9
+9L8FTs5tbL+0ttni+t/F3w
+-> ssh-ed25519 K3b7BA aGS/o8AhAKxWtNM+55WD+STDoEwKX/PojSk4dCvqcSs
+JukUiOnmyCYNXWpFbaIzclVQ1CbQva+j0ps+mS7IVEA
+-> ssh-ed25519 Gr9EaQ xvz/WMjkk9HDQDDCljJ6VtC1UizhyzaYH2lf6tu1/RE
+mObaIvIpjPZI0iMog1Ns9yeluA51lWCbn8YLsHBNuQA
+-> ssh-ed25519 3ENwVg wX6nR6ObE1y6jkRHOH6Ja0bfkwR5LdXirrHIm7L/Fnc
+BIw29tN0/NLJai67oRzjXXS4zm0bVJy1hKxe1t5a9rM
+--- oGcWJuUMV6P80XUtkV4E1Coq1CZ5uy4jbGUoDwAj6fg
+ˆ™#24'Ç·§²“ëÁ~ª]—0ê=M½1+ÎN5˜Ô^Úšhí­qaû=ìcRQKc›%#ÆÔO	4zù7[Žp–÷TÌ¬•U‰=ÏÛ¼
+ûˆ3zy(‘ŒÀ]Ü[,<hçŠ™n¶Ì€TƒM ò´2ÂÚ*ÔÚI·À¾ñ2÷?øÀ–íÀy|ê€’*¹÷¢`–!½’¾Äù–MaºçÖ‚‹`Û‘]U„š›F÷­B1^hæ~ßâÏOË‹ÆqÅØp$u¯ûº^U7×zu´þ¿Tâ;ÎBƒU†Â”‡¥jŠ©Ît´ÖUÅü¥6ŽyuµßˆÉÏë·ê:œ†‘«`s¼êÛ¿:ßé õÈ 8Ë»¨^ÓZúÌÛÍãò%ÍÔ½QˆŸŸ¨Rb …tÕ^ü}šý•ðÆZËƒ†RÏªv(ŠT A ’Ô|ŸÐñBÅRBÔø-”K”xæáMÜ'C-¦s&SþÂÉ"Ø°œÄ:šöýÏF‡œ"B–Í>PmHŸ4ŽQ¡ùVõR¦}^ÓÐŒ¤å¬Ù9—˜YKäoà1ÂU*Î¥|6€¸V

--- a/modules/backup.nix
+++ b/modules/backup.nix
@@ -1,0 +1,162 @@
+{ lib
+, config
+, ...
+}:
+
+let
+  cfg = config.services.backup;
+in
+{
+  options.services.backup = with lib; with types; {
+    user = mkOption {
+      type = str;
+      description = ''
+        Username for the SSH remote host.
+      '';
+    };
+
+    host = mkOption {
+      type = str;
+      description = ''
+        Hostname of the SSH remote host.
+      '';
+    };
+
+    hostPublicKey = mkOption {
+      type = str;
+      example = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EB5p/5Hp3hGW1oHok+PIOH9Pbn7cnUiGmUEBrCVjnAw+HrKyN8bYVV0dIGllswYXwkG/+bgiBlE6IVIBAq+JwVWu1Sss3KarHY3OvFJUXZoZyRRg/Gc/+LRCE7lyKpwWQ70dbelGRyyJFH36eNv6ySXoUYtGkwlU5IVaHPApOxe4LHPZa/qhSRbPo2hwoh0orCtgejRebNtW5nlx00DNFgsvn8Svz2cIYLxsPVzKgUxs8Zxsxgn+Q/UvR7uq4AbAhyBMLxv7DjJ1pc7PJocuTno2Rw9uMZi1gkjbnmiOh6TTXIEWbnroyIhwc8555uto9melEUmWNQ+C+PwAK+MPw==";
+      description = ''
+        Public SSH host key of the remote host. Discoverable using e.g. `ssh-keyscan`.
+      '';
+    };
+
+    port = mkOption {
+      type = port;
+      default = 22;
+      description = ''
+        Port of the SSH remote host.
+      '';
+      apply = toString;
+    };
+
+    sshKey = mkOption {
+      type = path;
+      example = "/var/keys/ssh-key";
+      description = ''
+        Path to the SSH key required to access the remote host.
+      '';
+    };
+
+    secretPath = mkOption {
+      type = path;
+      example = "/var/keys/borg-secret";
+      description = ''
+        Path to the secret used to encrypt backups in the repository.
+      '';
+    };
+
+    quota = mkOption {
+      type = nullOr str;
+      default = null;
+      example = "90G";
+      description = ''
+        Quota for the borg repository. Useful to prevent the target disk from running full and ensuring borg keeps some space to work with.
+      '';
+    };
+
+    includes = mkOption {
+      type = listOf path;
+      default = [];
+      description = ''
+        Paths to include in the backup.
+      '';
+    };
+
+    excludes = mkOption {
+      type = listOf path;
+      default = [];
+      description = ''
+        Paths to exclude in the backup.
+      '';
+    };
+
+    preHook = mkOption {
+      type = lines;
+      default = "";
+      description = ''
+        Shell commands to run before the backup.
+      '';
+    };
+
+    postHook = mkOption {
+      type = lines;
+      default = "";
+      description = ''
+        Shell commands to run after the backup.
+      '';
+    };
+
+    wantedUnits = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        List of units to require before starting the backup.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.includes != []) {
+    programs.ssh.knownHosts."${if cfg.port != 22 then "[${cfg.host}]:${cfg.port}" else cfg.host}" = {
+      publicKey = "${cfg.hostPublicKey}";
+    };
+
+    systemd.services.borgbackup-job-state = {
+      wants = cfg.wantedUnits;
+      after = cfg.wantedUnits;
+    };
+
+    systemd.timers.borgbackup-job-state.timerConfig = {
+      # Spread all backups over the day
+      RandomizedDelaySec = "24h";
+      FixedRandomDelay = true;
+    };
+
+    services.borgbackup.jobs.state = {
+      inherit (cfg) preHook postHook;
+
+      # Create the repo
+      doInit = true;
+
+      # Create daily backups, but prune to a reasonable amount
+      startAt = "daily";
+      prune.keep = {
+        daily = 7;
+        weekly = 4;
+        monthly = 3;
+      };
+
+      # What to backup
+      paths = cfg.includes;
+      exclude = cfg.excludes;
+
+      # Where to backup it to
+      repo = "${cfg.user}@${cfg.host}:${config.networking.fqdn}";
+      environment.BORG_RSH = "ssh -p ${cfg.port} -i ${cfg.sshKey}";
+
+      # Ensure we don't fill up the destination disk
+      extraInitArgs = lib.optionalString (cfg.quota != null) "--storage-quota ${cfg.quota}";
+
+      # Authenticated & encrypted, key resides in the repository
+      encryption = {
+        mode = "repokey-blake2";
+        passCommand = "cat ${cfg.secretPath}";
+      };
+
+      # Reduce the backup size
+      compression = "auto,zstd";
+
+      # Show summary detailing data usage once completed
+      extraCreateArgs = "--stats";
+    };
+  };
+}

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -3,6 +3,10 @@
 with lib;
 
 {
+  imports = [
+    ./backup.nix
+  ];
+
   time.timeZone = "UTC";
 
   users.mutableUsers = false;


### PR DESCRIPTION
- sets the mountpoints for prometheus and victoriametrics dataset
- copies the backup module from non-critical-infra
- prepare the backup to the storagebox
- configure backups to include prometheus, grafana, victoriametrics