### PR TITLE
non-critical-infra: update flake inputs

### DIFF
--- a/non-critical-infra/flake.lock
+++ b/non-critical-infra/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706509311,
-        "narHash": "sha256-QQKQ6r3CID8aXn2ZXZ79ZJxdCOeVP+JTnOctDALErOw=",
+        "lastModified": 1711386353,
+        "narHash": "sha256-gWEpb8Hybnoqb4O4tmpohGZk6+aerAbJpywKcFIiMlg=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "c84ccd0a7a712475e861c2b111574472b1a8d0cd",
+        "rev": "cd65ef7a25cdc75052fbd04b120aeb066c3881db",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708564520,
-        "narHash": "sha256-juduDTYBhGN6jNfQ5RMDpbQF+MkO0pj3k7XGDSTjAbs=",
+        "lastModified": 1713152224,
+        "narHash": "sha256-k1aV06cotPwWO3FW+ho+dEoGjxNM303+UmhiG2o6XPs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "23d308f0059955e3719efc81a34d1fc0369fbb74",
+        "rev": "bb5ba68ebb73b5ca7996b64e1457fe885891e78e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708702655,
-        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
+        "lastModified": 1713013257,
+        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5101e457206dd437330d283d6626944e28794b3",
+        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1708210246,
-        "narHash": "sha256-Q8L9XwrBK53fbuuIFMbjKvoV7ixfLFKLw4yV+SD28Y8=",
+        "lastModified": 1713042715,
+        "narHash": "sha256-RifMwYuKu5v6x6O65msKDTqKkQ9crGwOB7yr20qMEuE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69405156cffbdf2be50153f13cbdf9a0bea38e49",
+        "rev": "c27f3b6d8e29346af16eecc0e9d54b1071eae27e",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708500294,
-        "narHash": "sha256-mvJIecY3tDKZh7297mqOtOuAvP7U1rqjfLNfmfkjFpU=",
+        "lastModified": 1713174909,
+        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f6b80ab6cd25e57f297fe466ad689d8a77057c11",
+        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
         "type": "github"
       },
       "original": {
@@ -244,11 +244,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708676872,
-        "narHash": "sha256-q7UU7tcLlSw0rbHSqm8NHLkNtg+7Egdx5GhII1tgXtA=",
+        "lastModified": 1712943026,
+        "narHash": "sha256-x2PaFsoZjqm2mC8dbUbv93to8H7wAruauluOH81lzA8=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "8d159ac5bb67368509861cf1a94717402d8d216e",
+        "rev": "bed9cfce2adc4c72de9bc90656d5cfe66e4371f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Not applied yet: 

```
umbriel.nixos.org | would stop the following units: audit.service, growpart.service, kmod-static-nodes.service, logrotate-checkconf.service, mjolnir.service, mount-pstore.service, network-local-commands.service, nscd.service, pantalaimon-mjolnir.service, systemd-modules-load.service, systemd-oomd.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-udevd.service, systemd-vconsole-setup.service, zfs-mount.service, zfs-share.service, zfs-zed.service
umbriel.nixos.org | would NOT stop the following changed units: getty@tty1.service, serial-getty@ttyAMA0.service, serial-getty@ttyS0.service, systemd-fsck@dev-disk-by\x2dpartlabel-disk\x2dmain\x2desp.service, systemd-journal-flush.service, systemd-logind.service, systemd-random-seed.service, systemd-remount-fs.service, systemd-update-utmp.service, systemd-user-sessions.service, user-runtime-dir@0.service, user@0.service
umbriel.nixos.org | would activate the configuration...
umbriel.nixos.org | --- diff to current-system
umbriel.nixos.org | <<< /run/current-system
umbriel.nixos.org | >>> /nix/store/y3kmhfdiff56cq5yf1hp1azsc6y8x8ha-nixos-system-umbriel-23.11.20240413.90055d5
umbriel.nixos.org | Version changes:
umbriel.nixos.org | [C.]  #01  gnupg                 2.4.4 -> 2.4.4 x2
umbriel.nixos.org | [U.]  #02  initrd-linux          6.1.79 -> 6.1.86
umbriel.nixos.org | [U*]  #03  libressl              3.8.2, 3.8.2-nc -> 3.8.4, 3.8.4-nc
umbriel.nixos.org | [U.]  #04  linux                 6.1.79, 6.1.79-modules-shrunk -> 6.1.86, 6.1.86-modules-shrunk
umbriel.nixos.org | [U*]  #05  mkpasswd              5.5.20 -> 5.5.21
umbriel.nixos.org | [C*]  #06  nix                   2.15.3, 2.15.3-man, 2.18.1, 2.18.1-man -> 2.18.1, 2.18.1-man
umbriel.nixos.org | [U.]  #07  nixos-system-umbriel  23.11.20240223.c5101e4 -> 23.11.20240413.90055d5
umbriel.nixos.org | [U.]  #08  nodejs                18.18.2 -> 18.19.1
umbriel.nixos.org | [U.]  #09  nss-cacert            3.95, 3.95-p11kit -> 3.98, 3.98-p11kit
umbriel.nixos.org | [U.]  #10  python3               3.11.6 x2 -> 3.11.8 x2
umbriel.nixos.org | [U*]  #11  strace                6.7 -> 6.8
umbriel.nixos.org | [C*]  #12  systemd               <none>, 254.6 -> <none>, 254.10
umbriel.nixos.org | [U.]  #13  systemd-minimal       254.6 -> 254.10
umbriel.nixos.org | [U.]  #14  systemd-minimal-libs  254.6 -> 254.10
umbriel.nixos.org | [U.]  #15  unbound               1.18.0-lib -> 1.19.2-lib
umbriel.nixos.org | [U.]  #16  zfs-kernel            2.2.2-6.1.79 -> 2.2.3-6.1.86
umbriel.nixos.org | [U*]  #17  zfs-user              2.2.2 -> 2.2.3
umbriel.nixos.org | Added packages:
umbriel.nixos.org | [A.]  #1  cyrus-sasl     2.1.28
umbriel.nixos.org | [A.]  #2  initrd-fsinfo  <none>
umbriel.nixos.org | [A.]  #3  keymap         <none>
umbriel.nixos.org | [A.]  #4  libksba        1.6.4
umbriel.nixos.org | [A.]  #5  libtool        2.4.7-lib
umbriel.nixos.org | [A.]  #6  libusb         1.0.26
umbriel.nixos.org | [A.]  #7  openldap       2.6.6
umbriel.nixos.org | Closure size: 629 -> 635 (626 paths added, 620 paths removed, delta +6, disk usage +8.1MiB).
umbriel.nixos.org | ---
umbriel.nixos.org | sops-install-secrets: Imported /etc/ssh/ssh_host_rsa_key as GPG key with fingerprint 7012a974b94b36127d210545345ca18a4749f936
umbriel.nixos.org | sops-install-secrets: Imported /etc/ssh/ssh_host_ed25519_key as age key with fingerprint age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6
umbriel.nixos.org | would restart systemd
umbriel.nixos.org | would reload the following units: dbus.service, firewall.service, reload-systemd-vconsole-setup.service
umbriel.nixos.org | would restart the following units: sshd.service, systemd-journald.service, systemd-networkd.service, systemd-resolved.service
umbriel.nixos.org | would start the following units: audit.service, growpart.service, kmod-static-nodes.service, logrotate-checkconf.service, mjolnir.service, mount-pstore.service, network-local-commands.service, nscd.service, pantalaimon-mjolnir.service, systemd-modules-load.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-vconsole-setup.service, zfs-mount.service, zfs-share.l.nixos.org | '/nix/store/lck7g7mj3hvs3cdbblxsf81cjxf9078m-zfs-user-2.2.3/lib/libnvpair.so.3.0.0' -> '/nix/storeservice, zfs-zed.service
umbriel.nixos.org | Dry activation successful
umbriel.nixos.org | No post-activation keys to upload
caliban.nixos.org | would stop the following units: acme-fixperms.service, acme-lockfiles.service, audit.service, fail2ban.service, kmod-static-nodes.service, logrotate-checkconf.service, mount-pstore.service, network-local-commands.service, nscd.service, systemd-modules-load.service, systemd-oomd.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-udevd.service, systemd-vconsole-setup.service, vaultwarden.service, zfs-mount.service, zfs-share.service, zfs-zed.service
caliban.nixos.org | would NOT stop the following changed units: getty@tty1.service, systemd-journal-flush.service, systemd-logind.service, systemd-random-seed.service, systemd-remount-fs.service, systemd-update-utmp.service, systemd-user-sessions.service, user-runtime-dir@0.service, user@0.service
caliban.nixos.org | would activate the configuration...
caliban.nixos.org | --- diff to current-system
caliban.nixos.org | <<< /run/current-system
caliban.nixos.org | >>> /nix/store/4ngpnidyp9fxzx3wslwjzpngandbz7mj-nixos-system-caliban-23.11.20240413.90055d5
caliban.nixos.org | Version changes:
caliban.nixos.org | [U.]  #01  giflib                5.2.1 -> 5.2.2
caliban.nixos.org | [C.]  #02  gnupg                 2.4.4 -> 2.4.4 x2
caliban.nixos.org | [U.]  #03  initrd-linux          6.1.79 -> 6.1.86
caliban.nixos.org | [U*]  #04  libressl              3.8.2, 3.8.2-nc -> 3.8.4, 3.8.4-nc
caliban.nixos.org | [U.]  #05  linux                 6.1.79, 6.1.79-modules-shrunk -> 6.1.86, 6.1.86-modules-shrunk
caliban.nixos.org | [U.]  #06  linux-firmware        20240220-xz -> 20240410-xz
caliban.nixos.org | [U*]  #07  mkpasswd              5.5.20 -> 5.5.21
caliban.nixos.org | [C*]  #08  nix                   2.15.3, 2.15.3-man, 2.18.1, 2.18.1-man -> 2.18.1, 2.18.1-man
caliban.nixos.org | [U.]  #09  nixos-system-caliban  23.11.20240223.c5101e4 -> 23.11.20240413.90055d5
caliban.nixos.org | [U.]  #10  nss-cacert            3.95, 3.95-p11kit -> 3.98, 3.98-p11kit
caliban.nixos.org | [U.]  #11  python3               3.11.6 x2, 3.11.6-env -> 3.11.8 x2, 3.11.8-env
caliban.nixos.org | [U*]  #12  strace                6.7 -> 6.8
caliban.nixos.org | [C*]  #13  systemd               <none>, 254.6 -> <none>, 254.10
caliban.nixos.org | [U.]  #14  systemd-minimal       254.6 -> 254.10
caliban.nixos.org | [U.]  #15  systemd-minimal-libs  254.6 -> 254.10
caliban.nixos.org | [C.]  #16  udev-rules            <none> x2 -> <none>
caliban.nixos.org | [U.]  #17  unbound               1.18.0-lib -> 1.19.2-lib
caliban.nixos.org | [U.]  #18  zfs-kernel            2.2.2-6.1.79 -> 2.2.3-6.1.86
caliban.nixos.org | [U*]  #19  zfs-user              2.2.2 -> 2.2.3
caliban.nixos.org | Added packages:
caliban.nixos.org | [A.]  #1  cyrus-sasl  2.1.28
caliban.nixos.org | [A.]  #2  libksba     1.6.4
caliban.nixos.org | [A.]  #3  libtool     2.4.7-lib
caliban.nixos.org | [A.]  #4  libusb      1.0.26
caliban.nixos.org | [A.]  #5  openldap    2.6.6
caliban.nixos.org | Removed packages:
caliban.nixos.org | [R.]  #1  extra-utils                   <none>
caliban.nixos.org | [R.]  #2  initrd-fsinfo                 <none>
caliban.nixos.org | [R.]  #3  initrd-kmod-blacklist-ubuntu  <none>
caliban.nixos.org | [R.]  #4  keymap                        <none>
caliban.nixos.org | [R.]  #5  link-units                    <none>
caliban.nixos.org | [R.]  #6  stage                         1-init.sh
caliban.nixos.org | Closure size: 711 -> 708 (694 paths added, 697 paths removed, delta -3, disk usage -26.5MiB).
caliban.nixos.org | ---
caliban.nixos.org | sops-install-secrets: Imported /etc/ssh/ssh_host_rsa_key as GPG key with fingerprint 15bda7f360f6030eaa06aee6bc65823d8faf4e3a
caliban.nixos.org | sops-install-secrets: Imported /etc/ssh/ssh_host_ed25519_key as age key with fingerprint age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq
caliban.nixos.org | would restart systemd
caliban.nixos.org | would reload the following units: dbus.service, firewall.service, reload-systemd-vconsole-setup.service
caliban.nixos.org | would restart the following units: nginx.service, sshd.service, systemd-journald.service, systemd-networkd.service, systemd-resolved.service
caliban.nixos.org | would start the following units: acme-fixperms.service, acme-lockfiles.service, audit.service, fail2ban.service, kmod-static-nodes.service, logrotate-checkconf.service, mount-pstore.service, network-local-commands.service, nscd.service, systemd-modules-load.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-udevd-control.socket, systemd-udevd-kernel.socket, systemd-vconsole-setup.service, vaultwarden.service, zfs-mount.service, zfs-share.service, zfs-zed.service
caliban.nixos.org | Dry activation successful
caliban.nixos.org | No post-activation keys to upload
                  | All done!
```
