### PR TITLE
Customize bounce template for mailserver

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,12 +4,11 @@ about: Suggest an improvement for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**
 
-<!-- 
+<!--
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 -->
 

--- a/.github/ISSUE_TEMPLATE/service_disruption.md
+++ b/.github/ISSUE_TEMPLATE/service_disruption.md
@@ -4,7 +4,6 @@ about: Use this to report service instabilities
 title: '<service-name>: '
 labels: bug
 assignees: ''
-
 ---
 
 **Affected service**
@@ -18,4 +17,3 @@ assignees: ''
 **System information**
 
 <!-- Relevant system versions. If it's a connectivity issue, `mtr` reports. -->
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
   nix-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v30
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
-    - run: nix run github:Mic92/nix-fast-build -- --no-nom
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix run github:Mic92/nix-fast-build -- --no-nom
   # all builds combined consume too much disk space... we should soon switch to something else
   nixos:
     runs-on: ubuntu-latest
@@ -30,10 +30,10 @@ jobs:
         #machine: [caliban, umbriel]
         machine: [caliban]
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v30
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
-    - run: nix build '.#nixosConfigurations."${{ matrix.machine }}.nixos.org".config.system.build.toplevel'
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build '.#nixosConfigurations."${{ matrix.machine }}.nixos.org".config.system.build.toplevel'
   nix-darwin:
     runs-on: macos-latest
     strategy:
@@ -41,7 +41,7 @@ jobs:
         # Doesn't seem that x86_64 is still in use?
         machine: [arm64]
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v30
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
-    - run: nix build '.#darwinConfigurations."${{ matrix.machine }}".config.system.build.toplevel'
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - run: nix build '.#darwinConfigurations."${{ matrix.machine }}".config.system.build.toplevel'

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 This repository contains all the hardware configuration for the nixos project
 infrastructure.
 
-All the hosts are currently managed using NixOps. Some of the infrastructure
-is managed using Terraform. There are still a lot of things configured
-manually.
+All the hosts are currently managed using NixOps. Some of the infrastructure is
+managed using Terraform. There are still a lot of things configured manually.
 
 ## Docs
 
-* [Resources inventory](docs/inventory.md)
+- [Resources inventory](docs/inventory.md)
 
 ## Team
 
@@ -29,9 +28,11 @@ All the members should be watching this repository for changes.
 
 ## Regular catch up
 
-We meet regularly over Jitsi to hash some issues out. Sometimes it helps to have dedicated focus and higher communication bandwidth.
+We meet regularly over Jitsi to hash some issues out. Sometimes it helps to have
+dedicated focus and higher communication bandwidth.
 
-It started Thursday, January 11, 2024, at 6 pm CET (UTC+1), and then repeats every two weeks, on Thursdays at 6 pm CET.
+It started Thursday, January 11, 2024, at 6 pm CET (UTC+1), and then repeats
+every two weeks, on Thursdays at 6 pm CET.
 
 <a target="_blank" href="https://calendar.google.com/calendar/event?action=TEMPLATE&amp;tmeid=MDVjdjNpOG5qazhscjlna3Mxcmw0aHVzODIgam9uYXNAbnVtdGlkZS5jb20&amp;tmsrc=jonas%40numtide.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
 
@@ -39,7 +40,7 @@ Location: <https://jitsi.lassul.us/nixos-infra>
 
 ## Reporting issues
 
-If you experience any issues with the infrastructure, please [post a new issue
-to this repository][1].
+If you experience any issues with the infrastructure, please
+[post a new issue to this repository][1].
 
 [1]: https://github.com/NixOS/nixos-org-configurations/issues/new

--- a/build/haumea/zrepl.yml
+++ b/build/haumea/zrepl.yml
@@ -5,10 +5,10 @@
 global:
   logging:
     - type: "stdout"
-      level:  "error"
+      level: "error"
       format: "human"
     - type: "syslog"
-      level:  "info"
+      level: "info"
       format: "logfmt"
 
 # mostly from https://blog.lenny.ninja/zrepl-on-rsync-net.html
@@ -17,7 +17,7 @@ jobs:
     type: sink
     serve:
       type: stdinserver
-      client_identities: [ haumea ]
+      client_identities: [haumea]
     recv:
       placeholder:
         encryption: off

--- a/build/nginx-error-pages/503.html
+++ b/build/nginx-error-pages/503.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Hydra is down</title>
+    <style type="text/css" media="screen">
+      body {
+        font-family: Helvetica, Arial, sans-serif;
+        color: rgba(0, 0, 0, 0.7);
+      }
+    </style>
+  </head>
 
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <title>Hydra is down</title>
-  <style type="text/css" media="screen">
-    body {
-      font-family: Helvetica, Arial, sans-serif;
-      color: rgba(0, 0, 0, 0.7);
-    }
-  </style>
-</head>
-
-<body>
-  <center>
-    <img src="/apache-errors/warning.png" alt="Warning" />
-    <p>Looks like Hydra is having some problems. Sorry about that!</p>
-    <p style="font-size: 90%;">
-      <a href="https://nixos.org/">NixOS Homepage</a> |
-      <a href="https://monitoring.nixos.org/prometheus/alerts">System Alerts</a> |
-      <a href="https://monitoring.nixos.org/grafana/">Dashboards</a> |
-      <a href="https://github.com/NixOS/nixpkgs/labels/infrastructure">Related Issues</a>
-    </p>
-  </center>
-</body>
-
+  <body>
+    <center>
+      <img src="/apache-errors/warning.png" alt="Warning" />
+      <p>Looks like Hydra is having some problems. Sorry about that!</p>
+      <p style="font-size: 90%">
+        <a href="https://nixos.org/">NixOS Homepage</a> |
+        <a href="https://monitoring.nixos.org/prometheus/alerts"
+        >System Alerts</a> |
+        <a href="https://monitoring.nixos.org/grafana/">Dashboards</a> |
+        <a href="https://github.com/NixOS/nixpkgs/labels/infrastructure"
+        >Related Issues</a>
+      </p>
+    </center>
+  </body>
 </html>

--- a/build/rhea/install.md
+++ b/build/rhea/install.md
@@ -1,13 +1,14 @@
 # Setup
 
 ## Switch to UEFI
-First submit a support ticket asking them to enable UEFI.
-See: https://docs.hetzner.com/robot/dedicated-server/operating-systems/uefi/
+
+First submit a support ticket asking them to enable UEFI. See:
+https://docs.hetzner.com/robot/dedicated-server/operating-systems/uefi/
 
 # Correct the NVMe namespace's block size
 
-Verify the NVMe disks are formatted at the namespace level with 4096 blocks.
-See https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Hardware.html#nvme-low-level-formatting
+Verify the NVMe disks are formatted at the namespace level with 4096 blocks. See
+https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Hardware.html#nvme-low-level-formatting
 
 This disk's LBA is 512:
 
@@ -236,7 +237,8 @@ nixos-generate-config --root /mnt
 In the `configuration.nix`:
 
 1. Add `hetzner.nix` to the list of `imports` at the top.
-2. Add an authorized key and enable SSH. This will be removed later when it is imported into NixOps, so it is just for bootstrapping:
+2. Add an authorized key and enable SSH. This will be removed later when it is
+   imported into NixOps, so it is just for bootstrapping:
 
 ```
 services.openssh.enable = true;
@@ -245,24 +247,28 @@ users.users.root.openssh.authorizedKeys.keys = [ "ssh-..." ];
 
 ### Hardware Configuration Changes
 
-Edit `hardware-configuration.nix` and change the fileSystems value for `/nix/var/nix` to make it required for boot:
+Edit `hardware-configuration.nix` and change the fileSystems value for
+`/nix/var/nix` to make it required for boot:
 
 ```nix
