### PR TITLE
channels: Promote NixOS 24.11 to stable

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -42,33 +42,33 @@ rec {
     "nixos-24.11" = {
       job = "nixos/release-24.11/tested";
       variant = "primary";
-      status = "beta";
+      status = "stable";
     };
     "nixos-24.11-small" = {
       job = "nixos/release-24.11-small/tested";
       variant = "small";
-      status = "beta";
+      status = "stable";
     };
     "nixpkgs-24.11-darwin" = {
       job = "nixpkgs/nixpkgs-24.11-darwin/darwin-tested";
       variant = "darwin";
-      status = "beta";
+      status = "stable";
     };
 
     "nixos-24.05" = {
       job = "nixos/release-24.05/tested";
       variant = "primary";
-      status = "stable";
+      status = "deprecated";
     };
     "nixos-24.05-small" = {
       job = "nixos/release-24.05-small/tested";
       variant = "small";
-      status = "stable";
+      status = "deprecated";
     };
     "nixpkgs-24.05-darwin" = {
       job = "nixpkgs/nixpkgs-24.05-darwin/darwin-tested";
       variant = "darwin";
-      status = "stable";
+      status = "deprecated";
     };
   };
 


### PR DESCRIPTION
*To be released on Saturday, November 30th.*