### PR TITLE
Allow umbriel to send emails as nixos.org

### DIFF
--- a/non-critical-infra/hosts/umbriel/README.md
+++ b/non-critical-infra/hosts/umbriel/README.md
@@ -1,12 +1,1 @@
 # `umbriel`
-
-## Provisioning
-
-If you recreate `umbriel`, it will generate a new `DKIM` signature. That's ok to
-do, but you'll need to update the corresponding `mail._domainkey.*` `TXT` DNS
-record in `terraform/dns.tf` with the generated key in
-`/var/dkim/mail-test.nixos.org.mail.txt`.
-
-TODO: declaratively manage the `DKIM` key once
-<https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/merge_requests/344>
-lands.

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -9,8 +9,33 @@
 
     fqdn = config.networking.fqdn;
 
-    # TODO: change to `nixos.org` when ready
-    domains = [ "mail-test.nixos.org" ];
+    domains = [ "nixos.org" ];
+  };
+
+  sops.secrets."nixos.org.mail.key" = {
+    format = "binary";
+    owner = "opendkim";
+    group = "opendkim";
+    mode = "0600";
+
+    # How to generate:
+    #
+    # ```console
+    # cd non-critical-infra
+    # DOMAIN=nixos.org
+    # SELECTOR=mail
+    # PRIVATE_KEY_PATH=secrets/$DOMAIN.$SELECTOR.key.umbriel
+    # nix shell nixpkgs#opendkim --command opendkim-genkey --selector="$SELECTOR" --domain="$DOMAIN" --bits=1024
+    # mv mail.private "$PRIVATE_KEY_PATH"
+    # sops encrypt --in-place "$PRIVATE_KEY_PATH"
+    # ```
+    #
+    # Next, look at `mail.txt` and update DNS accordingly.
+    sopsFile = ../../secrets/nixos.org.mail.key.umbriel;
+
+    # Ensure the file gets symlinked to where Simple NixOS Mailserver expects
+    # to find it.
+    path = "${config.mailserver.dkimKeyDirectory}/nixos.org.mail.key";
   };
 
   ### Mailing lists go here ###
