### PR TITLE
Init security tracker domain and monitoring

### DIFF
--- a/build/pluto/prometheus/exporters/blackbox.nix
+++ b/build/pluto/prometheus/exporters/blackbox.nix
@@ -61,6 +61,7 @@ in
         "https://wiki.nixos.org"
         "https://www.nixos.org"
         "https://netboot.nixos.org"
+        "https://tracker.security.nixos.org"
       ])
     ];
 

--- a/build/pluto/prometheus/exporters/node.nix
+++ b/build/pluto/prometheus/exporters/node.nix
@@ -25,6 +25,7 @@
             targets = [
               "caliban.nixos.org:9100"
               "umbriel.nixos.org:9100"
+              "tracker.security.nixos.org:9100"
             ];
           }
           {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -287,6 +287,16 @@ locals {
       value    = "caliban.nixos.org"
     },
     {
+      hostname = "tracker.security.nixos.org"
+      type     = "A"
+      value    = "188.245.41.195"
+    },
+    {
+      hostname = "tracker.security.nixos.org"
+      type     = "AAAA"
+      value    = "2a01:4f8:1c1b:b87b::1"
+    },
+    {
       hostname = "caliban.nixos.org"
       type     = "TXT"
       value    = "v=spf1 ip4:65.109.26.213 ip6:2a01:4f9:5a:186c::2 ~all"


### PR DESCRIPTION
This is a PR to setup the [Nixpkgs Security Tracker](https://github.com/Nix-Security-WG/nix-security-tracker) on the nixos.org domain.

On the surface this PR is very simple as it only:
- Creates a new A record for `tracker.security.nixos.org` that points to a Hetzner Cloud VM host (188.245.41.195)
- Adds monitoring for this domain

The VM is part of the `nixpkgs-security-tracker` Hetzner Cloud project which @zimbatm gave me access to a while ago.

The configuration of this host will eventually be [here](https://github.com/Nix-Security-WG/nix-security-tracker/tree/main/infra), but please note that [this draft PR](https://github.com/Nix-Security-WG/nix-security-tracker/pull/454) contains the important bits for now and isn't merged yet as it depends on having a .nixos.org domain for the host.

I've copy-pasted `ssh-keys.nix` as it exists in commit 0d476c97da758e94856e02dc90f772e54841b58e, so everyone from the (current) infra team has access to the host as root.

I think if this is merged and applied as is, we'll get an alert for the domain. If we don't mind that, this is the simplest option to move forward as I'll be able to generate a certificate for `tracker.security.nixos.org` then and the alert will go away. Otherwise, we can first only apply the Terraform DNS change and later the Prometheus change to avoid the alert.