### PR TITLE
flake.nix: Update nix-darwin branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,15 +51,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736085891,
-        "narHash": "sha256-bTl9fcUo767VaSx4Q5kFhwiDpFQhBKna7lNbGsqCQiA=",
+        "lastModified": 1737421067,
+        "narHash": "sha256-/hgw8fDKDpko0XqOw1e9tX8lS2Hqecg7W/JsONun6Qc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ba9b3173b0f642ada42b78fb9dfc37ca82266f6c",
+        "rev": "cae8d1c4a3bd37be5887203fe3b0c3a860c53a07",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
+        "ref": "nix-darwin-24.11",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
     darwin = {
-      url = "github:LnL7/nix-darwin";
+      url = "github:LnL7/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'darwin':
    'github:LnL7/nix-darwin/ba9b3173b0f642ada42b78fb9dfc37ca82266f6c' (2025-01-05)
  → 'github:LnL7/nix-darwin/cae8d1c4a3bd37be5887203fe3b0c3a860c53a07' (2025-01-21)