-  fileSystems."/nix/var/nix/db" =
-    { device = "rpool/local/nix/db";
-      fsType = "zfs";
-      neededForBoot = true;
-    };
+fileSystems."/nix/var/nix/db" =
+  { device = "rpool/local/nix/db";
+    fsType = "zfs";
+    neededForBoot = true;
+  };
 ```
 
 ### Hetzner.nix
 
 Then create a file, `hetzner.nix`.
 
-* The all-zeros hostId is fine, though I generated one with `head -c4 /dev/urandom | od -A none -t x4`
-* The `enp7s0` and `MACAddress` value I got from `ip addr`
-* The IP addresses and gateways I got from the Robot webpage under the IPs tab, hovering over the IPv4 and IPv6 addresses.
-* Thee DNS resolvers I got from https://docs.hetzner.com/dns-console/dns/general/recursive-name-servers/
+- The all-zeros hostId is fine, though I generated one with
+  `head -c4 /dev/urandom | od -A none -t x4`
+- The `enp7s0` and `MACAddress` value I got from `ip addr`
+- The IP addresses and gateways I got from the Robot webpage under the IPs tab,
+  hovering over the IPv4 and IPv6 addresses.
+- Thee DNS resolvers I got from
+  https://docs.hetzner.com/dns-console/dns/general/recursive-name-servers/
 
 ```nix
 {

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -3,14 +3,15 @@
 This is the current list of hardware and services that everyone has access to.
 
 # Accounts
+
 ## GitHub
 
 owner: @edolstra @domenkozar @garbas @grahamc @rbvermaa
 
 ## Domains
 
-owner: @edolstra
-* nixos.org - https://www.uniteddomains.com/
+- owner: @edolstra
+- nixos.org - https://www.uniteddomains.com/
 
 ## DNS
 
@@ -20,25 +21,25 @@ Managed by Netlify.
 
 ## AWS account
 
-owner: Infor
-alias: lb-nixos
-access: @rbvermaa and @edolstra
+- owner: Infor
+- alias: lb-nixos
+- access: @rbvermaa and @edolstra
 
 ## Packet.net
 
-owner: @grahamc
+- owner: @grahamc
 
 ## Hetzner Cloud
 
-owner: Graham
-(for ofborg)
+- owner: Graham
+- (for ofborg)
 
 ## IRC logging bot
 
-owner: @samueldr
-url: https://logs.nix.samueldr.com/nixos/
-nick: <code>{\`-\`}</code>
-config: https://gitlab.com/samueldr.nix/overlays/irclogger
+- owner: @samueldr
+- url: https://logs.nix.samueldr.com/nixos/
+- nick: <code>{\`-\`}</code>
+- config: https://gitlab.com/samueldr.nix/overlays/irclogger
 
 ## nix.ci
 
@@ -50,9 +51,9 @@ hosted on Packet.
 
 ## arch64 community builder
 
-owner: @grahamc
-access: community members that have asked access to it
-host: Packet
+- owner: @grahamc
+- access: community members that have asked access to it
+- host: Packet
 
 lots of cores to build for the aarch64 platform
 
@@ -64,7 +65,6 @@ owner: @davidak
 
 owner: Christine?
 
-
 ## nixcon2018.org
 
 owner: @zimbatm
@@ -75,22 +75,18 @@ access: see https://wiki.nixos.org/wiki/NixOS_Wiki:About
 
 ## Twitter accounts
 
-**nixpkg**
-owner: Graham
+**nixpkg** owner: Graham
 
-**nixos_org**
-owner: Rob Vermaas
+**nixos_org** owner: Rob Vermaas
 
-**nixcon2017**
-owner: Christine?
+**nixcon2017** owner: Christine?
 
-**nixcon2018**
-owner: zimbatm
-
+**nixcon2018** owner: zimbatm
 
 ## IRC
 
-Group registration on FreeNode. Eelco and Graham can get OP on all channels about NixOS.
+Group registration on FreeNode. Eelco and Graham can get OP on all channels
+about NixOS.
 
 The group owns:
 
@@ -104,55 +100,46 @@ The group owns:
 
 `**#nixos-dev**`
 
-`#``**nixos**`
+`#` **nixos**``
 
-1 niksnut +AFRefiorstv [modified ? ago]
-17:30 2 goodwill +o [modified 3y 36w 6d ago]  - 
-17:30 3 kmicu +o [modified 2y 32w 5d ago]   long time member - left 4 months ago
-17:30 4 gchristensen +o [modified 1y 37w 1d ago]
+- 1 niksnut +AFRefiorstv [modified ? ago]
+- 17:30 2 goodwill +o [modified 3y 36w 6d ago] -
+- 17:30 3 kmicu +o [modified 2y 32w 5d ago] long time member - left 4 months ago
+- 17:30 4 gchristensen +o [modified 1y 37w 1d ago]
 
-`**#nixos-borg**`
-`**#nixos-aarch64**`
-`**#nix-darwin**`
-`#nixos-chat`
-`**#nix-core**`
-`**#nixos-security**`
-`**#nixos-bots**`
-`**#nixos-docs**`
-`**#nixos-wiki**`
-`**#nixos-on-your-router**`
-
-
-
+`**#nixos-borg**` `**#nixos-aarch64**` `**#nix-darwin**` `#nixos-chat`
+`**#nix-core**` `**#nixos-security**` `**#nixos-bots**` `**#nixos-docs**`
+`**#nixos-wiki**` `**#nixos-on-your-router**`
 
 ## cachix.org
 
 owner: Domen
 
 # Hardware
+
 ## On Packet.net
 
 owner: Graham
 
-
 2 builders: aarch64 packet type 2 : for hydra
 
-1 aarch64 for ofborg *and* community use
+1 aarch64 for ofborg _and_ community use
 
 ## Hetzner:
 
 owner: Eelco and Rob, owned by the NixOS Foundation
 
-“chef”: runs hydra.nixos.org, postgresql database, queue runner, hydra provisioner. binary cache signing keys.
+“chef”: runs hydra.nixos.org, postgresql database, queue runner, hydra
+provisioner. binary cache signing keys.
 
-monitoring:
-**DataDog, accessible by Eelco (and Rob?) (Amine?) on the Infor account**
+monitoring: **DataDog, accessible by Eelco (and Rob?) (Amine?) on the Infor
+account**
 
 ## Mac Minis at Hetzner Cloud
 
-owner: the NixOS Foundation
-access: Cole-h & Hexa
-role: build machines
+- owner: the NixOS Foundation
+- access: Cole-h & Hexa
+- role: build machines
 
 Current machine names:
 
@@ -164,9 +151,9 @@ Current machine names:
 
 ## Mac Minis at Graham's house
 
-owner: the NixOS Foundation
-access: Cole-h
-role: build machines
+- owner: the NixOS Foundation
+- access: Cole-h
+- role: build machines
 
 - arm64:
   - cosmic-stud
@@ -174,12 +161,13 @@ role: build machines
   - quality-ram
   - becoming-hyena
 
-There are also x86_64 mac minis, but they are offline because they produce too much heat.
+There are also x86_64 mac minis, but they are offline because they produce too
+much heat.
 
 ## Mac Stadium
 
-owner: MacStadium and rented to daniel peebles or the foundation?
-role: build machines
+- owner: MacStadium and rented to daniel peebles or the foundation?
+- role: build machines
 
 Eelco had a root password
 
@@ -193,7 +181,8 @@ owner: LogicBlox EC2 instance
 
 deployed from Eelco’s laptop
 
-runs the website
-runs the channel mirror script, systemd services with timers, updates /releases buckets and the nixpkgs-channels repository (repo: nixos-channel-scripts)
+runs the website runs the channel mirror script, systemd services with timers,
+updates /releases buckets and the nixpkgs-channels repository (repo:
+nixos-channel-scripts)
 
 The tarball mirror script is running from that machine.

--- a/docs/meeting-notes/2024-01-11.md
+++ b/docs/meeting-notes/2024-01-11.md
@@ -6,13 +6,13 @@ Participants: delroth, hexa, raitobezarius, vcunat, zimbatm
 
 ## [zimbatm] Presentation
 
-- At NixCon, we added new people to the team, but we were not able to give space to those new
-  people, with this in mind, I would like to dedicate one hour per week or two weeks where I can
-  unblock the infrastructure matters.
-- I don’t know what people are interested in, I believe this is a volunteer ecosystem and you should
-  work on what you would like to work on.
-- We have big challenges in front of us, e.g. the cache situation, with a new team, maybe we can
-  tackle those bigger challenges.
+- At NixCon, we added new people to the team, but we were not able to give space
+  to those new people, with this in mind, I would like to dedicate one hour per
+  week or two weeks where I can unblock the infrastructure matters.
+- I don’t know what people are interested in, I believe this is a volunteer
+  ecosystem and you should work on what you would like to work on.
+- We have big challenges in front of us, e.g. the cache situation, with a new
+  team, maybe we can tackle those bigger challenges.
 
 ## Round of intros
 
@@ -34,7 +34,8 @@ Skipped in these edited notes.
 - delroth/hexa are in favor of self-hosting.
   - But we need the database dump from EMS.
   - hexa to prepare the config for this, delroth can act as backup/fallback.
-- Fallback: we can always pay the $1200 (excl. VAT) for renewing the 1 year plan.
+- Fallback: we can always pay the $1200 (excl. VAT) for renewing the 1 year
+  plan.
 
 ## [hexa] Moving NGI out of nixos-org-configurations
 
@@ -46,16 +47,18 @@ Skipped in these edited notes.
 
 ## Builders
 
-- Context: various cost reduction efforts need to happen on the Hydra/ofborg builders infra.
+- Context: various cost reduction efforts need to happen on the Hydra/ofborg
+  builders infra.
 - There might be the possibility to get Hetzner to sponsor one more machine.
-- [delroth] Pretty sure we are not using our build resources efficiently as it is (queue-runner
-  bottleneck)
+- [delroth] Pretty sure we are not using our build resources efficiently as it
+  is (queue-runner bottleneck)
 - [vcunat] xz compression is the main problem
 - [zimbatm] We should properly analyze where the bottlenecks are.
 
 ## Backups
 
 - We are not doing proper backups of the NixOS infra.
-- There is an rsync.net account where the Hydra database gets backed up to, at least.
-- Julien's vaultwarden PR is currently blocked by this, we're getting backup storage space from
-  Hetzner (storage boxes).
+- There is an rsync.net account where the Hydra database gets backed up to, at
+  least.
+- Julien's vaultwarden PR is currently blocked by this, we're getting backup
+  storage space from Hetzner (storage boxes).

--- a/docs/meeting-notes/2024-01-25.md
+++ b/docs/meeting-notes/2024-01-25.md
@@ -4,8 +4,8 @@
 
 - Configuration hasn’t been written yet, hexa might get it done this week.
 - When will we get the data?
-  - Graham still holding it until it can get cleaned up (removing private user data). Board set a
-    deadline during the last meeting.
+  - Graham still holding it until it can get cleaned up (removing private user
+    data). Board set a deadline during the last meeting.
   - We could talk to EMS directly, to get the account handed over
   - We want ~10 days to do the migration (so: we want the data before Feb 7th)
 
@@ -33,9 +33,12 @@
     - Advanced communication will be sent out
     - Build list of store paths we want to keep and configure gc root for them
       - Plan is to keep all FODs
-    - Make store paths that are about to get deleted unavailable prior to deletion
+    - Make store paths that are about to get deleted unavailable prior to
+      deletion
 - Potentially move parts of the cache to Hetzner
   - delroth has capacity to look into this in 2024/02
-  - Needs a service to decide, where (S3 or Hetzner) the request would need to go
+  - Needs a service to decide, where (S3 or Hetzner) the request would need to
+    go
     - Logic could be installed at fastly, to try hetzner first, fallback to s3
-  - Service is in the critical path, currently fastly/s3 solve availability for us
+  - Service is in the critical path, currently fastly/s3 solve availability for
+    us

--- a/docs/meeting-notes/2024-02-08.md
+++ b/docs/meeting-notes/2024-02-08.md
@@ -1,6 +1,7 @@
 # 2024-02-08
 
-Attendees: delroth, hexa, JulienMalka, lheckemann, raitobezarius, vcunat, zimbatm
+Attendees: delroth, hexa, JulienMalka, lheckemann, raitobezarius, vcunat,
+zimbatm
 
 ## [hexa, delroth] EMS Migration
 
@@ -9,34 +10,37 @@ Context: https://github.com/NixOS/infra/issues/325
 - PR for Synapse and its dependencies is up.
   - https://github.com/NixOS/infra/pull/336
 - [Julien] What's the status of the backup module?
-  - Split off into its own PR and merged already: https://github.com/NixOS/infra/pull/345
+  - Split off into its own PR and merged already:
+    https://github.com/NixOS/infra/pull/345
 - raito and Ron met with Matrix / EMS folks at FOSDEM 2024
-  - They have scripts for GDPR compliance (user data purge), but we need to ask them by email.
+  - They have scripts for GDPR compliance (user data purge), but we need to ask
+    them by email.
   - Then we can get a clean DB dump, presumably without user data.
-  - Not sure whether we sent an email or not. But Graham might be in contact directly, and EMS folks
-    made him an offer to do the data deletion.
+  - Not sure whether we sent an email or not. But Graham might be in contact
+    directly, and EMS folks made him an offer to do the data deletion.
   - Worst case Graham/DetSys will pay for the extension of the EMS plan.
-  - Probably no hurry anymore from the infra side. Foundation board is monitoring this to make sure
-    we have a solution at some point.
+  - Probably no hurry anymore from the infra side. Foundation board is
+    monitoring this to make sure we have a solution at some point.
 
 ## [delroth] Should we publish these notes more widely?
 
 - There is a trend towards publishing notes on Discourse, etc. for visibility.
-- [delroth] My thoughts: we should archive (edited) notes in Git somewhere in our docs/ folder,
-  update a Discourse thread every 2 weeks.
+- [delroth] My thoughts: we should archive (edited) notes in Git somewhere in
+  our docs/ folder, update a Discourse thread every 2 weeks.
   - I of course volunteer to take care of this :)
 - Consensus: let’s do it.
 
 ## [delroth] Packet/EQM access to infra-core
 
-- Our builders are very, very outdated. But risky to try and update stuff with 0 debugging
-  capabilities.
-- Any reason why infra-core shouldn’t have full Packet/EQM access like we have Hetzner access?
+- Our builders are very, very outdated. But risky to try and update stuff with 0
+  debugging capabilities.
+- Any reason why infra-core shouldn’t have full Packet/EQM access like we have
+  Hetzner access?
   - Not entirely clear who currently has access?
   - [zimbatm] Got access from eelco last weekend, will delegate.
 - [raito] Does nix-netboot-serve run on our infra?
-  - [hexa] Yes, on eris. The images are also built from our infra, it’s a Hydra jobset. But the
-    jobset has not successfully completed for a year.
+  - [hexa] Yes, on eris. The images are also built from our infra, it’s a Hydra
+    jobset. But the jobset has not successfully completed for a year.
   - [hexa] We can update stuff, but we have no way to debug issues if we do so.
 - zimbatm took care of it live, woo!
 
@@ -47,43 +51,53 @@ Context: https://github.com/NixOS/infra/issues/325
 - In general: who should have ownership to accounts?
   - A bunch of GH org owners for example are inactive.
   - Not really aligned with any subgroup e.g. foundation board.
-  - [zimbatm] I think the foundation should have access, but unfortunately the foundation also
-    doesn’t have the best personal security to hold those credentials.
-  - [zimbatm] Maybe it should be the infra team instead? i.e. delroth/hexa/vcunat/…
-  - [raito] That would work too, as long as it’s active folks who can take care of day to day stuff.
-    I don’t care that it’s specifically me, just that we don’t get blocked due to not finding an
-    owner.
-  - [zimbatm] I don’t feel like I can make that decision alone right now. Let’s find some kind of
-    organization which makes sense.
+  - [zimbatm] I think the foundation should have access, but unfortunately the
+    foundation also doesn’t have the best personal security to hold those
+    credentials.
+  - [zimbatm] Maybe it should be the infra team instead? i.e.
+    delroth/hexa/vcunat/…
+  - [raito] That would work too, as long as it’s active folks who can take care
+    of day to day stuff. I don’t care that it’s specifically me, just that we
+    don’t get blocked due to not finding an owner.
+  - [zimbatm] I don’t feel like I can make that decision alone right now. Let’s
+    find some kind of organization which makes sense.
 - Raito got invited into the private infra matrix channel (at least, for now)
 
 ## [Julien] NixOS wiki collaboration w/ infra team
 
-- We have a bunch of candidate sysadmins in mind. Do we want to merge this into non-critical-infra?
-- [Julien] I’m a bit biased since I’m sitting on both sides of this discussion, but I think this
-  would be a good onramp to bring more people into non-critical-infra.
-- [zimbatm] We can subdivide permissions on the Hetzner Cloud side of things, but I’m not sure
-  whether we should share stuff further.
-- [hexa] They have their setup mostly figured out already, including backups. We can let them run
-  with it for now, and we can always pick it up later.
-- [linus] What about inviting them to non-critical-infra and just giving them access to all the
-  non-critical-infra? Even if they just want to maintain the wiki.
-  - [hexa] It’s about responsible for all of it. I don’t think we should grant unneeded access.
+- We have a bunch of candidate sysadmins in mind. Do we want to merge this into
+  non-critical-infra?
+- [Julien] I’m a bit biased since I’m sitting on both sides of this discussion,
+  but I think this would be a good onramp to bring more people into
+  non-critical-infra.
+- [zimbatm] We can subdivide permissions on the Hetzner Cloud side of things,
+  but I’m not sure whether we should share stuff further.
+- [hexa] They have their setup mostly figured out already, including backups. We
+  can let them run with it for now, and we can always pick it up later.
+- [linus] What about inviting them to non-critical-infra and just giving them
+  access to all the non-critical-infra? Even if they just want to maintain the
+  wiki.
+  - [hexa] It’s about responsible for all of it. I don’t think we should grant
+    unneeded access.
   - [Julien] +1.
-  - [delroth] I feel like if it’s official, we should treat it as such and onboard it as part of
-    non-critical infra. Doesn’t require giving them access to everything.
-  - [linus] If it is official, then it should be maintained by the official infra team
+  - [delroth] I feel like if it’s official, we should treat it as such and
+    onboard it as part of non-critical infra. Doesn’t require giving them access
+    to everything.
+  - [linus] If it is official, then it should be maintained by the official
+    infra team
   - [hexa] I think we’re mostly in agreement then.
-- [delroth] non-critical-infra should be restricted to the relevant directories and go through PRs
-  for touching other stuff
+- [delroth] non-critical-infra should be restricted to the relevant directories
+  and go through PRs for touching other stuff
   - [Julien] They probably want to iterate fast in the beginning
-  - [delroth] They should get a dedicated machine on Hetzner Cloud, that they can play with
+  - [delroth] They should get a dedicated machine on Hetzner Cloud, that they
+    can play with
   - [Julien] Too much shared code will increase reliance on core infra members.
 - [delroth] Action items
   - Let’s give them SSH access to a Hetzner Cloud VM
-    - Or a separate project so they get direct access to machines. Might already be done.
-  - Let’s make sure we agree on the idea of moving this to non-critical-infra in the short/mid-term
-    future
+    - Or a separate project so they get direct access to machines. Might already
+      be done.
+  - Let’s make sure we agree on the idea of moving this to non-critical-infra in
+    the short/mid-term future
   - Provision DNS etc.
 
 ## External requests
@@ -91,11 +105,12 @@ Context: https://github.com/NixOS/infra/issues/325
 - Hydra DB access (raitobezarius)
   - Hashing out details in https://github.com/NixOS/infra/issues/348
 - CA derivations for Hydra (Ericson2314)
-  - Nix 2.20 broke interop with the old Nix 2.13 we run on builders. Rolled back to 2.19.
+  - Nix 2.20 broke interop with the old Nix 2.13 we run on builders. Rolled back
+    to 2.19.
     - https://github.com/NixOS/nix/issues/9961
   - DB schema change applied.
 
 ## Ongoing projects
 
-- [delroth] Hoping to complete the nixops deprecation this week. Then: core/non-critical-infra
-  alignment.
+- [delroth] Hoping to complete the nixops deprecation this week. Then:
+  core/non-critical-infra alignment.

--- a/docs/meeting-notes/2024-02-22.md
+++ b/docs/meeting-notes/2024-02-22.md
@@ -11,109 +11,122 @@ Attendees: delroth, edolstra, hexa, JulienMalka, raitobezarius, vcunat, zimbatm
 
 - How do we backup haumea, long term?
   - borgbackup isn't really a good fit for a 500GB Postgres DB.
-  - Currently: zrepl to my personal infra and hexa's, but that's obviously not a good long term
-    solution.
-  - Used to have backups to graham's rsync.net account, but that's broken since mid-Jan.
+  - Currently: zrepl to my personal infra and hexa's, but that's obviously not a
+    good long term solution.
+  - Used to have backups to graham's rsync.net account, but that's broken since
+    mid-Jan.
   - [raito] Have you ever tried pg_dump's optimized dump format?
     - [delroth] Is it fast enough to do a daily dump?
     - [raito] unsure, but there are ways to do incremental backups:
-        - pg_basebackup + pg_dump compressed format
+      - pg_basebackup + pg_dump compressed format
 
 ## [hexa] Migration of Synapse from EMS
 
 - Apparently waiting for EMS to sort out removal of PII?
-- [raito] As long as there's discussion happening between Graham and EMS we probably don't have to
-  care about this, the legacy hosting plan is not getting cancelled.
+- [raito] As long as there's discussion happening between Graham and EMS we
+  probably don't have to care about this, the legacy hosting plan is not getting
+  cancelled.
 - [raito] If anything goes wrong we'd likely get notified.
 
 ## [eelco] Move fastly log aggregator to pluto
 
 - This is currently running on Eelco's local machine which is suboptimal.
-- Weekly script that takes Fastly logs and loads them into AWS Athena + generates some aggregates.
+- Weekly script that takes Fastly logs and loads them into AWS Athena +
+  generates some aggregates.
 - https://github.com/NixOS/infra/tree/master/metrics/fastly
 - We will put that on the new Eris: Pluto
-- [eelco] I will need to create an AWS IAM to bestow the adequate permissions to enable the script
-  to run on Pluto.
-    - [eelco] I just need read/write access to Athena and some S3 bucket.
+- [eelco] I will need to create an AWS IAM to bestow the adequate permissions to
+  enable the script to run on Pluto.
+  - [eelco] I just need read/write access to Athena and some S3 bucket.
 - [delroth] Who is using this data?
-    - [eelco] You can see on that page that the reporting is generated via this data
+  - [eelco] You can see on that page that the reporting is generated via this
+    data
 - PII data regarding access logs of cache.nixos.org
-    - [everyone] What kind of policy do we want regarding PII and the non-critical infrastructure?
-      e.g. new wiki access logs are available to the non-critical infrastructure
-        - Let's take note of this, think about it for the next weeks
+  - [everyone] What kind of policy do we want regarding PII and the non-critical
+    infrastructure? e.g. new wiki access logs are available to the non-critical
+    infrastructure
+    - Let's take note of this, think about it for the next weeks
 
 ## [delroth, hexa] Machine changes
 
-Our spend on outdated AWS EC2 instances and EBS volumes is too high and we are cutting back on our
-use of EC2 and instead renew our infra at Hetzner.
+Our spend on outdated AWS EC2 instances and EBS volumes is too high and we are
+cutting back on our use of EC2 and instead renew our infra at Hetzner.
 
 - Reduce AWS spending
-    - Started pruning old snapshots and EBS volumes (e.g. nixos-webserver, old nixos versions)
-        - [eelco] I think it should be fine to delete them. There's a small risk there could be some
-          historical data, for instance, our subversion repo used to be there as well and the
-          nix-dev mailing list too. In theory, we have copies of all of that.
-        - [delroth] I might start an instance and extract the data out there otherwise I will just
-          delete it.
-        - [eelco] There was a lot of scratch space for something… I don't remember it.
-        - [delroth] I think it was bastion and is now paused.
-    - Bastion is now stopped/paused
-        - [hexa] Migrated to Eris and now to Pluto
-        - [hexa] Channel scripts are running way faster
-        - [raito] :tada:
-    - Pinged survey.nixos.org owners (@garbas), to get the limesurvey instance migrated to something
-      more reasonable
-        - [hexa] $ 150 USD/mo
-        - [hexa] Proposal: Migrate to Hetzner Cloud for a fraction of the costs
-        - [delroth] I asked Julien to look into it
-        - [delroth] In general, it's open to anyone who are looking to do non-critical work
-    - Archeology machine from the cache team
-        - [delroth] Jonas, can you look into the cost? And can we make it start on-demand?
-        - [jonas] asking edef whether they can accomodate these changes]
+  - Started pruning old snapshots and EBS volumes (e.g. nixos-webserver, old
+    nixos versions)
+    - [eelco] I think it should be fine to delete them. There's a small risk
+      there could be some historical data, for instance, our subversion repo
+      used to be there as well and the nix-dev mailing list too. In theory, we
+      have copies of all of that.
+    - [delroth] I might start an instance and extract the data out there
+      otherwise I will just delete it.
+    - [eelco] There was a lot of scratch space for something… I don't remember
+      it.
+    - [delroth] I think it was bastion and is now paused.
+  - Bastion is now stopped/paused
+    - [hexa] Migrated to Eris and now to Pluto
+    - [hexa] Channel scripts are running way faster
+    - [raito] :tada:
+  - Pinged survey.nixos.org owners (@garbas), to get the limesurvey instance
+    migrated to something more reasonable
+    - [hexa] $ 150 USD/mo
+    - [hexa] Proposal: Migrate to Hetzner Cloud for a fraction of the costs
+    - [delroth] I asked Julien to look into it
+    - [delroth] In general, it's open to anyone who are looking to do
+      non-critical work
+  - Archeology machine from the cache team
+    - [delroth] Jonas, can you look into the cost? And can we make it start
+      on-demand?
+    - [jonas] asking edef whether they can accomodate these changes]
 - Hetzner machine renewal
