### PR TITLE
builders: increase tmpfs size on standard builders to 128G

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }:
@@ -40,6 +41,23 @@
       ];
       use-cgroups = true;
       max-silent-time = 7200; # 2h
+    };
+  };
+
+  systemd.services.prune-stale-nix-builds = {
+    description = "Prune stale nix build roots";
+    startAt = "hourly";
+    unitConfig.Documentation = "https://github.com/NixOS/nix/issues/5207";
+    serviceConfig = {
+      ExecStart = lib.concatStringsSep " " [
+        (lib.getExe pkgs.findutils)
+        "/tmp"
+        "-maxdepth 1"
+        "-type d"
+        "-iname \"nix-build-*\""
+        "-mtime +1" # days
+        "-exec rm -rf {} +"
+      ];
     };
   };
 }

--- a/builders/profiles/hetzner-ax101r.nix
+++ b/builders/profiles/hetzner-ax101r.nix
@@ -15,9 +15,9 @@
 
   boot.tmp = {
     useTmpfs = true;
-    #  96G tmpfs, 160G RAM for standard builders
+    # 128G tmpfs, 128G RAM for standard builders
     # 160G tmpfs, 96G RAM for big parallel builders
-    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "160G" else "96G";
+    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "160G" else "128G";
   };
 
   boot.initrd.availableKernelModules = [

--- a/builders/profiles/hetzner-rx220.nix
+++ b/builders/profiles/hetzner-rx220.nix
@@ -16,9 +16,9 @@
   # 96G for build roots, 160G for working memory
   boot.tmp = {
     useTmpfs = true;
-    #  96G tmpfs, 160G RAM for standard builders
+    # 128G tmpfs, 128G RAM for standard builders
     # 128G tmpfs, 128G RAM for big parallel builders
-    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "128G" else "96G";
+    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "128G" else "128G";
   };
 
   boot.initrd.availableKernelModules = [


### PR DESCRIPTION
Another try to strike a balance between storage and memory requirements.