### PR TITLE
haumea/zrepl: create pg checkpoint before taking snapshot

### DIFF
--- a/delft/haumea/zrepl.nix
+++ b/delft/haumea/zrepl.nix
@@ -24,6 +24,12 @@
         type = "periodic";
         interval = "5m";
         prefix = "zrepl_snap_";
+        hooks = [ {
+          # https://zrepl.github.io/master/configuration/snapshotting.html#postgres-checkpoint-hook
+          type = "postgres-checkpoint";
+          dsn = "host=/run/postgresql user=root sslmode=disable";
+          filesystems."rpool/safe/postgres" = true;
+        } ];
       };
       pruning = {
         keep_sender = [


### PR DESCRIPTION
Creating a checkpoint flushes all memory to disk, and applies all WAL files to persistent storage, forward-paying the cost of WAL replay, but on the other hand making snapshots much cheaper.

https://zrepl.github.io/master/configuration/snapshotting.html#job-hook-type-postgres-checkpoint https://www.postgresql.org/docs/current/sql-checkpoint.html
https://www.postgresql.org/docs/current/wal-configuration.html

Whether we should do this is debatable, but the linked documentation should be studied in full, before we make a decision.