### PR TITLE
prometheus: Monitor HTTP status of wiki.nixos.org

### DIFF
--- a/delft/pluto/prometheus/exporters/blackbox.nix
+++ b/delft/pluto/prometheus/exporters/blackbox.nix
@@ -56,6 +56,7 @@ in
         "https://survey.nixos.org"
         "https://tarballs.nixos.org"
         "https://weekly.nixos.org"
+        "https://wiki.nixos.org"
         "https://www.nixos.org"
         "https://netboot.nixos.org"
       ])


### PR DESCRIPTION
A couple of days ago `wiki.nixos.org` was [down for some minutes](https://matrix.to/#/!JrBtSIugVadKwbhvCc:matrix.org/$MYx0CTR3LL294KETwloJws1BPn7T0zAFnlgHILnR51o?via=nixos.org&via=matrix.org&via=fairydust.space). This patch adds `wiki.nixos.org` to the list of monitored domains via blackbox exporter, similarly to what we do for the rest of the nixos.org websites. While it won't alert people [1] if it happens again, at the very least it will provide some insight and help debug things if they misbehave again.

[1]: There are currently no alerts for a *.nixos.org website being down in general.