-    - Phasing out eris.nixos.org (EX41S-SSD, Intel i7-6700, 64GB RAM, 2x 256GB SATA)
-        - [hexa] Old hardware
-    - Created and deployed pluto.nixos.org (EX44, Intel i5-13500, 2x512GB NVME)
-        - [hexa] Slightly cheaper but modern hardware
-        - [hexa] Everything migrated except for monitoring
-        - [delroth] Some disentanglement required to migrate monitoring
+  - Phasing out eris.nixos.org (EX41S-SSD, Intel i7-6700, 64GB RAM, 2x 256GB
+    SATA)
+    - [hexa] Old hardware
+  - Created and deployed pluto.nixos.org (EX44, Intel i5-13500, 2x512GB NVME)
+    - [hexa] Slightly cheaper but modern hardware
+    - [hexa] Everything migrated except for monitoring
+    - [delroth] Some disentanglement required to migrate monitoring
 
-There's a potential of around $700/month of savings in all those operations. That is, we're
-offsetting our whole current Hetzner spend with those AWS savings.
+There's a potential of around $700/month of savings in all those operations.
+That is, we're offsetting our whole current Hetzner spend with those AWS
+savings.
 
 - [delroth] Future savings (more involved):
-    - [delroth] Two layers of storage for cache.nixos.org: warm paths on Hetzner
-    - [delroth] It might be easier to do that stuff on NixOS releases S3 bucket (much smaller
-      bucket) and it's costing ~1000 USD per month in **bandwidth**
+  - [delroth] Two layers of storage for cache.nixos.org: warm paths on Hetzner
+  - [delroth] It might be easier to do that stuff on NixOS releases S3 bucket
+    (much smaller bucket) and it's costing ~1000 USD per month in **bandwidth**
 
 ## [julien] Opening non-critical to more members
 
-- [Julien] Idea of non-critical infra was to lower the barrier to entry, because people could be
-  trusted with less risky infra
-    - [Julien] I would like to post a Discourse post to look for new people who might be interested
-      to join the team
-    - [Julien] It seems like we have some issues open for non-critical infra and let people to
-      tackle them and could constitute a first project
-      - [delroth]
-        https://github.com/NixOS/infra/issues?q=is%3Aopen+is%3Aissue+label%3Anon-critical-infra
-    - [Julien] I think it's a good time to do such a post and reach out
-    - [Julien] I wanted to know with everyone if it was okay to invite new people
-    - [delroth/zimbatm] Yes
-    - [delroth] I think the most important thing is to know who will take care of onboarding and
-      leading the work
-    - [Julien] I am ready to handle the onboarding load and the lead, I would prefer to manage
-      newcomers rather than do all the stuff by myself
+- [Julien] Idea of non-critical infra was to lower the barrier to entry, because
+  people could be trusted with less risky infra
+  - [Julien] I would like to post a Discourse post to look for new people who
+    might be interested to join the team
+  - [Julien] It seems like we have some issues open for non-critical infra and
+    let people to tackle them and could constitute a first project
+    - [delroth]
+      https://github.com/NixOS/infra/issues?q=is%3Aopen+is%3Aissue+label%3Anon-critical-infra
+  - [Julien] I think it's a good time to do such a post and reach out
+  - [Julien] I wanted to know with everyone if it was okay to invite new people
+  - [delroth/zimbatm] Yes
+  - [delroth] I think the most important thing is to know who will take care of
+    onboarding and leading the work
+  - [Julien] I am ready to handle the onboarding load and the lead, I would
+    prefer to manage newcomers rather than do all the stuff by myself
 
 ## [delroth, hexa] Deployment changes
 
-We removed nixops and deployment now happens from a `flake.nix`. The plan is to go for colmena
-eventually.
+We removed nixops and deployment now happens from a `flake.nix`. The plan is to
+go for colmena eventually.
 
