### PR TITLE
macs: update deployment hints

### DIFF
--- a/macs/README.md
+++ b/macs/README.md
@@ -1,6 +1,29 @@
 # Deploying to darwin
 
 See [inventory](../docs/inventory.md).
+
+## At Graham's place
+
 We have mac-mini's are in [Grahams](https://github.com/grahamc) house,
 that only [@cole-h](https://github.com/cole-h) can deploy.
-Furthermore we have builders at Hetzner online.
+
+- These are getting erased and automatically redeployed from the configuration in this directory.
+
+## Hetzner
+
+Additional we have five M1 builders at Hetzner online:
+
+- enormous-catfish.mac.nixos.org
+- growing-jennet.mac.nixos.org
+- intense-heron.mac.nixos.org
+- maximum-snail.mac.nixos.org
+- sweeping-filly.mac.nixos.org
+
+These are maintained by the build infra team.
+
+### Update
+
+```
+darwin-rebuild switch --flake github::nixos/infra#arm64
+```
+

--- a/macs/nix-darwin.nix
+++ b/macs/nix-darwin.nix
@@ -29,7 +29,7 @@ in
   programs.zsh.enable = true;
   programs.zsh.enableCompletion = false;
   programs.bash.enable = true;
-  programs.bash.enableCompletion = false;
+  programs.bash.completion.enable = true;
 
   #services.activate-system.enable = true;
 


### PR DESCRIPTION
Tested on intense-heron, where I also found a nix-2.13.3 profile which overruled the nix-darwin maintained nix version.

```
sh-3.2# nix profile list
0 - - /nix/store/pl497357lkfpvdr8v4pfan16k7jna2l2-nss-cacert-3.83
1 - - /nix/store/8w0v2mffa10chrf1h66cbvbpw86qmh85-nix-2.13.3

sh-3.2# nix profile remove 1
removing 'nix'

sh-3.2# nix --version
nix (Nix) 2.18.8
```