### PR TITLE
builders: add the "benchmark" feature on their nix side

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -30,6 +30,7 @@
       system-features = [
         "kvm"
         "nixos-test"
+        "benchmark" # we may restrict this in the central /etc/nix/machines anyway
       ];
       trusted-users = [
         "build"


### PR DESCRIPTION
Deployed on ~~`sleepy-brown`~~ `elated-minsky` for testing, and I don't think this is controversial anyway.