### PR TITLE
go-neb: Only show Grafana link when applicable

### DIFF
--- a/delft/pluto/prometheus/alertmanager.nix
+++ b/delft/pluto/prometheus/alertmanager.nix
@@ -110,7 +110,9 @@
                   {{ end }}
                   {{ index .Labels "alertname"}}: {{ index .Annotations "summary"}}
                   (
-                    <a href="{{ index .Annotations "grafana" }}">📈 Grafana</a>,
+                    {{ if .Annotations.grafana }}
+                      <a href="{{ index .Annotations "grafana" }}">📈 Grafana</a>,
+                    {{ end }}
                     <a href="{{ .GeneratorURL }}">🔥 Prometheus</a>,
                     <a href="{{ .SilenceURL }}">🔕 Silence</a>
                   )<br/>


### PR DESCRIPTION
This patch is a small change in the go-neb configuration to remove some clutter from the [infra alerts room](https://matrix.to/#/#infra-alerts:nixos.org). Since some alerts don't include a link to a Grafana dashboard, we can only print that part of the message when it's relevant.

I haven't tested this with an actual go-neb instance + alertmanager, but only a Go templating tester and seems to work fine.