### PR TITLE
dns: Move summer.nixos.org away from netlify

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -42,6 +42,11 @@ locals {
       value    = "makemake.ngi.nixos.org"
     },
     {
+      hostname = "summer.nixos.org"
+      type     = "CNAME"
+      value    = "makemake.ngi.nixos.org"
+    },
+    {
       hostname = "hydra.nixos.org"
       type     = "CNAME"
       value    = "mimas.nixos.org"

--- a/terraform/netlify_sites.tf
+++ b/terraform/netlify_sites.tf
@@ -13,17 +13,6 @@ resource "netlify_site" "nix-dev" {
   }
 }
 
-resource "netlify_site" "nixos-summer" {
-  name          = "nixos-summer"
-  custom_domain = "summer.nixos.org"
-
-  repo {
-    provider    = "github"
-    repo_path   = "NixOS/nixos-summer"
-    repo_branch = "main"
-  }
-}
-
 resource "netlify_site" "nixos-common-styles" {
   name          = "nixos-common-styles"
   custom_domain = "common-styles.nixos.org"


### PR DESCRIPTION
Done as part of https://github.com/NixOS/nixos-summer/issues/46 and https://github.com/NixOS/nixos-homepage/pull/1559. We no longer need `summer.nixos.org` to be hosted by Netlify, instead it will now point to `makemake.ngi.nixos.org` and only serve some [redirects](https://github.com/ngi-nix/ngipkgs/pull/476) to the relevant blog posts, reports, etc.

cc @fricklerhandwerk