### PR TITLE
Switch from `ix` to `termbin`

### DIFF
--- a/terraform/cache-staging/diagnostic.sh
+++ b/terraform/cache-staging/diagnostic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bind.dnsutils -p mtr -p curl
+#!nix-shell -i bash -p bind.dnsutils -p mtr -p curl -p netcat
 # shellcheck shell=bash
 # impure: needs ping
 #
@@ -29,8 +29,8 @@ curl_test() {
   curl -w "$curl_w" -v -o /dev/null "$@"
 }
 
-ix() {
-  url=$(cat | curl -F 'f:1=<-' ix.io 2>/dev/null)
+termbin() {
+  url=$(cat | nc termbin.com 9999)
   echo "Pasted at: $url"
 }
 
@@ -51,4 +51,4 @@ ix() {
   run curl -I -6 "https://$domain/"
   run curl -I -6 "https://$domain/"
   run curl -I -6 "https://$domain/"
-) | tee /dev/stderr | ix
+) | tee /dev/stderr | termbin

--- a/terraform/cache/diagnostic.sh
+++ b/terraform/cache/diagnostic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bind.dnsutils -p mtr -p curl
+#!nix-shell -i bash -p bind.dnsutils -p mtr -p curl -p netcat
 # shellcheck shell=bash
 # impure: needs ping
 #
@@ -29,8 +29,8 @@ curl_test() {
   curl -w "$curl_w" -v -o /dev/null "$@"
 }
 
-ix() {
-  url=$(cat | curl -F 'f:1=<-' ix.io 2>/dev/null)
+termbin() {
+  url=$(cat | nc termbin.com 9999)
   echo "Pasted at: $url"
 }
 
@@ -51,4 +51,4 @@ ix() {
   run curl -I -6 "https://$domain/"
   run curl -I -6 "https://$domain/"
   run curl -I -6 "https://$domain/"
-) | tee /dev/stderr | ix
+) | tee /dev/stderr | termbin


### PR DESCRIPTION
This fixes https://github.com/NixOS/infra/issues/537

Demo:

```
$ terraform/cache/diagnostic.sh
...
> curl_test -6 https://cache.nixos.org/
Pasted at: https://termbin.com/8p7n

```
