### PR TITLE
haumea/postgresql: use jit package, disable full page writes

### DIFF
--- a/delft/haumea/postgresql.nix
+++ b/delft/haumea/postgresql.nix
@@ -28,6 +28,9 @@
     settings = {
       listen_addresses = lib.mkForce "10.254.1.9";
 
+      # https://vadosware.io/post/everything-ive-seen-on-optimizing-postgres-on-zfs-on-linux/#zfs-related-tunables-on-the-postgres-side
+      full_page_writes = "off";
+
       checkpoint_completion_target = "0.9";
       default_statistics_target = 100;
 

--- a/delft/haumea/postgresql.nix
+++ b/delft/haumea/postgresql.nix
@@ -20,6 +20,7 @@
 
   services.postgresql = {
     enable = true;
+    enableJIT = true;
     package = pkgs.postgresql_16;
     dataDir = "/var/db/postgresql/16";
     # https://pgtune.leopard.in.ua/#/


### PR DESCRIPTION
JIT was previously enabled in the configuration, but the package did not
have support for it.

Disables full page writes, as they are unnecessary on ZFS.