### PR TITLE
delft/hydra: remove authorized_keys for hydra users

### DIFF
--- a/delft/hydra.nix
+++ b/delft/hydra.nix
@@ -7,13 +7,6 @@ let
 in
 
 {
-  users.extraUsers.hydra.openssh.authorizedKeys.keys =
-    (import ../ssh-keys.nix).infra-core;
-  users.extraUsers.hydra-www.openssh.authorizedKeys.keys =
-    (import ../ssh-keys.nix).infra-core;
-  users.extraUsers.hydra-queue-runner.openssh.authorizedKeys.keys =
-    (import ../ssh-keys.nix).infra-core;
-
   services.hydra-dev.enable = true;
   services.hydra-dev.logo = ./hydra-logo.png;
   services.hydra-dev.hydraURL = "https://hydra.nixos.org";


### PR DESCRIPTION
Nobody should ever need to directly log into these. The infra team already has root access and can switch to these users as needed.