### PR TITLE
Alert if any scraping job fails

### DIFF
--- a/build/pluto/prometheus/default.nix
+++ b/build/pluto/prometheus/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./alertmanager.nix
+    ./exporters/up.nix
     ./exporters/blackbox.nix
     ./exporters/channel.nix
     ./exporters/domain.nix

--- a/build/pluto/prometheus/exporters/hydra.nix
+++ b/build/pluto/prometheus/exporters/hydra.nix
@@ -76,13 +76,6 @@
                   annotations.summary = "{{ $labels.machine }} has {{ $value }} over-age jobs.";
                   annotations.grafana = "https://grafana.nixos.org/d/j0hJAY1Wk/in-progress-build-duration-heatmap";
                 }
-                {
-                  alert = "HydraQueueRunnerUp";
-                  expr = ''up{job="hydra_queue_runner"} == 0'';
-                  for = "30m";
-                  labels.severity = "warning";
-                  annotations.summary = "hydra-queue-runner's prometheus exporter is not up";
-                }
               ];
             }
           ];

--- a/build/pluto/prometheus/exporters/up.nix
+++ b/build/pluto/prometheus/exporters/up.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  services.prometheus.ruleFiles = [
+    (pkgs.writeText "up.rules" (
+      builtins.toJSON {
+        groups = [
+          {
+            name = "up";
+            rules = [
+              {
+                alert = "NotUp";
+                expr = ''
+                  up == 0
+                '';
+                for = "10m";
+                labels.severity = "warning";
+                annotations.summary = "scrape job {{ $labels.job }} is failing on {{ $labels.instance }}";
+              }
+            ];
+          }
+        ];
+      }
+    ))
+  ];
+}


### PR DESCRIPTION
I'm marking this as a draft until https://github.com/NixOS/infra/issues/551 is resolved.

My understanding is that we really ought to have something like this to avoid a scenario where (for whatever reason: network issue, accidentally stopped exporter process, etc) prometheus is no longer successfully scraping targets.

Without this I believe many of our alerts would just happily continue to evaluate nothing at all.