@@ -22,14 +47,14 @@
   # follow the instructions.
   mailing-lists = {
     # TODO: replace with the real `nixos.org` mailing lists.
-    "test-list@mail-test.nixos.org" = {
+    "test-list@nixos.org" = {
       forwardTo = [
         "jfly@playground.jflei.com"
         ../../secrets/jfly-email-address.umbriel
         "jeremyfleischman+subscriber@gmail.com"
       ];
     };
-    "test-sender@mail-test.nixos.org" = {
+    "test-sender@nixos.org" = {
       forwardTo = [ "jeremy@playground.jflei.com" ];
       loginAccount.encryptedHashedPassword = ../../secrets/test-sender-email-login.umbriel;
     };

--- a/non-critical-infra/packages/encrypt-email/encrypt-email.py
+++ b/non-critical-infra/packages/encrypt-email/encrypt-email.py
@@ -149,7 +149,7 @@ def login(address_id: str, force: bool) -> None:
 
     nix_code = dedent(
         f"""\
-        "{address_id}@mail-test.nixos.org" = {{
+        "{address_id}@nixos.org" = {{
           forwardTo = [
             # Add emails here
           ];

--- a/non-critical-infra/secrets/nixos.org.mail.key.umbriel
+++ b/non-critical-infra/secrets/nixos.org.mail.key.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:xzDS4Dzi5vDKnLRZCmaH/j5oI5rknLLSzm/BAcqVL3pReOW7rE6C7QGY2EoS99TfLQ3BxB1ckrB4f3/pefEH018KIgJ7UeaeWebmkBFsXF8r+4m/yOEiDWgnGKnsq1EIzbs67AvVYV4rcEPUmTrkeFYd6TOEqIhOSM/6DO6Lg6x+ioAGSEHK6eGgRVIFVjByOhvufhOib1exX2GEM6ayluutig6ToxdnE5jRGIY1gp1bOuwDSazD07RIZanAlS0sjZvMOASacLRvwwM0HC2NEsfHHjy1YMNr1WIbW3HWV/r/j0FTGEDI0W7IP9b0livuAX+K+EixZ6Cw+9ZMhUQMZzfLRcR/c8Zo+hgmc8SJtaPCwck1RlRqOXbqceH1oMIWpYxWmdLIhSQTNgoiMp6L4JzVz7flpnzzEB2U4tkIMwnEBpa8Jz0TAtgyw9clgdbgR+11T56CGzdykbDxPjkDFhnDjhpqmUDgq8rSRRh0fhGdi8FX2rUQXnOMVrYALV0zkAN4cg2Px5dIjlMBZmHkawR7U8phYMBfQRC2FRz9USIrYVTof+J+UImWbWJwa2zMDb5ogRwOF4XhI6NNolCdorlmCvbdG7nE0LbnIbdC1b5VEeVmo0YObnm5HcI11ctugirpXb1kIcfhpg7Zaq3s2iRCbaiy5UVqQNbcKmLktItdxfAzWPQQyyQqA5xA7vlr2jQvKYP7i86H2woKEUwum8htYJewYB3w91NsJaoPikuVLmrBe00hoMwXqb/MtstEhJbI6FN0SC9r+YE8OMvlyoTzmxrysq4/X5qxeXhpbH7fqUxY77UPtOjHfG/vA8cpYHNBnvjXiRGFQwB/P4/fTdtJA5UZiO+EwvNyepadazqmN6szXxHLOcEu+qnoEGsAcbQjjN+y2IUgTXTpje2qfH75141oqhG/DHT4DFDRkI6AMuwQAVtM+6Nqk4hTzJVua8AK+HS+UwBqap0GbtVg3inSuhmcq2wQQzezz6XNpajvEvFosSpIHBwxkBsY6gn/RiCEm7iHvdePhGzOBylX+kLRLp1/PatRLCBVnZ5uwpVGhzdIMvoz7i7+Grmify1XlLuY8hxcmjJzPVn3El5euSeSamDkgdGkaaWeDRaU33OIBo0aRLFnmQeNfm2wwKYba1moqCtuZxSBfze9wiOacAmicUZZ9i2fjcYa/ejtgxTl/k10S4Z6YVhxHvK1y4D5r2zzFA==,iv:lYv/cuI7dQnBq/UAOh0tP1e+GOPgMKzHc66+cmyjZXY=,tag:mEYrazYwd93xOV5Fw5vqHg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBalpYcW9xYUZsTi9ZUDJV\nWEV0ZEZKWnMyNXdXUHBmRkkyS1gzaU81bGt3CkZoZVp4OUhmKzU0dkNmOHRFb1I5\nQjBacWVYYWdjSHh4NHFGQlhyNENmb2sKLS0tIGNmZFZjQ2dMYTQ1OFJnNFBLejNo\ndDJ0SUgwVHcvNjRTVVZ5Wis0NDZ1dWcKi2RTUzwVVg2x+9L+96QNwpA32IupkzV7\nmTfRtizJXHbzfUBSCUiuVis92bsk05PBRB9Zw5hQMY7K7ZAkctLprQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoWFdCSWd4Z1VwOEU5L3or\nelpPcm9JcDE0eXB1L1hrcVFuaGxQRDN5b1V3CnlyZzhnbkNlVUswWUFLclBqOHdv\nSEwvbTN6R3oyMTc4aS8xSDhkcVFpNVUKLS0tIGh0ZWRuUkFMSEhvRjZuV05zbTNR\ncytkaXlIOG1vQ2RWVnZLaGtJOFQ2dDQK04Fq2wcKRINC9iTCWuDMbJY8QPQAknQk\nTOEvgZ4DRQa/MnG5WGZkoA0PygirZNQTJFge2RRa0YMY+wypQvQNgg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMWUtZd2RzOEhKbnE4THZL\nOXRsMHhJVk9XancrTi9XbGF2SWl4SjU3bm1ZCjlDWlZ3WlU3bDZma0gvbUIwdk5P\nMGt6YVZjOVBGRkFnQ3ZVakl0Z2xjTTgKLS0tIFFzbWlDNi9rNloxUzJHbFd6Qlgr\neVVudjJFSThLeWMvVFozTUg1Yy9JSVkKH4gAq3XTuWVlylHxIOU5l4pbrsU0cFAA\nSAZUQk3TsBw427B02uocjjpTQByuxFxAf3hoV5WgFfEZf04gMlEUUQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-11T08:24:47Z",
+		"mac": "ENC[AES256_GCM,data:NpYf1LwINXQyuiN4jCkp95Q1UUnp+7M++k28GfGM1oWquOYtUH0wbRKEk1ooIABGSj8uz6qx5KBBGRh8eU6ldh7qwYqqTLDey2qeJ/5kt1ZTC5aOm9qtDWYWYzzb+lznOegSL25ny16d6ipOiKJeCdfcrgJBSr+Y6MCE+GxqGEg=,iv:pzx0e4ySgKmer/zF3wsrN4vVAzPMWE8RPPbkIkx0W5o=,tag:Smm0vqPToCcy2XHyHyVkUw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}


### PR DESCRIPTION
Depends on <https://github.com/NixOS/infra/pull/571/>. Please review/merge that PR first.

Once this change is deployed, we should be able to start sending test emails from `@nixos.org` email addresses using umbriel. I updated our SPF record in a way such that it should allow umbriel without breaking our existing email sending capabilities (ImprovMX and gandi.net).

This does *not* change our MX (yet): ImprovMX will still be receiving emails send to `nixos.org`. To verify that we can receive emails sent to `nixos.org` addresses, I plan to edit `/etc/hosts` on my personal mailserver and send some test emails. Do folks have better ideas for testing this out?