### PR TITLE
Remove gandi.net from our SPF record

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -204,7 +204,7 @@ locals {
     {
       hostname = "nixos.org"
       type     = "TXT"
-      value    = "v=spf1 include:spf.improvmx.com include:_mailcust.gandi.net ~all"
+      value    = "v=spf1 include:spf.improvmx.com ~all"
     },
     {
       # hetzner ax162-r 2548595


### PR DESCRIPTION
Per @zimbatm:

> It's a legacy thing. Gandi used to offer free email and then removed
> it.