### PR TITLE
non-critical-infra: init jitsi

### DIFF
--- a/non-critical-infra/hosts/caliban.nixos.org/default.nix
+++ b/non-critical-infra/hosts/caliban.nixos.org/default.nix
@@ -9,6 +9,7 @@
       ../../modules/first-time-contribution-tagger.nix
       ../../modules/backup.nix
       ../../modules/vaultwarden.nix
+      ../../modules/jitsi.nix
     ];
 
   # Bootloader.

--- a/non-critical-infra/modules/jitsi.nix
+++ b/non-critical-infra/modules/jitsi.nix
@@ -1,0 +1,59 @@
+{ pkgs, ... }:
+{
+  services.jitsi-meet = {
+    enable = true;
+    hostName = "jitsi.nixos.org";
+    config = {
+      enableWelcomePage = true;
+      requireDisplayName = true;
+      analytics.disabled = true;
+      startAudioOnly = true;
+      channelLastN = 4;
+      lobby = {
+        autoKnock = true;
+        enableChat = false;
+      };
+      stunServers = [
+        { urls = "turn:turn.matrix.org:3478?transport=udp"; }
+        { urls = "turn:turn.matrix.org:3478?transport=tcp"; }
+      ];
+      constraints.video.height = {
+        ideal = 720;
+        max = 1080;
+        min = 240;
+      };
+      remoteVideoMenu.disabled = false;
+      breakoutRooms.hideAddRoomButton = false;
+      maxFullResolutionParticipants = 1;
+    };
+    updateMucs = {
+      "conference.jitsi.nixos.org".extraModules = [
+        "muc_mam"
+        "vcard_muc"
+        "lobby_autostart"
+        "secure_domain_lobby_bypass"
+      ];
+    };
+
+    interfaceConfig = {
+      SHOW_JITSI_WATERMARK = false;
+      SHOW_WATERMARK_FOR_GUESTS = false;
+      GENERATE_ROOMNAMES_ON_WELCOME_PAGE = false;
+      DISABLE_PRESENCE_STATUS = true;
+    };
+    secureDomain.enable = true;
+  };
+
+  services.prosody.extraPluginPaths = [
+    "${pkgs.jitsi-prosody-plugins}/lobby_autostart"
+    "${pkgs.jitsi-prosody-plugins}/secure_domain_lobby_bypass"
+  ];
+
+  services.prosody.extraModules = [ "muc_lobby_rooms" "persistent_lobby" "lobby_autostart" ];
+  services.prosody.virtualHosts."jitsi.nixos.org".extraConfig = ''
+    modules_enabled = {
+      "muc_lobby_rooms";
+      "persistent_lobby";
+    }
+  '';
+}


### PR DESCRIPTION
***This config still contains a bug where lobby-autostart kicks the moderator after joining using the secure domain bypass***

The jitsi config has the lobby enabled for every-room by-default, this means only people that get access will be able to join. Access control is done using the `Secure Domain Lobby Bypass` plugin and should be changed to `Token Lobby Bypass` once we have a IDP.

Adding users for Secure Domain Lobby Bypass has to be done in a imperativ way using:
```bash
prosodyctl register <username> jitsi.nixos.org <password>
```

Depends on [nixos/nixpkgs#297809](https://github.com/NixOS/nixpkgs/pull/297809)
And the DNS records are still missing from the pr.