-- Deployment via `nixos-rebuild --flake .#<host> --target-host root@<host>.nixos.org
+- Deployment via
+  `nixos-rebuild --flake .#<host> --target-host root@<host>.nixos.org
   --use-substitutes switch`
-- NixOps generated configuration was imported and is being migrated, for example we:
-    - started using agenix for secrets management and imported existing secrets
-    - and migrated Network configuration to systemd-networkd/resolved
-
+- NixOps generated configuration was imported and is being migrated, for example
+  we:
+  - started using agenix for secrets management and imported existing secrets
+  - and migrated Network configuration to systemd-networkd/resolved
 
 ## [delroth, hexa] Infra Changelog
 
@@ -121,27 +134,32 @@ eventually.
 - Migrated haumea's database to PostgreSQL 16
 - Align timezone across machines
 - Fix backup of haumea's database
-    - zrepl to delroth and hexa
-    - rsync.net stopped working due to zrepl API version mismatch
+  - zrepl to delroth and hexa
+  - rsync.net stopped working due to zrepl API version mismatch
 - Enabled trimming and scrubbing on all ZFS pools
 
 - Fix the fastly-exporter deployment
-    - Migrated to nixpkgs module, which [required its own
-      fixes](https://github.com/NixOS/nixpkgs/pull/287348)
-    - Generated a new API token, the old one was invalid
-    - 📊 [Dashboard](https://monitoring.nixos.org/grafana/d/SHjM6e-ik/fastly?orgId=1)
-- Fixed [race condition and world-writable state
-  file](https://github.com/packethost/prometheus-packet-sd/issues/15) upstream in packet-sd
+  - Migrated to nixpkgs module, which
+    [required its own fixes](https://github.com/NixOS/nixpkgs/pull/287348)
+  - Generated a new API token, the old one was invalid
+  - 📊
+    [Dashboard](https://monitoring.nixos.org/grafana/d/SHjM6e-ik/fastly?orgId=1)
+- Fixed
+  [race condition and world-writable state
+  file](https://github.com/packethost/prometheus-packet-sd/issues/15) upstream
+  in packet-sd
 - Added alerting for
-    - Failed systemd units
-    - [Domain expiry](https://github.com/NixOS/infra/pull/249) within the next 30 days
+  - Failed systemd units
+  - [Domain expiry](https://github.com/NixOS/infra/pull/249) within the next 30
+    days
 - Lazy loading of eval errors on hydra (Patch by @ajs124)
-    - Reduces page sizes on the common jobsets/evals by 15-20MB to a few kBs
-    - More work needed, because error logs are still being fetched from the DB, just not rendered
+  - Reduces page sizes on the common jobsets/evals by 15-20MB to a few kBs
+  - More work needed, because error logs are still being fetched from the DB,
+    just not rendered
 - Services migrated to pluto.nixos.org
-    - channel-scripts/hydra-mirror
-    - netboot
-    - rfc39
+  - channel-scripts/hydra-mirror
+  - netboot
+  - rfc39
 - Removed and refactored legacy code, e.g.
-    - hydra-provisioner
-    - delft/network.nix
+  - hydra-provisioner
+  - delft/network.nix

--- a/docs/meeting-notes/2024-03-07.md
+++ b/docs/meeting-notes/2024-03-07.md
@@ -1,71 +1,86 @@
 # 2024-03-07
 
-Attendees: hexa, vcunat, zimbatm (Jonas), Linus, Julien, Raito/Ryan, Jade (most of the time)
+Attendees: hexa, vcunat, zimbatm (Jonas), Linus, Julien, Raito/Ryan, Jade (most
+of the time)
 
 ## [hexa] arm64 hetzner machine config
 
 - Dump it into a new directory in the infra repo, allow infra-build to deploy
-    - vcunat: There's an issue containing the bits of the configuration
-    - vcunat: I assumed we wanted to migrate it directly to a new deployment system
-    - hexa: delroth wanted to script out iPXE but this has not panned out yet, we discovered we had DHCP available, which is promising
+  - vcunat: There's an issue containing the bits of the configuration
+  - vcunat: I assumed we wanted to migrate it directly to a new deployment
+    system
+  - hexa: delroth wanted to script out iPXE but this has not panned out yet, we
+    discovered we had DHCP available, which is promising
 
 ## [zimbatm] Round table
+
 What is on everyone's mind? What are your plans?
 
 - Linus:
-    - Happy to help out with stuff, pairing on with anything
-    - zimbatm: Do you think we should do a better presentation?
-    - linus: I think that'd be good
+  - Happy to help out with stuff, pairing on with anything
+  - zimbatm: Do you think we should do a better presentation?
+  - linus: I think that'd be good
 - hexa:
-    - Looking at iPXE, hold us back the most right now
-      - will coordinate with delroth, if he has already anything
-    - Open to discuss the Ceph scenario
-      - A lot of discussions ongoing with the self-hosted binary cache, that's good
-      - We are running into questions that cannot be answered by anyone
-        - What should be the availability?
-        - What should be the durability?
-        - Discussion running in circles right now
-      - Form a tightr discussion group
-        - So that you can identify the main points
-        - And address them
-        - And not run into circles
+  - Looking at iPXE, hold us back the most right now
+    - will coordinate with delroth, if he has already anything
+  - Open to discuss the Ceph scenario
+    - A lot of discussions ongoing with the self-hosted binary cache, that's
+      good
+    - We are running into questions that cannot be answered by anyone
+      - What should be the availability?
+      - What should be the durability?
+      - Discussion running in circles right now
+    - Form a tightr discussion group
+      - So that you can identify the main points
+      - And address them
+      - And not run into circles
 - vcunat:
-    - Continuously busy with staging iterations
-    - Unblocking difficult to access machines, e.g. aarch64 machine
-    - There's actually more of my machines in the infra and that also requires update
-    - Small benchmarking machine that makes sense:
-        - t2a
-        - The point is to have consistent benchmarking data
-        - Linus: we definitely don't have cloud VMs for benchmarking, we probably want dedicated hardware
-    - zimbatm: could you potentially create a ticket to make an inventory of your machines?
-    - vcunat: there's two machines: t2a and t4b only really
+  - Continuously busy with staging iterations
+  - Unblocking difficult to access machines, e.g. aarch64 machine
+  - There's actually more of my machines in the infra and that also requires
+    update
+  - Small benchmarking machine that makes sense:
+    - t2a
+    - The point is to have consistent benchmarking data
+    - Linus: we definitely don't have cloud VMs for benchmarking, we probably
+      want dedicated hardware
+  - zimbatm: could you potentially create a ticket to make an inventory of your
+    machines?
+  - vcunat: there's two machines: t2a and t4b only really
 - Julien:
-    - *Short-term*: I would like to onboard more folks on non-critical infrastructure
-        - I would like to give them tasks to do end to end
-        - Difficult to do with the current list of tasks atm
-    - The wiki is also something I also want to get out ASAP
-        - The technical issues are basically non-existent, just a little bit more work to do
-        - Then announcements, onboard people to do editorial work, and that's it
-        - We are near ready to launch
-    - zimbatm: Bitwarden
-        - Julien: we need to move the data from old to new and inform the change to the users
-        - zimbatm: OK, we need to organize that migration
-        - Julien: we can discuss this async
-    - Interested also in cache self-hosting discussions
-        - We have momentum and it'd be nice to have some sort of stance from infra people
-        - Addressing the recent unrest regarding the public stance of infra on self hosting
-        - zimbatm: we should/could do a proof of concept so we can get a feeling about how easy is it to operate
+  - _Short-term_: I would like to onboard more folks on non-critical
+    infrastructure
+    - I would like to give them tasks to do end to end
+    - Difficult to do with the current list of tasks atm
+  - The wiki is also something I also want to get out ASAP
+    - The technical issues are basically non-existent, just a little bit more
+      work to do
+    - Then announcements, onboard people to do editorial work, and that's it
+    - We are near ready to launch
+  - zimbatm: Bitwarden
+    - Julien: we need to move the data from old to new and inform the change to
+      the users
+    - zimbatm: OK, we need to organize that migration
+    - Julien: we can discuss this async
+  - Interested also in cache self-hosting discussions
+    - We have momentum and it'd be nice to have some sort of stance from infra
+      people
+    - Addressing the recent unrest regarding the public stance of infra on self
+      hosting
+    - zimbatm: we should/could do a proof of concept so we can get a feeling
+      about how easy is it to operate
 - Ryan:
   - Recommend https://github.com/zhaofengli/colmena/pull/198
 
-Things to pick up for infra: https://github.com/NixOS/infra/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Anew-service
+Things to pick up for infra:
+https://github.com/NixOS/infra/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Anew-service
 
 ## [hexa] darwin access
 
 - hexa: We have an inventory problem
-    - What machines exist? What machines should we be able to access?
-    - Important so we can delegate access and unblock work
-    - 
+  - What machines exist? What machines should we be able to access?
+  - Important so we can delegate access and unblock work
+  -
 
 - Braindump
   - Apple M1 at Hetzner (hydra)
@@ -75,28 +90,36 @@ Things to pick up for infra: https://github.com/NixOS/infra/issues?q=is%3Aissue+
 
 ## [hexa] ofBorg access
 
-- hexa: we have some folks who want to work on OfBorg but cannot do because they are not empowered on to do so
-    - it is also go via buildkite management mechanism from Graham
+- hexa: we have some folks who want to work on OfBorg but cannot do because they
+  are not empowered on to do so
+  - it is also go via buildkite management mechanism from Graham
 
 ## [raito] aarch64.nixos.community management
 
 - https://github.com/NixOS/aarch64-build-box/
-    - managed by community or infra?
-    - zimbatm: it used to be in the nix-community infra, but because the nix-community does not have access to the Packet account
-    - hexa: in the past, the worst we had is to debug the kernel issues, which is difficult w/o packet access
-    - utilized by ofBorg, too, not a problem because we don't need to trust its build results
-    - zimbatm: will talk with zowoq, who manages the nix-community day-to-day operation
+  - managed by community or infra?
+  - zimbatm: it used to be in the nix-community infra, but because the
+    nix-community does not have access to the Packet account
+  - hexa: in the past, the worst we had is to debug the kernel issues, which is
+    difficult w/o packet access
+  - utilized by ofBorg, too, not a problem because we don't need to trust its
+    build results
+  - zimbatm: will talk with zowoq, who manages the nix-community day-to-day
+    operation
 
 ## Changelog
+
 - Cancelled the contract for `eris.nixos.org` (ends after 2024-02-28)
-    - All services have been migrated to pluto.nixos.org
+  - All services have been migrated to pluto.nixos.org
 - Set up backups for Prometheus, Grafana, VictoriaMetrics
 - The primary hostnames for Prometheus and Grafana have changed
-    - https://prometheus.nixos.org
-    - https://grafana.nixos.org
-    - Redirects for the old hostname/path are in place
+  - https://prometheus.nixos.org
+  - https://grafana.nixos.org
+  - Redirects for the old hostname/path are in place
 - Hydra changes
-    - Increase pipe size to improve queue-runner performance 
-    - Increased retention interval of Prometheus to two years so we have more history to evaluate these changes
-- Builders have received the fix for https://github.com/NixOS/nix/security/advisories/GHSA-2ffj-w4mj-pg37
+  - Increase pipe size to improve queue-runner performance
+  - Increased retention interval of Prometheus to two years so we have more
+    history to evaluate these changes
+- Builders have received the fix for
+  https://github.com/NixOS/nix/security/advisories/GHSA-2ffj-w4mj-pg37
 - GitHub App for wiki.nixos.org so users can log in.

--- a/docs/meeting-notes/2024-03-21.md
+++ b/docs/meeting-notes/2024-03-21.md
@@ -3,46 +3,56 @@
 Attendees: hexa, vcunat, Linus, zimbatm, Eelco, Janik, raitobezariusm, Alex
 
 ## Round table
-- zimbatm
-    - had no spoons to think about cache
-- vcunat
-    - expensive nixos tests that could be improved
-    - noticed `nixos-disk-image.drv` steps taking a long time in send/receive phase
-- hexa
-    - unhappy with the board decision to let Anduril sponsor, like delroth. At an impass. We need to find a way to work on this together.
-    - not sure if delroth is ultimately out.
-    - don't want to burn out if delroth is gone.
-    - I also don't want to invest time, when the org agrees to military sponsorship.
-    - Next step: get to the policy, connect with delroth to see if we can keep working on it together or not.
-- Janik
-    - opened issue after the open board calls about meeting infrastructure. https://github.com/NixOS/infra/issues/401
-    - PR with Jitsi probably soon.
-    - Do we have a database for the pads?
-        - hexa: should be colocated with the machine.
-    - Jonas: do we have hardware for this?
-    - hexa: we can try it on caliban. If it grows too big we can move it.
-- Linus
-    - happy to review what Janik is doing.
-    - happy to pair with anyone
-- Eelco
-    - what the plan with the self-hosting?
-        - still in discussion, we intend to a do some exploration with Ceph
-    - we still need to find a way to pay for the cache.
-- Alex Ou
-    - NixCon NA attendee.
-    - Interested in infrastructure, their main use of NixOS, managing bare-metal fleet of servers
-- Raitobezarius
-    - Concerned with the state of the infra, due to delroth ragequitting.
-    - Tigris Data: CDN+S3 built on top of fly.io that migth be interested in sponsoring us.
-    - Meeting with PCH.org: have hundreds of datacenters, they can offer everything in terms of storage infra.
-        - Lots of POPs
-        - Storage
-        - ...
-        - Proposition in progress.
-    - Would like to update the set of people in the infra core for inactive people, in order to be able to reason on who has access, so we can reason about trust.
-        - Eelco?
-        - Graham?
-        - Amine?
-        - Proposal: remove access, and restore if needed
-        - Eelco agreed. (Actually Eelco needs to reconsider.)
 
+- zimbatm
+  - had no spoons to think about cache
+- vcunat
+  - expensive nixos tests that could be improved
+  - noticed `nixos-disk-image.drv` steps taking a long time in send/receive
+    phase
+- hexa
+  - unhappy with the board decision to let Anduril sponsor, like delroth. At an
+    impass. We need to find a way to work on this together.
+  - not sure if delroth is ultimately out.
+  - don't want to burn out if delroth is gone.
+  - I also don't want to invest time, when the org agrees to military
+    sponsorship.
+  - Next step: get to the policy, connect with delroth to see if we can keep
+    working on it together or not.
+- Janik
+  - opened issue after the open board calls about meeting infrastructure.
+    https://github.com/NixOS/infra/issues/401
+  - PR with Jitsi probably soon.
+  - Do we have a database for the pads?
+    - hexa: should be colocated with the machine.
+  - Jonas: do we have hardware for this?
+  - hexa: we can try it on caliban. If it grows too big we can move it.
+- Linus
+  - happy to review what Janik is doing.
+  - happy to pair with anyone
+- Eelco
+  - what the plan with the self-hosting?
+    - still in discussion, we intend to a do some exploration with Ceph
+  - we still need to find a way to pay for the cache.
+- Alex Ou
+  - NixCon NA attendee.
+  - Interested in infrastructure, their main use of NixOS, managing bare-metal
+    fleet of servers
+- Raitobezarius
+  - Concerned with the state of the infra, due to delroth ragequitting.
+  - Tigris Data: CDN+S3 built on top of fly.io that migth be interested in
+    sponsoring us.
+  - Meeting with PCH.org: have hundreds of datacenters, they can offer
+    everything in terms of storage infra.
+    - Lots of POPs
+    - Storage
+    - ...
+    - Proposition in progress.
+  - Would like to update the set of people in the infra core for inactive
+    people, in order to be able to reason on who has access, so we can reason
+    about trust.
+    - Eelco?
+    - Graham?
+    - Amine?
+    - Proposal: remove access, and restore if needed
+    - Eelco agreed. (Actually Eelco needs to reconsider.)

--- a/docs/meeting-notes/2024-04-18.md
+++ b/docs/meeting-notes/2024-04-18.md
@@ -5,7 +5,8 @@ Attendees: delroth, Janik, dgrig, vcunat, raitobezarius, hexa, Linus, Weija
 ## Topics
 
 - [delroth] Bringing up the topic of Keycloak / Kanidm again
-  - We'll probably want it for Jitsi? I'd also love to drop user management stuff from Hydra.
+  - We'll probably want it for Jitsi? I'd also love to drop user management
+    stuff from Hydra.
   - Other use cases:
     - Wiki? (I'm guessing mediawiki can SAML)
     - Pads? (for meeting notes that we'd rather not have vandalized)
@@ -14,16 +15,25 @@ Attendees: delroth, Janik, dgrig, vcunat, raitobezarius, hexa, Linus, Weija
   - [hexa] Requirements:
     - GitHub login, and being able to read organization membership info
     - Maybe Dex can do what we want as well? Proxy to backend apps
-        - @raitobezarius in chat: [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/github/) as well exist
-        - @raitobezarius in chat: [SATOSA Proxy](https://github.com/IdentityPython/SATOSA) can be used to do SAML2<->Social Login
+      - @raitobezarius in chat:
+        [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/github/)
+        as well exist
+      - @raitobezarius in chat:
+        [SATOSA Proxy](https://github.com/IdentityPython/SATOSA) can be used to
+        do SAML2<->Social Login
 
 - [delroth] releases.nixos.org S3 costs
-  - tl;dr discovered last week that the bandwidth costs rose significantly for no known reason
-  - Shape of the growth looks organic but there shouldn't really be anything causing it.
+  - tl;dr discovered last week that the bandwidth costs rose significantly for
+    no known reason
+  - Shape of the growth looks organic but there shouldn't really be anything
+    causing it.
   - Fastly logs analysis showed nothing interesting.
-      - Some access is blocked by [eelco not sharing credentials](https://github.com/NixOS/infra/pull/388#discussion_r1545856527)
+    - Some access is blocked by
+      [eelco not sharing credentials](https://github.com/NixOS/infra/pull/388#discussion_r1545856527)
   - Enabled S3 logging, haven't analyzed yet.
-  - Cost Explorer might be indicating that this isn't actually releases.nixos.org but something else in eu-west-1 also using S3? But then what? (or is Cost Explorer broken? wouldn't be too surprising)
+  - Cost Explorer might be indicating that this isn't actually
+    releases.nixos.org but something else in eu-west-1 also using S3? But then
+    what? (or is Cost Explorer broken? wouldn't be too surprising)
 
 - [Janik] Jitsi on non-critical-infra
   - nixpkgs+infra PRs were reviewed
@@ -32,47 +42,50 @@ Attendees: delroth, Janik, dgrig, vcunat, raitobezarius, hexa, Linus, Weija
 
 - [delroth] What do we still not have access to?
 
-    | Hostname | System | Location | Purpose | Access  <br>infra-build | Access  <br>infra | Comment |
-    | --- | --- | --- | --- | --- | --- | --- |
-    | haumea.nixos.org | x86_64-linux | Hetzner | Hydra database | have | \-  |     |
-    | makemake.nixos.org | x86_64-linux | Hetzner | NGI Hydra | \-  | \-  | via https://github.com/ngi-nix/ngi0-infra |
-    | intense-heron.mac.nixos.org | aarch64-darwin | Hetzner | Hydra builder | want | \-  |     |
-    | sweeping-filly.mac.nixos.org | aarch64-darwin | Hetzner | Hydra builder | want | \-  |     |
-    | maximum-snail.mac.nixos.org | aarch64-darwin | Hetzner | Hydra builder | want | \-  |     |
-    | growing-jennet.mac.nixos.org | aarch64-darwin | Hetzner | Hydra builder | want | \-  |     |
-    | enormous-catfish.mac.nixos.org | aarch64-darwin | Hetzner | Hydra builder | want | \-  |     |
-    | rhea.nixos.org | x86_64-linux | Hetzner | Hydra | have | \-  |     |
-    | caliban.nixos.org | x86-64-linux | Hetzner | NC-Infra | have | x   |     |
-    | aa-hetzner-1.nixos.org | aarch64-linux | Hetzner | Hydra | have | \-  | config import infra repo todo |
-    | pluto.nixos.org | x86_64-linux | Hetzner | Monitoring, Channel-Scripts | have | \-  |     |
-    | aarch64.nixos.community | aarch64-linux | Equinix | Community/ofborg builder | \-  | \-  | on demand |
-    | 208.83.1.145 | aarch64-darwin | Macstadium | OfBorg builder | want  | \-  |     |
-    | 208.83.1.173 | x86_64-darwin | Macstadium | OfBorg builder | want  | \-  |     |
-    | 208.83.1.175 | x86_64-darwin | Macstadium | OfBorg builder | want  | \-  |     |
-    | 208.83.1.181 | aarch64-darwin | Macstadium | OfBorg builder | want  | \-  |     |
-    | 208.83.1.186 | x86_64-darwin | Macstadium | OfBorg builder | want  | \-  |     |
-    | ofborg-core | x86_64-linux | Equinix | OfBorg controller | want | \-  | on demand |
-    | netboot-foundation | x86_64-linux | Equinix | ?   | \-  | \-  | on demand |
-    | ofborg-evaluator0 | x86_64-linux | Equinix | OfBorg evaluator/builder | want |     | on demand |
-    | ofborg-evaluator1 | x86_64-linux | Equinix | OfBorg evaluator/builder | want |     | on demand |
-    | ofborg-evaluator2 | x86_64-linux | Equinix | OfBorg evaluator/builder | want |     | on demand |
-    | ofborg-evaluator3 | x86_64-linux | Equinix | OfBorg evaluator/builder | want |     | on demand |
-    | ofborg-evaluator4 | x86_64-linux | Equinix | OfBorg evaluator/builder | want |     | on demand |
-    | small-c3.large.arm64 | aarch64-linux | Equinix | Hydra builder | have | \-  | on demand |
-    | big-parallel-c3.large.arm64 | aarch64-linux | Equinix | Hydra builder | have | \-  | on demand |
+  | Hostname                       | System         | Location   | Purpose                     | Access <br>infra-build | Access <br>infra | Comment                                   |
+  | ------------------------------ | -------------- | ---------- | --------------------------- | ---------------------- | ---------------- | ----------------------------------------- |
+  | haumea.nixos.org               | x86_64-linux   | Hetzner    | Hydra database              | have                   | \-               |                                           |
+  | makemake.nixos.org             | x86_64-linux   | Hetzner    | NGI Hydra                   | \-                     | \-               | via https://github.com/ngi-nix/ngi0-infra |
+  | intense-heron.mac.nixos.org    | aarch64-darwin | Hetzner    | Hydra builder               | want                   | \-               |                                           |
+  | sweeping-filly.mac.nixos.org   | aarch64-darwin | Hetzner    | Hydra builder               | want                   | \-               |                                           |
+  | maximum-snail.mac.nixos.org    | aarch64-darwin | Hetzner    | Hydra builder               | want                   | \-               |                                           |
+  | growing-jennet.mac.nixos.org   | aarch64-darwin | Hetzner    | Hydra builder               | want                   | \-               |                                           |
+  | enormous-catfish.mac.nixos.org | aarch64-darwin | Hetzner    | Hydra builder               | want                   | \-               |                                           |
+  | rhea.nixos.org                 | x86_64-linux   | Hetzner    | Hydra                       | have                   | \-               |                                           |
+  | caliban.nixos.org              | x86-64-linux   | Hetzner    | NC-Infra                    | have                   | x                |                                           |
+  | aa-hetzner-1.nixos.org         | aarch64-linux  | Hetzner    | Hydra                       | have                   | \-               | config import infra repo todo             |
+  | pluto.nixos.org                | x86_64-linux   | Hetzner    | Monitoring, Channel-Scripts | have                   | \-               |                                           |
+  | aarch64.nixos.community        | aarch64-linux  | Equinix    | Community/ofborg builder    | \-                     | \-               | on demand                                 |
+  | 208.83.1.145                   | aarch64-darwin | Macstadium | OfBorg builder              | want                   | \-               |                                           |
+  | 208.83.1.173                   | x86_64-darwin  | Macstadium | OfBorg builder              | want                   | \-               |                                           |
+  | 208.83.1.175                   | x86_64-darwin  | Macstadium | OfBorg builder              | want                   | \-               |                                           |
+  | 208.83.1.181                   | aarch64-darwin | Macstadium | OfBorg builder              | want                   | \-               |                                           |
+  | 208.83.1.186                   | x86_64-darwin  | Macstadium | OfBorg builder              | want                   | \-               |                                           |
+  | ofborg-core                    | x86_64-linux   | Equinix    | OfBorg controller           | want                   | \-               | on demand                                 |
+  | netboot-foundation             | x86_64-linux   | Equinix    | ?                           | \-                     | \-               | on demand                                 |
+  | ofborg-evaluator0              | x86_64-linux   | Equinix    | OfBorg evaluator/builder    | want                   |                  | on demand                                 |
+  | ofborg-evaluator1              | x86_64-linux   | Equinix    | OfBorg evaluator/builder    | want                   |                  | on demand                                 |
+  | ofborg-evaluator2              | x86_64-linux   | Equinix    | OfBorg evaluator/builder    | want                   |                  | on demand                                 |
+  | ofborg-evaluator3              | x86_64-linux   | Equinix    | OfBorg evaluator/builder    | want                   |                  | on demand                                 |
+  | ofborg-evaluator4              | x86_64-linux   | Equinix    | OfBorg evaluator/builder    | want                   |                  | on demand                                 |
+  | small-c3.large.arm64           | aarch64-linux  | Equinix    | Hydra builder               | have                   | \-               | on demand                                 |
+  | big-parallel-c3.large.arm64    | aarch64-linux  | Equinix    | Hydra builder               | have                   | \-               | on demand                                 |
 
 ## Changelog:
 
 - Removed unused apps on the infra repo
-    - Slack (unused)
+  - Slack (unused)
 - Removed apps from release-wiki repo
-    - HackMD (unused)
+  - HackMD (unused)
 - Removed unused apps on the org level
-    - Bors (discontinued)
-    - Marvin-MK2 (discontinued)
-    - Travis-CI (unused)
+  - Bors (discontinued)
+  - Marvin-MK2 (discontinued)
+  - Travis-CI (unused)
 - Hydra web UI is fast^W not as slow now (+ other improvements)
-    - https://github.com/NixOS/hydra/commit/6189ba9c5e5308e17a7d1fb7f38443272a70f072
-    - Queue runner CPU-heavy operations throttling: https://github.com/NixOS/hydra/commit/a51bd392a22fba5b0a0d90e2204a608b78c37ce1
-- Fastly shielding location fixed for releases.nixos.org and tarballs.nixos.org (used to go transatlantic for no good reason)
-- http:// redirects to https:// for all our S3 buckets except cache.nixos.org (broke nix-index, temporarily reverted)
+  - https://github.com/NixOS/hydra/commit/6189ba9c5e5308e17a7d1fb7f38443272a70f072
+  - Queue runner CPU-heavy operations throttling:
+    https://github.com/NixOS/hydra/commit/a51bd392a22fba5b0a0d90e2204a608b78c37ce1
+- Fastly shielding location fixed for releases.nixos.org and tarballs.nixos.org
+  (used to go transatlantic for no good reason)
+- http:// redirects to https:// for all our S3 buckets except cache.nixos.org
+  (broke nix-index, temporarily reverted)

--- a/docs/meeting-notes/2024-05-30.md
+++ b/docs/meeting-notes/2024-05-30.md
@@ -5,46 +5,48 @@ Attendees: hexa, vcunat, zimbatm, kenji, sterni
 ## Round table
 
 - [hexa]
-    - Updating Hydra to Nix 2.20
-        - Ran into (known) regression
-            - https://github.com/NixOS/nix/issues/9961
-        - vcunat rolled us back to the previous config
-        - TODO: needs to persist rollback in git
-        - nixpkgs is stuck on 2.18
-        - next step: wait on the next stable Nix release (in nixpkgs)
-    - Did a round of rotating shared passwords: Hetzner, Netlify (setup 2FA), ...
+  - Updating Hydra to Nix 2.20
+    - Ran into (known) regression
+      - https://github.com/NixOS/nix/issues/9961
+    - vcunat rolled us back to the previous config
+    - TODO: needs to persist rollback in git
+    - nixpkgs is stuck on 2.18
+    - next step: wait on the next stable Nix release (in nixpkgs)
+  - Did a round of rotating shared passwords: Hetzner, Netlify (setup 2FA), ...
 - [vcunat]
-    - Not anything else significant
+  - Not anything else significant
 - [kenji]
-    - Curious visitor
+  - Curious visitor
 - [sterni]
-    - Nothing in particular
+  - Nothing in particular
 
 ## Topics
 
 - [hexa] Vaultwarden mail delivery
-    - prevents onboarding of new people
-    - https://github.com/NixOS/infra/issues/430
-    - solution: https://github.com/NixOS/nixos-wiki-infra/blob/main/modules/postfix.nix
-    - talking to Julian if he can take it, with fallback to hexa
+  - prevents onboarding of new people
+  - https://github.com/NixOS/infra/issues/430
+  - solution:
+    https://github.com/NixOS/nixos-wiki-infra/blob/main/modules/postfix.nix
+  - talking to Julian if he can take it, with fallback to hexa
 
 - Netlify
-    - Need to talk to Marketing if GitHub pages would be sufficient
-        - Netlify provides preview environments
-    - Annoying because
-      - it's expensive,
-      - DNS is crap, 
-      - cost is per-user
-      - so we have to share a password.
+  - Need to talk to Marketing if GitHub pages would be sufficient
+    - Netlify provides preview environments
+  - Annoying because
+    - it's expensive,
+    - DNS is crap,
+    - cost is per-user
+    - so we have to share a password.
 
 - [hexa] API modernization in sign-binary-cache script
-    - https://github.com/NixOS/nixos-channel-scripts/pull/72
-    - Not used for hydra.nixos.org
-    - Should close the PR and remove the script to not mislead more people
+  - https://github.com/NixOS/nixos-channel-scripts/pull/72
+  - Not used for hydra.nixos.org
+  - Should close the PR and remove the script to not mislead more people
 
 - [zimbatm] Wants to transition out of the team
-    - Talked with hexa previously in private to take over team lead
-    - The person doing the things should be leading the team
-    - Transition out over the next month or so
-    - Maybe focus for the next month could be on making contributing to the infra repo more comfortable, needs more people who contribute to infra feel welcome
-
+  - Talked with hexa previously in private to take over team lead
+  - The person doing the things should be leading the team
+  - Transition out over the next month or so
+  - Maybe focus for the next month could be on making contributing to the infra
+    repo more comfortable, needs more people who contribute to infra feel
+    welcome

--- a/docs/meeting-notes/2024-06-13.md
+++ b/docs/meeting-notes/2024-06-13.md
@@ -5,68 +5,81 @@ Attendees: hexa, vcunat, Julien (partially), Eelco
 ## Round table
 
 - Julien
-    - currently otherwise occupied
-    - wants to finish the Lime survey migration away from AWS EC2 to non-critical infra
+  - currently otherwise occupied
+  - wants to finish the Lime survey migration away from AWS EC2 to non-critical
+    infra
 - vcunat
-    - Full disk on Haumea
-    - Checking on tarball mirroring service
-        - wasn't working for the last two weeks, we failed to notice
-        - issue in nixpkgs caused breakdown
-        - tending to the script and will merge the fixed version back
+  - Full disk on Haumea
+  - Checking on tarball mirroring service
+    - wasn't working for the last two weeks, we failed to notice
+    - issue in nixpkgs caused breakdown
+    - tending to the script and will merge the fixed version back
 - hexa
-    - Haumea's backup location
-        - Super write-intensive
-        - Return to rsync.net
-    - tried updating delft/* to 24.05 but hydra wouldn't compile
+  - Haumea's backup location
+    - Super write-intensive
+    - Return to rsync.net
+  - tried updating delft/* to 24.05 but hydra wouldn't compile
 - Eelco
-    - Interested in the cost-increase on the release bucket
-        - March 6xxx USD
-        - April 9700 USD
-        - May 8200 USD
-        - Still increasing as of June
-    - Need to move forward with the S3 Bucket (Cache & Releases)
-        - Move data into Glacier, would be cheaper there, but not accessible from cache.nixos.org anymore
-        - Moving things out of Glacier expensive, cheaper when we batch requests and request them for the next day or so
-        - Plan to move to Tigris data, they would give us a discount, and egress is currently free
-        - Need to get the relevant people in a room to make a final decision
-            - Eelco
-            - Edef
-            - Jonas
-            - Infra Build (hexa, vcunat)
+  - Interested in the cost-increase on the release bucket
+    - March 6xxx USD
+    - April 9700 USD
+    - May 8200 USD
+    - Still increasing as of June
+  - Need to move forward with the S3 Bucket (Cache & Releases)
+    - Move data into Glacier, would be cheaper there, but not accessible from
+      cache.nixos.org anymore
+    - Moving things out of Glacier expensive, cheaper when we batch requests and
+      request them for the next day or so
+    - Plan to move to Tigris data, they would give us a discount, and egress is
+      currently free
+    - Need to get the relevant people in a room to make a final decision
+      - Eelco
+      - Edef
+      - Jonas
+      - Infra Build (hexa, vcunat)
 
 ## Action items
+
 - Check Prometheus Alerting Pipeline, no Alerts since May 21
 - File issue about hydra/nix build failures
 - Schedule call about S3 bucket decision with Eelco, Jonas, Infra-Build
 
 ## Full disk on haumea
-- The ZFS pool (1 TB) on Haumea has been running full in the last few days, leading to the PostgreSQL database to be unavailable
-- Multiple options
-    - Reducing number and frequency of snapshots
-        - 3x5m, 4x15m, 24x1h, 4x1d, 3x1w
-            - [vcunat] 5 minutes probably excessive
-    - Replace haumea with a machine with bigger disks
-        - AX101 ~100 EUR/Mo
-    - Long-term maybe prune Hydras database
-        - or set up a new database and copy only the config over
 
-- Spend some more time debugging the situation, if it doesn't work out go for a bigger machine
+- The ZFS pool (1 TB) on Haumea has been running full in the last few days,
+  leading to the PostgreSQL database to be unavailable
+- Multiple options
+  - Reducing number and frequency of snapshots
+    - 3x5m, 4x15m, 24x1h, 4x1d, 3x1w
+      - [vcunat] 5 minutes probably excessive
+  - Replace haumea with a machine with bigger disks
+    - AX101 ~100 EUR/Mo
+  - Long-term maybe prune Hydras database
+    - or set up a new database and copy only the config over
+
+- Spend some more time debugging the situation, if it doesn't work out go for a
+  bigger machine
 
 ## Acquire rsync.net account for database backups of haumea
-- Previously rsync.net, but Account was paid by Graham. He eventually deleted that account
+
+- Previously rsync.net, but Account was paid by Graham. He eventually deleted
+  that account
 - Currently only backup location is on hexa's NAS at home
 - Backup size is currently 1.7TiB
 - At 1.2 Cents per GB/Month that would cost ~24 USD/Month for 2TiB
-    - https://www.rsync.net/signup/order.html
+  - https://www.rsync.net/signup/order.html
 
 ## E-Mail Alias Management
-- Rok would like access, so that he can switch around the alias on the streamyard account that the Marketing team uses
+
+- Rok would like access, so that he can switch around the alias on the
+  streamyard account that the Marketing team uses
 - Resource currently managed by Infra-Build
 - Not enough opinions, discuss in internal infra room instead
 
 ### Changelog
+
 - Non-Critical-Infra updated to NixOS 24.05
-    - migrated to systemd initrd
+  - migrated to systemd initrd
 - Local Postfix setup for mail delivery from vault.nixos.org
 - Owncast instance at live.nixos.org was set up
 - Synapse Reverse-Proxying uses Unix Domain Sockets now

--- a/docs/meeting-notes/2024-06-27.md
+++ b/docs/meeting-notes/2024-06-27.md
@@ -5,43 +5,57 @@ Attendees: edef, hexa, vcunat, zimbatm
 ## Round table
 
 - hexa
-    - Large PostgreSQL snapshot sizes caused by autovacuuming likely rewriting Indices (https://github.com/NixOS/infra/issues/446)
+  - Large PostgreSQL snapshot sizes caused by autovacuuming likely rewriting
+    Indices (https://github.com/NixOS/infra/issues/446)
 
-    - Actionables:
-      1. Setup rsync.net account, so we can have a proper backup, and help hexa's pipe
-      2. Try lighter compression with lz4 because we are seeing CPU load bottlenecking
-      3. https://github.com/NixOS/infra/pull/447
-    - Tried the limesurvey migration. Slightly cursed because NixOS 22.05. Upgrade path not clear because of incompatible DB versions. Might need a fresh instance after talking to the marketing team.
+  - Actionables:
+    1. Setup rsync.net account, so we can have a proper backup, and help hexa's
+       pipe
+    2. Try lighter compression with lz4 because we are seeing CPU load
+       bottlenecking
+    3. https://github.com/NixOS/infra/pull/447
+  - Tried the limesurvey migration. Slightly cursed because NixOS 22.05. Upgrade
+    path not clear because of incompatible DB versions. Might need a fresh
+    instance after talking to the marketing team.
 
 - vcunat:
-    - Haumea zrepl snapshot frequency to accomodate the smol pipe of hexa's backup target
-        - DB crashed due to full disk and would stop Hydra from working
+  - Haumea zrepl snapshot frequency to accomodate the smol pipe of hexa's backup
+    target
+    - DB crashed due to full disk and would stop Hydra from working
 
 - edef:
-    - Discussed with tomberek and jonas with getting the Glacier copy started. For only large objects to keep it simple.
-    - The release bucket traffic has grown again?
-        - edef: it doesn't seem that sizable based on the graphs I am watching
-        - hexa: did you see the chart Eelco posted? they looked worrying
-        - edef: to the fastly endpoint
-        - hexa: AWS
-        - edef: (looking the AWS Price explorer) looks like 1000 USD/month (30 USD/day), not exploded
-    - 2000/2010 style infra team
-        - We get this software thrown over and shall run it
-        - How can Hydra be made future-proof?
-        - Who maintains Hydra? Who makes sure the software works for the infra stack we can provide?
-        - hexa: Only Ericson updates Hydra to new Nix versions, probably for CA derivations, not much else is happening
-        - vcunat: Scale has increased much over the years since Hydra was written, and it hasn't kept up
-        - edef: too few people to commit and cover stuff
-        - biggest issues:
-            - queue-runner cannot compute runnables faster than they are getting consumed
-            - hydra kept busy with expensive xz compression of all results it gets
+  - Discussed with tomberek and jonas with getting the Glacier copy started. For
+    only large objects to keep it simple.
+  - The release bucket traffic has grown again?
+    - edef: it doesn't seem that sizable based on the graphs I am watching
+    - hexa: did you see the chart Eelco posted? they looked worrying
+    - edef: to the fastly endpoint
+    - hexa: AWS
+    - edef: (looking the AWS Price explorer) looks like 1000 USD/month (30
+      USD/day), not exploded
+  - 2000/2010 style infra team
+    - We get this software thrown over and shall run it
+    - How can Hydra be made future-proof?
+    - Who maintains Hydra? Who makes sure the software works for the infra stack
+      we can provide?
+    - hexa: Only Ericson updates Hydra to new Nix versions, probably for CA
+      derivations, not much else is happening
+    - vcunat: Scale has increased much over the years since Hydra was written,
+      and it hasn't kept up
+    - edef: too few people to commit and cover stuff
+    - biggest issues:
+      - queue-runner cannot compute runnables faster than they are getting
+        consumed
+      - hydra kept busy with expensive xz compression of all results it gets
 
 - jonas:
-    - requester pay on the release S3 bucket?
-        - last rollout resulted in 404 (silent 403s)
-        - we use the same code as for the cache
-        - edef: I tried the fastly code for the cache bucket. Tried it on a separate deployment. It doesn't appear to experience the same issues. Doesn't require a privileged token. Not sure how to further debug that.
-    - could talk about tigris data
-        - edef: let's get stuff in there
-        - edef: need to talk to AWS for free egress
-        - jonas: just the release bucket for now, because we have issues with it
+  - requester pay on the release S3 bucket?
+    - last rollout resulted in 404 (silent 403s)
+    - we use the same code as for the cache
+    - edef: I tried the fastly code for the cache bucket. Tried it on a separate
+      deployment. It doesn't appear to experience the same issues. Doesn't
+      require a privileged token. Not sure how to further debug that.
+  - could talk about tigris data
+    - edef: let's get stuff in there
+    - edef: need to talk to AWS for free egress
+    - jonas: just the release bucket for now, because we have issues with it

--- a/docs/meeting-notes/2024-11-14.md
+++ b/docs/meeting-notes/2024-11-14.md
@@ -1,75 +1,96 @@
 # 2024-11-14
 
-Attendees: jkarni, zimbatm, mic92, infinisil, kenji, drig/erethon, arian, sam , hexa, jeremy, jeff
+Attendees: jkarni, zimbatm, mic92, infinisil, kenji, drig/erethon, arian, sam ,
+hexa, jeremy, jeff
 
 ## Round Table
 
 ### Ofborg
 
-- Mic92: POC to evaluate nixpkgs on GitHub Actions. Results looked promising. nixpkgs-review would run in 5 minutes. the ofborg-eval was heavily swapping and taking 15min.
-- Infinisil: people might have to enable GHA in their fork, which is disabled by default
-    - Mic92: I didn't see this behaviour?
-    - Kenji: I think Github changed some defaults
-        - ref: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#changes-to-workflow-validation-for-pull-requests-originating-from-forked-repositories
-    - Mic92: I think this is true for periodic
-    - Infinisil: trying now for a new user
-- Mic92: if we want to pursue GHA, we would have to evaluate nixpkgs twice because we need to get the store paths for master, and the changes of the PR, and then we can compute all packages that have been changed, and append that textfile as data. This can then be re-used by nixpkgs-review.
+- Mic92: POC to evaluate nixpkgs on GitHub Actions. Results looked promising.
+  nixpkgs-review would run in 5 minutes. the ofborg-eval was heavily swapping
+  and taking 15min.
+- Infinisil: people might have to enable GHA in their fork, which is disabled by
+  default
+  - Mic92: I didn't see this behaviour?
+  - Kenji: I think Github changed some defaults
+    - ref:
+      https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#changes-to-workflow-validation-for-pull-requests-originating-from-forked-repositories
+  - Mic92: I think this is true for periodic
+  - Infinisil: trying now for a new user
+- Mic92: if we want to pursue GHA, we would have to evaluate nixpkgs twice
+  because we need to get the store paths for master, and the changes of the PR,
+  and then we can compute all packages that have been changed, and append that
+  textfile as data. This can then be re-used by nixpkgs-review.
 - Arian: why are we not using the PR workflow?
-    - Mic92: concurrency issues (limit of 20 runners per org).
-    - TODO: check if we hit the limit
+  - Mic92: concurrency issues (limit of 20 runners per org).
+  - TODO: check if we hit the limit
 - hexa: the idea to comment on the PR is to compensate for the visibility issue?
-    - Mic92: yes. it sucks a bit, but this could be mitigated by a small web service.
-    - A thin wrapper that receives a webhook, checks back the PR status and translates it as a comment.
-- Infinisil: wouldn't it be possible to have a workflow that polls on behalf of the user?
-    - It's a workflow that tries to find the workflow on the user's push, in their fork.
-    - It would be triggered every time you synchronize the PR.
-    - Mic92: can you set this up in a way that the workflow gets triggered once the workflow is finished?
-    - Infinisil: I think you need to poll for this.
-    - Mic92: Is it a 1:1 mapping, or 1:N?
-    - infinisil: Something like
-      ```yaml
-      # .github/workflows/query-pr.yml
-      on: pull_request_target
-      jobs:
-        check:
-          runs-on: ubuntu-latest
-          steps:
-            - run: |
-              gh api /repos/BASE_REPO/commits/GITHUB_SHA/check-runs
-      ```
-    - Worry: Offloading OfBorg on to GH could give us trouble, because it might not be insignificant compute.
+  - Mic92: yes. it sucks a bit, but this could be mitigated by a small web
+    service.
+  - A thin wrapper that receives a webhook, checks back the PR status and
+    translates it as a comment.
+- Infinisil: wouldn't it be possible to have a workflow that polls on behalf of
+  the user?
+  - It's a workflow that tries to find the workflow on the user's push, in their
+    fork.
+  - It would be triggered every time you synchronize the PR.
+  - Mic92: can you set this up in a way that the workflow gets triggered once
+    the workflow is finished?
+  - Infinisil: I think you need to poll for this.
+  - Mic92: Is it a 1:1 mapping, or 1:N?
+  - infinisil: Something like
+    ```yaml
+    # .github/workflows/query-pr.yml
+    on: pull_request_target
+    jobs:
+      check:
+        runs-on: ubuntu-latest
+        steps:
+          - run: |
+            gh api /repos/BASE_REPO/commits/GITHUB_SHA/check-runs
+    ```
+  - Worry: Offloading OfBorg on to GH could give us trouble, because it might
+    not be insignificant compute.
 - Jeremy: is this confined to PRs, or running on all branches?
-    - Mic92: it would be on push, but checking if the branch is part of the PR.
-    - Mic92: actually, there might be some synchronicity issue, because the PR happens after the push.
-    - Mic92: Because of that we might need a webservice that can trigger actions
-    - Mic92: can we get an event when we open a PR?
+  - Mic92: it would be on push, but checking if the branch is part of the PR.
+  - Mic92: actually, there might be some synchronicity issue, because the PR
+    happens after the push.
+  - Mic92: Because of that we might need a webservice that can trigger actions
+  - Mic92: can we get an event when we open a PR?
 
-- Arian: Team plan gives us 60 concurrent actions by the way.  (And team plan is free for non-profit orgs)
+- Arian: Team plan gives us 60 concurrent actions by the way. (And team plan is
+  free for non-profit orgs)
 
 - Pushes don't have a base branch, need a base branch to compare the out paths
-    - Mic92: only if not open as a PR
-    - infinisil: Can pre-compute the out paths on push, cache out paths on Nixpkgs master, then comparing can be done in a PR action fairly easily
+  - Mic92: only if not open as a PR
+  - infinisil: Can pre-compute the out paths on push, cache out paths on Nixpkgs
+    master, then comparing can be done in a PR action fairly easily
 
 - Jonas: who is going to make this happen?
-    - Infinisil, Alex Balsoft, Jeremy after early December, Mic92 can write some scripts and don't want to lead (want to work on the binary cache).
+  - Infinisil, Alex Balsoft, Jeremy after early December, Mic92 can write some
+    scripts and don't want to lead (want to work on the binary cache).
 
 - Infinisil: not convinced if that's a good idea.
 
 - Jonas: What would it take to get to feature parity
-    - What is the minimal set?
-    - Mic92: Minimal - Evaluate Prs
-    - Mic92: 2nd Phase - We can build packages.
-    - Mic92: Labels for mass-rebuilds
-    - Silvan: Requests reviews from maintainers (maybe not needed?)
-    - Silvan: Don't need to build manual with OfBorg anymore (Is already built in ci)
-    - Silvan: Evaluating without aliases
-    - Jonas: Discourage IFD's
-    - Silvan: Maybe it really is good to split this up in two parts:
-        - Evaluating
-        - Building
+  - What is the minimal set?
+  - Mic92: Minimal - Evaluate Prs
+  - Mic92: 2nd Phase - We can build packages.
+  - Mic92: Labels for mass-rebuilds
+  - Silvan: Requests reviews from maintainers (maybe not needed?)
+  - Silvan: Don't need to build manual with OfBorg anymore (Is already built in
+    ci)
+  - Silvan: Evaluating without aliases
+  - Jonas: Discourage IFD's
+  - Silvan: Maybe it really is good to split this up in two parts:
+    - Evaluating
+    - Building
 
-- Arian: Average job queue time is currently 9s: https://github.com/NixOS/nixpkgs/actions/metrics/performance
-- Arian: I would aim for: Lets just try with `pull_request:` and only do the complicated `push:` abuse if that job queue time is gonna go up significantly
+- Arian: Average job queue time is currently 9s:
+  https://github.com/NixOS/nixpkgs/actions/metrics/performance
+- Arian: I would aim for: Lets just try with `pull_request:` and only do the
+  complicated `push:` abuse if that job queue time is gonna go up significantly
 - Jonas: Looking forward to having eval failures to block merges!
 
 - Silvan: Who can review pr's and help out:
@@ -81,84 +102,103 @@ Attendees: jkarni, zimbatm, mic92, infinisil, kenji, drig/erethon, arian, sam , 
 - Silvan: TODO - Mention this effort on Discourse
 
 - Mic92: How do we coordinate?
-    - Main Evalation
-    - Figure out parts we can parallelize:
-        - most parts are fairly orthogonal
+  - Main Evalation
+  - Figure out parts we can parallelize:
+    - most parts are fairly orthogonal
 
 - Silvan: Somebody could lead the Building part:
-    - Mic92: Find someone who can help out, maybe on discourse?
-    - Silvan: GH doesn't have all the architectures
-    - Mic92: Start with the ones we have currently
-    - Silvan: If we don't need ealuation anymore - this could save a lot of resources, could optimize
-    - hexa: Yes, but it might not apply on top of staging for example
-    - Silvan: Yes, staging can probably be ignored
-    - hexa: Yes, it tries to build against the target branch, led to some problems, for example always trying to build llvm on darwin -> continuuous timeouts
-    - Mic92: A ton of stuff we could potentially optimize
-    - Silvan: Empower users to build on more architectures
-    - Mic92: Convenient to have logs in public
-    - Mic92: I would like to see a /build command, so that builds can be manually triggered
+  - Mic92: Find someone who can help out, maybe on discourse?
+  - Silvan: GH doesn't have all the architectures
+  - Mic92: Start with the ones we have currently
+  - Silvan: If we don't need ealuation anymore - this could save a lot of
+    resources, could optimize
+  - hexa: Yes, but it might not apply on top of staging for example
+  - Silvan: Yes, staging can probably be ignored
+  - hexa: Yes, it tries to build against the target branch, led to some
+    problems, for example always trying to build llvm on darwin -> continuuous
+    timeouts
+  - Mic92: A ton of stuff we could potentially optimize
+  - Silvan: Empower users to build on more architectures
+  - Mic92: Convenient to have logs in public
+  - Mic92: I would like to see a /build command, so that builds can be manually
+    triggered
 
 - Silvan: Optimization of the Eval part:
-    - look at path that actually changed
-    - mic92: Aware of nix script that gives names of paths that are actually changed?
-    - Silvan: Yes
-    - Mic92: If heavy swapping, then it might speed up, else we might see a slow down
+  - look at path that actually changed
+  - mic92: Aware of nix script that gives names of paths that are actually
+    changed?
+  - Silvan: Yes
+  - Mic92: If heavy swapping, then it might speed up, else we might see a slow
+    down
 
 - Silvan: Where should we report?
-    - discourse?
-    - Mic92: Discussion would be nicer on GH, because we can link issues/pr's.
+  - discourse?
+  - Mic92: Discussion would be nicer on GH, because we can link issues/pr's.
 
 ## Topics
 
 - Transfer of the Macs located at Detsys to Flying Circus
-    - Scheduled for 2024-11-25
-    - Currently enrolled into Detsys MDM Account. Can we set something up to migrate that to an infra team account?
-        - Report back the result to the Mac Mini Logistics room on Matrix
-        - MDM built into macs, but need to be enrolled into an mdm vendor
-        - Arian: Don't have to do it, but very convenient
-        - Mic92: if there are no major problems, should look into MDM as well.
+  - Scheduled for 2024-11-25
+  - Currently enrolled into Detsys MDM Account. Can we set something up to
+    migrate that to an infra team account?
+    - Report back the result to the Mac Mini Logistics room on Matrix
+    - MDM built into macs, but need to be enrolled into an mdm vendor
+    - Arian: Don't have to do it, but very convenient
+    - Mic92: if there are no major problems, should look into MDM as well.
 - Oakhost Macs are available
-    - Need the usual setup
-    - 3 new machines
-    - arian can set this up
-    - initial password
-    - Mic92: Mac enrollment not very automated yet, last time hexa wrote some stuff down
-    - Arians keys needs to be added to the repository
-    - Arian:
-        - need access to oakhost
-        - ssh key to infra
+  - Need the usual setup
+  - 3 new machines
+  - arian can set this up
+  - initial password
+  - Mic92: Mac enrollment not very automated yet, last time hexa wrote some
+    stuff down
+  - Arians keys needs to be added to the repository
+  - Arian:
+    - need access to oakhost
+    - ssh key to infra
 - Mac Issues:
-    - hexa: Forking issues on seqoia
-    - hexa: Running quite well atm
-    - hexa: Patched out chrooting of nix, applied patches on top of darwin builders
-    - hexa: Not sure exactly why that works
-    - hexa: Upstreaming rosetta2-gc to nix-darwin currently
-    - hexa: darwin 15.1 had issues -> hetzner doesn't roll back (need rescue mode)
-    - hexa: Rollbacks likely possible with mdm
-    - arian: We can likely add hetzner darwin machines to be managed by mdm, but not too sure
-    - arian: Looks into if we can add without physical access, look into what detsys did
+  - hexa: Forking issues on seqoia
+  - hexa: Running quite well atm
+  - hexa: Patched out chrooting of nix, applied patches on top of darwin
+    builders
+  - hexa: Not sure exactly why that works
+  - hexa: Upstreaming rosetta2-gc to nix-darwin currently
+  - hexa: darwin 15.1 had issues -> hetzner doesn't roll back (need rescue mode)
+  - hexa: Rollbacks likely possible with mdm
+  - arian: We can likely add hetzner darwin machines to be managed by mdm, but
+    not too sure
+  - arian: Looks into if we can add without physical access, look into what
+    detsys did
 - Equinix Metal Exit Plan
-    - https://md.darmstadt.ccc.de/eqm-exit-plan
-    - hexa: This is what we had, this is what we need, this is what it is going to cost.
-    - mic92: Should we check out what we need for the arm64 builders?
-    - hexa: Basically choice between: 64GB, or 256GB of memory
-    - hexa: Likely want the bigger memory
-    - Mic92: Can try the same for arm64, for x86 we can look in to funding.
-    - Mic92: How long do we need for set up? - a day? Shouldn't take long to set up.
-    - Mic92: I will set this in motion, unless someone else want's to reach out.
-    - Mic92: Ok, I will do it.
-    - hexa: Ideally we don't have 20 small machine, but 5 big machines. Which would be good for maintenance reasons. Because we likely won't get a netboot setup anymore.
+  - https://md.darmstadt.ccc.de/eqm-exit-plan
+  - hexa: This is what we had, this is what we need, this is what it is going to
+    cost.
+  - mic92: Should we check out what we need for the arm64 builders?
+  - hexa: Basically choice between: 64GB, or 256GB of memory
+  - hexa: Likely want the bigger memory
+  - Mic92: Can try the same for arm64, for x86 we can look in to funding.
+  - Mic92: How long do we need for set up? - a day? Shouldn't take long to set
+    up.
+  - Mic92: I will set this in motion, unless someone else want's to reach out.
+  - Mic92: Ok, I will do it.
+  - hexa: Ideally we don't have 20 small machine, but 5 big machines. Which
+    would be good for maintenance reasons. Because we likely won't get a netboot
+    setup anymore.
 - Security Tracker
-    - dgrig: Jonas gave me access to a Hetzner Cloud project a couple of weeks ago. A VM is up and running, I'm figuring out how to implement this in the same way as nixos-infra.
-    - dgrig: Do we care about having this in Terraform? I used TF to spin this up, but the state is in my computer currently, do we care to push it to S3?
-    - drgrig: Can I do `nixos-installer --flake nixos/nixos-infra`?How can I install the nixos-infra
-    - Mic02: Inputs :"${inputs.nixos-infra}/keys" can convert to string.
-    - Example:
-      ```nix
-      users.users.root.openssh.authorizedKeys.keys = [] ++ (builtins.filter (l: l != [ ]) (builtins.split "\n" (builtins.readFile inputs.phaer-keys)));
-      ```
-    - dgrig: Do we care about the Terraform state yet?
-    - hexa: Do we need the state yet?
-    - drgrid: It is the tf state
-    - consensus: We don't care
-    - Jeremy: Nit - export the keys as a module
+  - dgrig: Jonas gave me access to a Hetzner Cloud project a couple of weeks
+    ago. A VM is up and running, I'm figuring out how to implement this in the
+    same way as nixos-infra.
+  - dgrig: Do we care about having this in Terraform? I used TF to spin this up,
+    but the state is in my computer currently, do we care to push it to S3?
+  - drgrig: Can I do `nixos-installer --flake nixos/nixos-infra`?How can I
+    install the nixos-infra
+  - Mic02: Inputs :"${inputs.nixos-infra}/keys" can convert to string.
+  - Example:
+    ```nix
+    users.users.root.openssh.authorizedKeys.keys = [] ++ (builtins.filter (l: l != [ ]) (builtins.split "\n" (builtins.readFile inputs.phaer-keys)));
+    ```
+  - dgrig: Do we care about the Terraform state yet?
+  - hexa: Do we need the state yet?
+  - drgrid: It is the tf state
+  - consensus: We don't care
+  - Jeremy: Nit - export the keys as a module

--- a/formatter/flake-module.nix
+++ b/formatter/flake-module.nix
@@ -9,6 +9,10 @@
         # Used to find the project root
         projectRootFile = ".git/config";
 
+        settings.global.excludes = [
+          "*.age"
+          "non-critical-infra/secrets/*"
+        ];
         programs.terraform.enable = true;
         programs.deadnix.enable = true;
         programs.nixfmt.enable = true;

--- a/formatter/flake-module.nix
+++ b/formatter/flake-module.nix
@@ -3,7 +3,7 @@
   imports = [ inputs.treefmt-nix.flakeModule ];
 
   perSystem =
-    { pkgs, ... }:
+    { ... }:
     {
       treefmt = {
         # Used to find the project root
@@ -19,7 +19,6 @@
         programs.terraform.enable = true;
         programs.deadnix.enable = true;
         programs.nixfmt.enable = true;
-        programs.nixfmt.package = pkgs.nixfmt-rfc-style;
         programs.ruff-format.enable = true;
         programs.ruff-check.enable = true;
 

--- a/formatter/flake-module.nix
+++ b/formatter/flake-module.nix
@@ -13,6 +13,8 @@
           "*.age"
           "non-critical-infra/secrets/*"
         ];
+
+        programs.actionlint.enable = true;
         programs.terraform.enable = true;
         programs.deadnix.enable = true;
         programs.nixfmt.enable = true;

--- a/formatter/flake-module.nix
+++ b/formatter/flake-module.nix
@@ -15,6 +15,7 @@
         ];
 
         programs.actionlint.enable = true;
+        programs.deno.enable = true;
         programs.terraform.enable = true;
         programs.deadnix.enable = true;
         programs.nixfmt.enable = true;

--- a/hydra-packet-importer/README.md
+++ b/hydra-packet-importer/README.md
@@ -1,5 +1,5 @@
-Imports builders' and their SSH keys from the Packet API. Requires the
-builder run this script at startup:
+Imports builders' and their SSH keys from the Packet API. Requires the builder
+run this script at startup:
 
 ```bash
 #!/usr/bin/env nix-shell

