### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -69,7 +69,7 @@ owner: Christine?
 
 owner: @zimbatm
 
-## NixOS community wiki + bot
+## NixOS Wiki
 
 access: see https://wiki.nixos.org/wiki/NixOS_Wiki:About
 

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -71,7 +71,6 @@ owner: @zimbatm
 
 ## NixOS community wiki + bot
 
-owner: @fadenb
 access: see https://wiki.nixos.org/wiki/NixOS_Wiki:About
 
 ## Twitter accounts

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -72,7 +72,7 @@ owner: @zimbatm
 ## NixOS community wiki + bot
 
 owner: @fadenb
-access: see https://nixos.wiki/wiki/NixOS_Wiki:About
+access: see https://wiki.nixos.org/wiki/NixOS_Wiki:About
 
 ## Twitter accounts
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️