### PR TITLE
macs: configure cores/jobs per profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # Doesn't seem that x86_64 is still in use?
-        machine: [arm64]
+        machine: [m1, m2-large]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30

--- a/macs/common.nix
+++ b/macs/common.nix
@@ -48,10 +48,6 @@ in
       patches = oldAttrs.patches or [ ] ++ [ ./disable-chroot.patch ];
     });
     settings = {
-      # 8C/16G machines means 2C/4G per job on average
-      cores = 2;
-      max-jobs = 4;
-
       extra-experimental-features = [
         "nix-command"
         "flakes"

--- a/macs/flake-module.nix
+++ b/macs/flake-module.nix
@@ -3,15 +3,18 @@
   flake.darwinConfigurations =
     let
       mac =
-        system:
+        system: entrypoint:
         inputs.darwin.lib.darwinSystem {
           inherit system;
 
-          modules = [ ./nix-darwin.nix ];
+          modules = [
+            ./common.nix
+            entrypoint
+          ];
         };
     in
     {
-      arm64 = mac "aarch64-darwin";
-      x86_64 = mac "x86_64-darwin";
+      m1 = mac "aarch64-darwin" ./profiles/m1.nix;
+      m2-large = mac "aarch64-darwin" ./profiles/m2.large.nix;
     };
 }

--- a/macs/mac-update
+++ b/macs/mac-update
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+PIDS=()
+
+update() {
+	local HOST=${1}
+	local PROFILE=${2}
+	(ssh "$HOST" -- darwin-rebuild switch --flake "github:nixos/infra#$PROFILE" 2>&1| sed -e "s/^/${HOST} | /") &
+	PIDS+=($!)
+}
+
+update hetzner@enormous-catfish.mac.nixos.org m1
+update hetzner@growing-jennet.mac.nixos.org m1
+update hetzner@intense-heron.mac.nixos.org m1
+update hetzner@maximum-snail.mac.nixos.org m1
+update hetzner@sweeping-filly.mac.nixos.org m1
+update customer@eager-heisenberg.mac.nixos.org m2-large
+update customer@kind-lumiere.mac.nixos.org m2-large
+
+wait "${PIDS[@]}"

--- a/macs/profiles/m1.nix
+++ b/macs/profiles/m1.nix
@@ -1,0 +1,8 @@
+{
+  # 8 Cores, 16 GB RAM, 256 GB Disk
+  # split into 4 jobs with 2C/4G
+  nix.settings = {
+    cores = 2;
+    max-jobs = 4;
+  };
+}

--- a/macs/profiles/m2.large.nix
+++ b/macs/profiles/m2.large.nix
@@ -1,0 +1,8 @@
+{
+  # 8 Cores, 24 GB RAM, 1 TB Disk
+  # split into 2 jobs with 4C/12G
+  nix.settings = {
+    cores = 4;
+    max-jobs = 2;
+  };
+}


### PR DESCRIPTION
We need jobs with larger core counts to accomodate big build jobs, that would otherwise timeout.