--- a/hydra-packet-importer/config-example.json
+++ b/hydra-packet-importer/config-example.json
@@ -1,34 +1,34 @@
 {
-    "token": "You read only API token",
-    "project_id": "Your project's unique ID",
-    "mandatory_tags": [ "tags which each", "server", "must have" ],
-    "skip_tags": [ "tags which will", "exclude a server from", "being imported" ],
-    "plans": {
-        "c2.large.arm": {
-            "user": "root",
-            "system_types": ["aarch64-linux"],
-            "ssh_key": "/path/to/hydras-ssh-key",
-            "max_jobs": 15,
-            "speed_factor": 1,
-            "features": ["kvm","nixos-test","big-parallel"],
-            "mandatory_features": []
-        },
-        "c2.medium.x86": {
-            "user": "root",
-            "system_types": ["x86_64-linux", "i686-linux"],
-            "ssh_key": "/var/lib/hydra/queue-runner/.ssh/id_buildfarm_rsa",
-            "max_jobs": 18,
-            "speed_factor": 1,
-            "features": [ "kvm","nixos-test","big-parallel" ]
-        }
+  "token": "You read only API token",
+  "project_id": "Your project's unique ID",
+  "mandatory_tags": ["tags which each", "server", "must have"],
+  "skip_tags": ["tags which will", "exclude a server from", "being imported"],
+  "plans": {
+    "c2.large.arm": {
+      "user": "root",
+      "system_types": ["aarch64-linux"],
+      "ssh_key": "/path/to/hydras-ssh-key",
+      "max_jobs": 15,
+      "speed_factor": 1,
+      "features": ["kvm", "nixos-test", "big-parallel"],
+      "mandatory_features": []
     },
-    "name_overrides": {
-        "machines-with-this-name-override-defaults-in-plan": {
-            "max_jobs": 20,
-            "system_types": [ "x86_64-linux" ],
-            "max_jobs": 1,
-            "speed_factor": 100,
-            "features": [ "kvm","nixos-test","big-parallel" ]
-        }
+    "c2.medium.x86": {
+      "user": "root",
+      "system_types": ["x86_64-linux", "i686-linux"],
+      "ssh_key": "/var/lib/hydra/queue-runner/.ssh/id_buildfarm_rsa",
+      "max_jobs": 18,
+      "speed_factor": 1,
+      "features": ["kvm", "nixos-test", "big-parallel"]
     }
+  },
+  "name_overrides": {
+    "machines-with-this-name-override-defaults-in-plan": {
+      "max_jobs": 20,
+      "system_types": ["x86_64-linux"],
+      "max_jobs": 1,
+      "speed_factor": 100,
+      "features": ["kvm", "nixos-test", "big-parallel"]
+    }
+  }
 }

--- a/macs/README.md
+++ b/macs/README.md
@@ -6,15 +6,16 @@ See [inventory](../docs/inventory.md).
 
 ### At Graham's place
 
-We have mac-mini's are in [Grahams](https://github.com/grahamc) house,
-that only [@cole-h](https://github.com/cole-h) can deploy:
+We have mac-mini's are in [Grahams](https://github.com/grahamc) house, that only
+[@cole-h](https://github.com/cole-h) can deploy:
 
 - becoming-hyena.foundation.detsys.dev
 - cosmic-stud.foundation.detsys.dev
 - quality-ram.foundation.detsys.dev
 - tight-bug.foundation.detsys.dev
 
-- These are getting erased and automatically redeployed from the configuration in this directory.
+- These are getting erased and automatically redeployed from the configuration
+  in this directory.
 
 ### Hetzner
 
@@ -42,14 +43,15 @@ These are maintained by the build infra team.
   - ~~softwareupdate --install --all --restart~~
 - Disable auto-updates:
   - We are currently seeing performance regression in macOS Sequoia.
-  - So to not have the machines auto-upgrade, we use: `sudo softwareupdate --schedule off`
+  - So to not have the machines auto-upgrade, we use:
+    `sudo softwareupdate --schedule off`
 - Install rosetta2
   - softwareupdate --install-rosetta2 --agree-to-license
 - Set up passwordless sudo
   ```
   # visudo /etc/sudoers.d/passwordless
   %admin ALL = NOPASSWD: ALL
-  ````
+  ```
 - Install nix
   - `sh <(curl -L https://nixos.org/nix/install) --daemon`
 - Install nix-darwin
@@ -61,4 +63,3 @@ These are maintained by the build infra team.
 ```
 darwin-rebuild switch --flake github:nixos/infra#arm64
 ```
-

--- a/metrics/fastly/README.md
+++ b/metrics/fastly/README.md
@@ -2,21 +2,20 @@
 
 This flake provides a systemd timer (`./cron.sh`) that every week:
 
-* Ingests raw Fastly logs for
-  {cache,channels,tarballs,releases}.nixos.org (which are very big)
-  and aggregates them into a smaller AWS Athena database.
+- Ingests raw Fastly logs for {cache,channels,tarballs,releases}.nixos.org
+  (which are very big) and aggregates them into a smaller AWS Athena database.
 
   This is performed by `./ingest-raw-logs.sh`.
 
-* Runs a number of SQL queries against the Athena database and stores
-  them in S3.
+- Runs a number of SQL queries against the Athena database and stores them in
+  S3.
 
   This is performed by `./run-queries.sh`.
 
 ## AWS Athena database
 
-The Athena database is stored in the NixOS Foundation AWS account. To
-get the schema, run
+The Athena database is stored in the NixOS Foundation AWS account. To get the
+schema, run
 
 ```
 # aws athena list-table-metadata --region eu-west-1 --catalog-name AwsDataCatalog --database-name default
@@ -24,26 +23,26 @@ get the schema, run
 
 It has the following external tables:
 
-* `requests`: An external table. These are the raw fastly logs stored
-  in s3://fastly-logs-20220622145016462800000001/ as compressed JSON
-  records. Note that this bucket has a lifecycle rule that moves logs
-  to Glacier after a few weeks. Logs in Glacier are not processed by
-  Athena.
+- `requests`: An external table. These are the raw fastly logs stored in
+  s3://fastly-logs-20220622145016462800000001/ as compressed JSON records. Note
+  that this bucket has a lifecycle rule that moves logs to Glacier after a few
+  weeks. Logs in Glacier are not processed by Athena.
 
-* `asn_list`: A list of ASNs. This can be updated by running
+- `asn_list`: A list of ASNs. This can be updated by running
   `./update-asn-list.sh`.
 
-* `hosting-asns`: A list of ASNs belonging to hosting/cloud providers.
+- `hosting-asns`: A list of ASNs belonging to hosting/cloud providers.
 
-* `all_paths`: The set of all store paths known in the hydra.nixos.org
-  database. This is used to expand the hash part of `.narinfo` requests
-  (e.g. `8kbx6s9nn7060zsdms3br0mk7bjrvbij`) to store paths
-  (e.g. `/nix/store/8kbx6s9nn7060zsdms3br0mk7bjrvbij-coreutils-full-9.0`).
+- `all_paths`: The set of all store paths known in the hydra.nixos.org database.
+  This is used to expand the hash part of `.narinfo` requests (e.g.
+  `8kbx6s9nn7060zsdms3br0mk7bjrvbij`) to store paths (e.g.
+  `/nix/store/8kbx6s9nn7060zsdms3br0mk7bjrvbij-coreutils-full-9.0`).
 
   FIXME: describe how to update.
 
-* `release_paths`: All the store paths belonging to NixOS evals in
-  hydra.nixos.org, as `{project, jobset, eval, release_name, build,
+- `release_paths`: All the store paths belonging to NixOS evals in
+  hydra.nixos.org, as
+  `{project, jobset, eval, release_name, build,
   output, path}` tuples.
 
   FIXME: describe how to update.
@@ -51,70 +50,67 @@ It has the following external tables:
 The ingestion script populates the following tables stored in
 s3://nixos-athena/fastly-logs-processed/:
 
-* `urls`: For each host/day/url, the total number of requests, bytes
-  and elapsed microseconds. This only includes info about successful
-  (2xx/3xx) requests.
+- `urls`: For each host/day/url, the total number of requests, bytes and elapsed
+  microseconds. This only includes info about successful (2xx/3xx) requests.
 
-* `clients`: For each host/day/ASN/country/region, the total number of
-  requests, bytes and elapsed microseconds.
+- `clients`: For each host/day/ASN/country/region, the total number of requests,
+  bytes and elapsed microseconds.
 
-* `nix_cache_info`: For each day/ASN/country/region/user-agent, the
-  number of requests for `nix-cache-info`.
+- `nix_cache_info`: For each day/ASN/country/region/user-agent, the number of
+  requests for `nix-cache-info`.
 
 ## Reports
 
 Currently the following reports are created every week:
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/traffic-per-day.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/traffic-per-day.csv
 
-  For each day and site, the number of requests and the number of
-  bytes transferred.
+  For each day and site, the number of requests and the number of bytes
+  transferred.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/traffic-per-country.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/traffic-per-country.csv
 
-  For each country, the number of requests and the number of
-  bytes transferred.
+  For each country, the number of requests and the number of bytes transferred.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day.csv
 
   For each day, the number of requests for
   https://cache.nixos.org/nix-cache-info.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day-not-hosted.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day-not-hosted.csv
 
-  The same, but with requests from "hosting" ASNs (e.g. AWS and
-  Hetzner) filtered out. Note that Nix caches `nix-cache-info` file
-  for a week, so the intent of this report is to gauge the number of
-  active weekly users.
+  The same, but with requests from "hosting" ASNs (e.g. AWS and Hetzner)
+  filtered out. Note that Nix caches `nix-cache-info` file for a week, so the
+  intent of this report is to gauge the number of active weekly users.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day-per-ua.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/cache-info-requests-per-day-per-ua.csv
 
-  For each day and user agent (e.g. `Nix/2.12.0`), the number of
-  requests for https://cache.nixos.org/nix-cache-info. This is
-  intended to track the adoption of Nix releases.
+  For each day and user agent (e.g. `Nix/2.12.0`), the number of requests for
+  https://cache.nixos.org/nix-cache-info. This is intended to track the adoption
+  of Nix releases.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/flake-registry-requests-per-day.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/flake-registry-requests-per-day.csv
 
   For each day, the number of requests for
-  https://channels.nixos.org/flake-registry.json. This is intended to
-  track how widely flakes are used.
+  https://channels.nixos.org/flake-registry.json. This is intended to track how
+  widely flakes are used.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/top-store-paths.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/top-store-paths.csv
 
-  For each store path listed in `all_paths`, the number of requests for its `.narinfo` file.
+  For each store path listed in `all_paths`, the number of requests for its
+  `.narinfo` file.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/narinfo-queries-per-release.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/narinfo-queries-per-release.csv
 
-  For each major NixOS release (e.g. `nixos-22.05`), the number of
-  requests for `.narinfo` files of store paths that are part of an
-  eval of that release.
+  For each major NixOS release (e.g. `nixos-22.05`), the number of requests for
+  `.narinfo` files of store paths that are part of an eval of that release.
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/nix-installer-downloads.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/nix-installer-downloads.csv
 
-  For each day, the number of downloads of the Nix installer
-  (i.e. `https://releases.nixos.org/nix/nix-[^/]+/install`).
+  For each day, the number of downloads of the Nix installer (i.e.
+  `https://releases.nixos.org/nix/nix-[^/]+/install`).
 
-* http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/nix-installer-architectures.csv
+- http://nixos-metrics.s3-website-eu-west-1.amazonaws.com/latest/nix-installer-architectures.csv
 
-  For each architecture (e.g. `x86_64-linux`), the number of downloads
-  of the Nix binary tarball.
+  For each architecture (e.g. `x86_64-linux`), the number of downloads of the
+  Nix binary tarball.

--- a/non-critical-infra/.sops.yaml
+++ b/non-critical-infra/.sops.yaml
@@ -1,4 +1,4 @@
-keys: 
+keys:
   - &hexa age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x
   - &zimbatm age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h
   - &caliban age1sv307kkrxwgjah8pjpap5kzl4j2r6fqr3vg234n7m32chlchs9lsey7nlq
@@ -7,14 +7,14 @@ keys:
 creation_rules:
   - path_regex: secrets/[^/]+.caliban
     key_groups:
-    - age:
-      - *caliban
-      - *hexa
-      - *zimbatm
+      - age:
+          - *caliban
+          - *hexa
+          - *zimbatm
 
   - path_regex: secrets/[^/]+.umbriel
     key_groups:
-    - age:
-      - *umbriel
-      - *hexa
-      - *zimbatm
+      - age:
+          - *umbriel
+          - *hexa
+          - *zimbatm

--- a/non-critical-infra/README.md
+++ b/non-critical-infra/README.md
@@ -1,19 +1,25 @@
-Non-critical-infra
-================
+# Non-critical-infra
 
-This folder of the repository contains all files relative to the non-critical infra team. Machines managed by that specific configuration are distinct from the ones used in the rest of that repository and used to host services useful to the general Nix/NixOS community.
+This folder of the repository contains all files relative to the non-critical
+infra team. Machines managed by that specific configuration are distinct from
+the ones used in the rest of that repository and used to host services useful to
+the general Nix/NixOS community.
 
-
-## For the users 
+## For the users
 
 ### I would like my project hosted by this infrastructure
-Open a PR or an issue, and members of the infra team will tell you if this infrastructure is suitable to the project!
+
+Open a PR or an issue, and members of the infra team will tell you if this
+infrastructure is suitable to the project!
 
 ### I would like to join the team
-Come and talk to us on matrix: #infra:nixos.org
 
+Come and talk to us on matrix: #infra:nixos.org
 
 ## For the contributors
 
-### Secret access 
-Secret access is on a "need to have" basis. If you think you need access to the secrets, please add your key to the `.sops.yaml` file on a PR and ping people that already have access for them to run the `updatekeys` command.
+### Secret access
+
+Secret access is on a "need to have" basis. If you think you need access to the
+secrets, please add your key to the `.sops.yaml` file on a PR and ping people
+that already have access for them to run the `updatekeys` command.

--- a/non-critical-infra/hosts/umbriel.nixos.org/README.md
+++ b/non-critical-infra/hosts/umbriel.nixos.org/README.md
@@ -2,9 +2,9 @@
 
 ## Provisioning
 
-If you recreate `umbriel`, it will generate a new `DKIM` signature. That's
-ok to do, but you'll need to update the corresponding `mail._domainkey.*` `TXT`
-DNS record in `terraform/dns.tf` with the generated key in
+If you recreate `umbriel`, it will generate a new `DKIM` signature. That's ok to
+do, but you'll need to update the corresponding `mail._domainkey.*` `TXT` DNS
+record in `terraform/dns.tf` with the generated key in
 `/var/dkim/mail-test.nixos.org.mail.txt`.
 
 TODO: declaratively manage the `DKIM` key once

--- a/non-critical-infra/modules/mailserver/README.md
+++ b/non-critical-infra/modules/mailserver/README.md
@@ -5,7 +5,8 @@ This module will [eventually][issue 485] provide mail services for `nixos.org`.
 ## Mailing lists
 
 To create a new mailing list, or change membership of a mailing list, see the
-instructions under `### Mailing lists go here ###` in [`default.nix`](./default.nix).
+instructions under `### Mailing lists go here ###` in
+[`default.nix`](./default.nix).
 
 Some mailing lists allow login and sending email via `SMTP`. Search for
 `loginAccount` to find examples of this.

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
 {
   imports = [ ./mailing-lists.nix ];
@@ -34,4 +34,52 @@
       loginAccount.encryptedHashedPassword = ../../secrets/test-sender-email-login.umbriel;
     };
   };
+
+  services.postfix.config.bounce_template_file = "${pkgs.writeText "bounce-template.cf" ''
+    failure_template = <<EOF
+    Charset: us-ascii
+    From: MAILER-DAEMON (Mail Delivery System)
+    Subject: Undelivered Mail Returned to Sender
+    Postmaster-Subject: Postmaster Copy: Undelivered Mail
+
+    This is the mail system at host $myhostname.
+
+    I'm sorry to have to inform you that your message could not
+    be delivered to one or more recipients. It's attached below.
+
+    For further assistance, please file an issue at
+    https://github.com/NixOS/infra/issues/new. Please anonymize any personal
+    email addresses in your report.
+
+    If you do so, please include this problem report. You can
+    delete your own text from the attached returned message.
+
+                  The mail system
+    EOF
+
+    delay_template = <<EOF
+    Charset: us-ascii
+    From: MAILER-DAEMON (Mail Delivery System)
+    Subject: Delayed Mail (still being retried)
+    Postmaster-Subject: Postmaster Warning: Delayed Mail
+
+    This is the mail system at host $myhostname.
+
+    ####################################################################
+    # THIS IS A WARNING ONLY.  YOU DO NOT NEED TO RESEND YOUR MESSAGE. #
+    ####################################################################
+
+    Your message could not be delivered for more than $delay_warning_time_hours hour(s).
+    It will be retried until it is $maximal_queue_lifetime_days day(s) old.
+
+    For further assistance, please file an issue at
+    https://github.com/NixOS/infra/issues/new. Please anonymize any personal
+    email addresses in your report.
+
+    If you do so, please include this problem report. You can
+    delete your own text from the attached returned message.
+
+                       The mail system
+    EOF
+  ''}";
 }

--- a/terraform-iam/README.md
+++ b/terraform-iam/README.md
@@ -3,9 +3,10 @@
 This module is for superadmins in the team.
 
 This terraform root module manages:
-* IAM roles
-* fastly log module
-* infrastructure for archeologist team
+
+- IAM roles
+- fastly log module
+- infrastructure for archeologist team
 
 ## Setup
 
@@ -17,7 +18,8 @@ Run `aws sso login` to acquire a temporary token.
 
 ## Usage
 
-We use opentofu, which is a fork of https://www.terraform.io/ maintained by the Linux foundation.
+We use opentofu, which is a fork of https://www.terraform.io/ maintained by the
+Linux foundation.
 
 Then run the following command to diff the changes and then apply if approved:
 
@@ -31,7 +33,7 @@ Write the Tofu code and test the changes using `./tf.sh validate`.
 
 Before committing run `nix fmt`.
 
-Once the code is ready to be deployed, create a new PR with the attached
-output of `./tf.sh plan`.
+Once the code is ready to be deployed, create a new PR with the attached output
+of `./tf.sh plan`.
 
 Once the PR is merged, run `./tf.sh apply` to apply the changes.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,19 +1,20 @@
 # For the bits that are not nixops-able
 
 This terraform root module manages:
-* the resource in the AWS main account (S3 buckets)
-* Fastly
-* Netlify DNS
+
+- the resource in the AWS main account (S3 buckets)
+- Fastly
+- Netlify DNS
 
 ## Setup
 
 In order to use this, make sure to install direnv and Nix with flakes enabled.
 
-Then copy the `.envrc.local.template` to `.envrc.local`, and fill in the
-related keys.
+Then copy the `.envrc.local.template` to `.envrc.local`, and fill in the related
+keys.
 
-> FIXME: Unset the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars if
->        they are already set. Those have been replaced by AWS SSO.
+> FIXME: Unset the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars if they
+> are already set. Those have been replaced by AWS SSO.
 
 Then run `direnv allow` to load the environment with the runtime dependencies.
 
@@ -21,7 +22,8 @@ Run `aws sso login` to acquire a temporary token.
 
 ## Usage
 
-We use opentofu, which is a fork of https://www.terraform.io/ maintained by the Linux foundation.
+We use opentofu, which is a fork of https://www.terraform.io/ maintained by the
+Linux foundation.
 
 Then run the following command to diff the changes and then apply if approved:
 
@@ -35,12 +37,12 @@ Write the Tofu code and test the changes using `./tf.sh validate`.
 
 Before committing run `nix fmt`.
 
-Once the code is ready to be deployed, create a new PR with the attached
-output of `./tf.sh plan`.
+Once the code is ready to be deployed, create a new PR with the attached output
+of `./tf.sh plan`.
 
 Once the PR is merged, run `./tf.sh apply` to apply the changes.
 
 ## Upgrade from terraform to opentofu
 
-If you have used terraform, you may have to delete .terraform in this directory once
-to fixup provider registry addresses.
+If you have used terraform, you may have to delete .terraform in this directory
+once to fixup provider registry addresses.


### PR DESCRIPTION
The default template tells you to "please send mail to postmaster" which isn't very actionable (what's the postmaster?). This directs people to a place where they can actually get help.

# Before

![2024-11-09_11-48-13_pattern](https://github.com/user-attachments/assets/1a466ef5-c2a2-48d2-8f2f-fa81df981f5f)

# After

![2024-11-09_12-25-36_pattern](https://github.com/user-attachments/assets/65ca6bef-f798-4923-bffc-877754a59eb0)

# Alternatives considered

- We could set up a mailing list for the infra team, and direct people to it
- We could direct people to reach out to the infra team over matrix