### PR TITLE
macs/flake.lock: Update and unpin nix.package

### DIFF
--- a/macs/flake.lock
+++ b/macs/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1722445220,
+        "narHash": "sha256-PW5FRqLhqg0xGpPjY2Poa464tyBQiyKd0tQGZ0HnMiU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "7e08a9dd34314fb8051c28b231a68726c54daa7b",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678298120,
-        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
         "type": "github"
       },
       "original": {

--- a/macs/nix-darwin.nix
+++ b/macs/nix-darwin.nix
@@ -32,7 +32,6 @@ in
 
   services.nix-daemon.enable = true;
 
-  nix.package = pkgs.nixVersions.nix_2_13;
   nix.settings = {
     "extra-experimental-features" = [ "nix-command" "flakes" ];
     max-jobs = 4;


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'darwin':
    'github:LnL7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943' (2023-01-09)
  → 'github:LnL7/nix-darwin/7e08a9dd34314fb8051c28b231a68726c54daa7b' (2024-07-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1e383aada51b416c6c27d4884d2e258df201bc11' (2023-03-08)
  → 'github:nixos/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce' (2024-07-31)
```

This should bring us to nix 2.18.5.