### PR TITLE
hydra: increase local worker thread count

### DIFF
--- a/build/hydra.nix
+++ b/build/hydra.nix
@@ -44,6 +44,9 @@ in
 
       max_concurrent_evals = 1
 
+      # increase the number of active compress slots
+      max_local_worker_threads = 48
+
       max_unsupported_time = 86400
 
       allow_import_from_derivation = false


### PR DESCRIPTION
Our hydra fork has a limit on the number of active build slots, which defaults to the number of threads minus two, so 32-2=30.

The plan is to increase the utilization of rhea more to unblock build slots on the various builders.