### PR TITLE
dns: `hydra.ngi0, buildbot.ngi → makemake`

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -37,14 +37,24 @@ locals {
       value    = "2a01:4f8:212:41c9::1"
     },
     {
-      hostname = "hydra.ngi0.nixos.org"
+      hostname = "makemake.ngi.nixos.org"
       type     = "A"
       value    = "116.202.113.248"
     },
     {
-      hostname = "hydra.ngi0.nixos.org"
+      hostname = "makemake.ngi.nixos.org"
       type     = "AAAA"
       value    = "2a01:4f8:231:4187::"
+    },
+    {
+      hostname = "buildbot.ngi.nixos.org"
+      type     = "CNAME"
+      value    = "makemake.nixos.org"
+    },
+    {
+      hostname = "hydra.ngi0.nixos.org"
+      type     = "CNAME"
+      value    = "makemake.nixos.org"
     },
     {
       hostname = "hydra.nixos.org"


### PR DESCRIPTION
The Hydra instance at hydra.ngi0.nixos.org is being sunset and will be replaced by a buildbot instance, see https://github.com/ngi-nix/ngipkgs/issues/200. The CNAME will be removed once we've moved to buildbot.

Some context:
 - The host config for hydra.ngi0.nixos.org was moved from this repo to [ngi-nix/ngi0-infra](https://github.com/ngi-nix/ngi0-infra), see https://github.com/NixOS/infra/issues/326
 - We're now moving it from there to [ngi-nix/ngipkgs](https://github.com/ngi-nix/ngipkgs), see https://github.com/ngi-nix/ngipkgs/pull/201

cc @Erethon