### PR TITLE
haumea/zrepl: reduce number of snapshots

### DIFF
--- a/delft/haumea/zrepl.nix
+++ b/delft/haumea/zrepl.nix
@@ -31,7 +31,6 @@
             type = "grid";
             regex = "^zrepl_snap_.*";
             grid = lib.concatStringsSep " | " [
-              "3x5m"
               "4x15m"
               "24x1h"
               "4x1d"
@@ -43,12 +42,10 @@
           { type = "grid";
             regex = "^zrepl_snap_.*";
             grid = lib.concatStringsSep " | " [
-              "20x5m"
               "96x1h"
               "12x4h"
               "7x1d"
               "52x1w"
-              "120x3w"
             ];
           }
         ];


### PR DESCRIPTION
- 3x5m is not actionable since we often take more than 15 minutes to actually notice any issue
- 20x5m is a lot of write churn on the backup target, which is currently only my personal NAS
- 52x1w already offers 52 weekly backups, so 120x3w goes back 6 years and overlaps 17 times with 52x1w. Hopefully we don't need to restore data that is older than 1y.