### PR TITLE
hydra: increase max_output_size

### DIFF
--- a/build/hydra.nix
+++ b/build/hydra.nix
@@ -105,7 +105,7 @@ in
 
     allow_import_from_derivation = false
 
-    max_output_size = 3621225472 # 3 << 30 + 400000000 = 3 GiB + 0.4 GB
+    max_output_size = 3821225472 # 3 << 30 + 600000000 = 3 GiB + 0.6 GB
     max_db_connections = 350
 
     queue_runner_metrics_address = [::]:9198


### PR DESCRIPTION
The new ISOs will have the LTS and latest kernel integrated as specialisations, which makes them about 205 MB larger on x86-64-linux.

What we get out of this is one less separate ISO for x86_64-linux and aarch64-linux we need to create and store.