### PR TITLE
fastly: use shielding POPs that match backend location

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -122,7 +122,7 @@ resource "fastly_service_vcl" "cache" {
     name                  = "s3.amazonaws.com"
     override_host         = aws_s3_bucket.cache.bucket_domain_name
     port                  = 443
-    shield                = local.fastly_shield
+    shield                = "iad-va-us"
     ssl_cert_hostname     = "s3.amazonaws.com"
     ssl_check_cert        = true
     use_ssl               = true

--- a/terraform/channels.tf
+++ b/terraform/channels.tf
@@ -100,7 +100,7 @@ resource "fastly_service_vcl" "channels" {
     name              = local.channels_backend
     override_host     = local.channels_backend
     request_condition = "not-flake-registry"
-    shield            = local.fastly_shield
+    shield            = "iad-va-us"
   }
 
   backend {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,8 +4,6 @@ locals {
   # TLS v1.2, protocols HTTP/1.1 and HTTP/2
   fastly_tls12_sni_configuration_id = "5PXBTa6c01Xoh54ylNwmVA"
 
-  fastly_shield = "iad-va-us"
-
   cache-iam  = data.terraform_remote_state.terraform-iam.outputs.cache
   fastlylogs = data.terraform_remote_state.terraform-iam.outputs.fastlylogs
 

--- a/terraform/nixpkgs-tarballs.tf
+++ b/terraform/nixpkgs-tarballs.tf
@@ -164,7 +164,7 @@ resource "fastly_service_vcl" "nixpkgs-tarballs" {
     name                  = local.tarballs_backend
     override_host         = local.tarballs_backend
     port                  = 80
-    shield                = local.fastly_shield
+    shield                = "dub-dublin-ie"
     use_ssl               = false
     weight                = 100
   }

--- a/terraform/releases.tf
+++ b/terraform/releases.tf
@@ -102,7 +102,7 @@ resource "fastly_service_vcl" "releases" {
     name                  = local.releases_backend
     override_host         = local.releases_backend
     port                  = 443
-    shield                = local.fastly_shield
+    shield                = "dub-dublin-ie"
     ssl_cert_hostname     = local.releases_backend
     ssl_check_cert        = true
     use_ssl               = true


### PR DESCRIPTION
We were previously always shielding via the Virginia POP which is closest to us-east-1. However the S3 buckets for releases.nixos.org and tarballs.nixos.org are hosted in eu-west-1 (Dublin). Let's save on some transatlantic roundtrips, and maybe even improve #212.