### PR TITLE
dns: Fix typo in makemake hostname

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -49,12 +49,12 @@ locals {
     {
       hostname = "buildbot.ngi.nixos.org"
       type     = "CNAME"
-      value    = "makemake.nixos.org"
+      value    = "makemake.ngi.nixos.org"
     },
     {
       hostname = "hydra.ngi0.nixos.org"
       type     = "CNAME"
-      value    = "makemake.nixos.org"
+      value    = "makemake.ngi.nixos.org"
     },
     {
       hostname = "hydra.nixos.org"


### PR DESCRIPTION
While reviewing https://github.com/ngi-nix/ngipkgs/pull/201/ I noticed that `makemake.nixos.org` doesn't resolve to anything but it's used as a CNAME after #419. This is a typo I believe and it should be `makemake.ngi.nixos.org`. This PR fixes that.

CC @lorenzleutgeb who knows more about this