### PR TITLE
Document why Lix is used on builders

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -6,6 +6,8 @@
 
 {
   nix = {
+    # Used because Nix had a weird random segfault and using Lix was the easiest solution to get the builds going
+    # TODO: Try to reproduce the crashes to generate a proper issue or fix in Nix.
     package = pkgs.lix;
     nrBuildUsers = config.nix.settings.max-jobs + 32;
 


### PR DESCRIPTION
This was introduced [without any linked discussion/explanation](https://github.com/NixOS/infra/pull/524), so let's document it now. I asked about the reason on Matrix and [was told](https://matrix.to/#/!RROtHmAaQIkiJzJZZE:nixos.org/$_zH2bGUSUChkNFNjxwpCeWL_OVa-9XELobMhsqCOinE?via=nixos.org&via=matrix.org&via=nixos.dev) the answer by @K900. Though I'm leaving this as a draft until we actually know what the segfault was.

Nothing against Lix, but on the Nix Hydra we should really be dog-fooding Nix. Imo if there's a bug, it should be reported so it can be fixed before upgrading.

Pinging @NixOS/nix-team in case anybody has a clue what the problem could be, and how it could be fixed.

Note that evals on the coordinator still use Nix, it's only builder machines that are using Lix for now.