### PR TITLE
no longer depends on nixpkgs-unstable

### DIFF
--- a/build/flake.nix
+++ b/build/flake.nix
@@ -98,16 +98,25 @@
           };
         }) self.nixosConfigurations;
 
-      # TODO: flake-utils.lib.eachDefaultSystem
-      devShell.x86_64-linux =
-        let
-          pkgs = import nixpkgs { system = "x86_64-linux"; };
-        in
-        pkgs.mkShell {
-          buildInputs = with pkgs; [
-            agenix.packages.x86_64-linux.agenix
-            colmena.packages.x86_64-linux.colmena
-          ];
-        };
+      devShells =
+        nixpkgs.lib.genAttrs
+          [
+            "aarch64-linux"
+            "aarch64-darwin"
+            "x86_64-linux"
+            "x86_64-darwin"
+          ]
+          (system: {
+            default =
+              let
+                pkgs = nixpkgs.legacyPackages.${system};
+              in
+              pkgs.mkShell {
+                buildInputs = [
+                  agenix.packages.${system}.agenix
+                  colmena.packages.${system}.colmena
+                ];
+              };
+          });
     };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -269,22 +269,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1739667012,
-        "narHash": "sha256-6QWdUgz2O2Mm+pYx/AYB4Rot5/s1OR1C6bt30TI81yY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1dcdd535fef84d4671129a10e7072d56dca9a4d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1732014248,
@@ -355,7 +339,6 @@
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "simple-nixos-mailserver": "simple-nixos-mailserver",
         "sops-nix": "sops-nix",
         "srvos": "srvos",

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 

--- a/non-critical-infra/flake-module.nix
+++ b/non-critical-infra/flake-module.nix
@@ -50,11 +50,7 @@
     };
 
   perSystem =
-    { inputs', ... }:
-    # Use the latest packages from `nixpkgs-unstable` for dev tools.
-    let
-      pkgs = inputs'.nixpkgs-unstable.legacyPackages;
-    in
+    { inputs', pkgs, ... }:
     {
       packages.encrypt-email = pkgs.callPackage ./packages/encrypt-email { };
 


### PR DESCRIPTION
the only place we were using this, was for the devshell.

But it's not really clear to me if we still need this?

cc @jfly 