### PR TITLE
Use `diskSelector` variable

### DIFF
--- a/build/pluto/prometheus/exporters/node.nix
+++ b/build/pluto/prometheus/exporters/node.nix
@@ -78,7 +78,7 @@
                   {
                     alert = "PartitionLowDiskSpace";
                     expr = ''
-                      round((node_filesystem_free_bytes{${diskSelector}} * 100) / node_filesystem_size_bytes{mountpoint="/"}) < 10 and ON (instance, device, mountpoint) node_filesystem_free_bytes < 100 * 1024^3
+                      round((node_filesystem_free_bytes{${diskSelector}} * 100) / node_filesystem_size_bytes{${diskSelector}}) < 10 and ON (instance, device, mountpoint) node_filesystem_free_bytes < 100 * 1024^3
                     '';
                     for = "30m";
                     labels.severity = "warning";


### PR DESCRIPTION
This doesn't make a material difference (the only value for `diskSelector` is `/`, which we were already using here), but somebody went to the effort to put this in a variable, so IMO we should be consistent about using it.

An alternative would be to just inline the mountpoint everywhere. Let me know what you prefer.