### PR TITLE
terraform-iam: create user for fastly<->releases authn

### DIFF
--- a/terraform-iam/outputs.tf
+++ b/terraform-iam/outputs.tf
@@ -9,3 +9,11 @@ output "cache" {
 output "fastlylogs" {
   value = module.fastlylogs
 }
+
+output "releases" {
+  value = {
+    key    = aws_iam_access_key.fastly-releases-access.id
+    secret = aws_iam_access_key.fastly-releases-access.secret
+  }
+  sensitive = true
+}

--- a/terraform-iam/releases.tf
+++ b/terraform-iam/releases.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_user" "fastly-releases-access" {
+  name = "fastly-releases-access"
+}
+
+resource "aws_iam_access_key" "fastly-releases-access" {
+  user = aws_iam_user.fastly-releases-access.name
+}


### PR DESCRIPTION
Create a dedicated user for Fastly to authenticate against the S3 release bucket.

```
  # aws_iam_access_key.fastly-releases-access will be created
  + resource "aws_iam_access_key" "fastly-releases-access" {
      + create_date                    = (known after apply)
      + encrypted_secret               = (known after apply)
      + encrypted_ses_smtp_password_v4 = (known after apply)
      + id                             = (known after apply)
      + key_fingerprint                = (known after apply)
      + secret                         = (sensitive value)
      + ses_smtp_password_v4           = (sensitive value)
      + status                         = "Active"
      + user                           = "fastly-releases-access"
    }

  # aws_iam_user.fastly-releases-access will be created
  + resource "aws_iam_user" "fastly-releases-access" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "fastly-releases-access"
      + path          = "/"
      + tags_all      = (known after apply)
      + unique_id     = (known after apply)
    }
```