### PR TITLE
Update DKIM key for test mailserver

### DIFF
--- a/macs/nix-darwin.nix
+++ b/macs/nix-darwin.nix
@@ -46,9 +46,7 @@ in
   };
 
   nix.package = pkgs.nixVersions.nix_2_24.overrideAttrs (oldAttrs: {
-    patches = oldAttrs.patches or [ ] ++ [
-      ./disable-chroot.patch
-    ];
+    patches = oldAttrs.patches or [ ] ++ [ ./disable-chroot.patch ];
   });
   nix.gc.automatic = true;
   nix.gc.user = "";

--- a/non-critical-infra/hosts/umbriel.nixos.org/README.md
+++ b/non-critical-infra/hosts/umbriel.nixos.org/README.md
@@ -4,4 +4,9 @@
 
 If you recreate `umbriel`, it will generate a new `DKIM` signature. That's
 ok to do, but you'll need to update the corresponding `mail._domainkey.*` `TXT`
-DNS record in `terraform/dns.tf`.
+DNS record in `terraform/dns.tf` with the generated key in
+`/var/dkim/mail-test.nixos.org.mail.txt`.
+
+TODO: declaratively manage the `DKIM` key once
+<https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/merge_requests/344>
+lands.

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -346,7 +346,8 @@ locals {
     {
       hostname = "mail._domainkey.mail-test.nixos.org"
       type     = "TXT"
-      value    = "v=DKIM1; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDTLW88xioTw4YUMSBw2+RO1+ASTbWNsqDwrpCmA+ikru4cWLEkx2JVEcms4Uxqrk2A8Qhfjvc8Oe026HdTXiTNEb9e+Sh0d/IR/eH5MFhiSUGrahZBx1FGVvMf5zfjYWZXn+7oXW8zNpxWd042hLMcY14G8v+/OBQ9IJL+ja3wFwIDAQAB"
+      # From `/var/dkim/mail-test.nixos.org.mail.txt` on `umbriel`.
+      value = "v=DKIM1; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDG4Tx788TCAW/sv1h6JefVJChqbaot1yhycwEq0Uo5x9ZIyq43Dkxxl7LdsHIW75HMI7aTKQRru+5xQ26vQmwiIRFJlJlRSYzlZZ2xnFZPXQ27dXnFh7MxLGC7YEyQFksiA2xxgqtQSyIvwu1whm2WK0fXkoJf87SgTtVjjKjnkQIDAQAB"
     },
     {
       hostname = "_dmarc.mail-test.nixos.org"


### PR DESCRIPTION
While working on
<https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/merge_requests/344>, I accidentally deleted the `DKIM` key on `umbriel` :(