### PR TITLE
Add host label to `smtp_starttls` scrapes

### DIFF
--- a/build/pluto/prometheus/exporters/blackbox.nix
+++ b/build/pluto/prometheus/exporters/blackbox.nix
@@ -39,6 +39,10 @@ let
         target_label = "__param_target";
       }
       {
+        source_labels = [ "__address__" ];
+        target_label = "host";
+      }
+      {
         source_labels = [ "__meta_dns_name" ];
         target_label = "instance";
       }


### PR DESCRIPTION
Previously, we had `instance=mail-test.nixos.org`, but this doesn't tell us the host this MX record points at. Now we have a host as well (such as `host=umbriel.nixos.org`).