### PR TITLE
Monitor STMP on umbriel explicity, as well as `nixos.org`

### DIFF
--- a/build/pluto/prometheus/exporters/blackbox.nix
+++ b/build/pluto/prometheus/exporters/blackbox.nix
@@ -108,9 +108,13 @@ in
         "https://www.nixos.org"
         "https://tracker.security.nixos.org"
       ])
+      # TODO: remove this static probe once `umbriel` is our MX record, and
+      # ImprovMX is out of the picture.
+      # https://github.com/NixOS/infra/issues/485
+      (mkStaticProbe "smtp_starttls_umbriel" [ "umbriel.nixos.org" ])
       (mkDnsSdProbe "smtp_starttls" {
         names = [
-          "mail-test.nixos.org"
+          "nixos.org"
         ];
         type = "MX";
         port = 25;


### PR DESCRIPTION
Today, our MX record point at `mx*.improvmx.com`. Soon, we'll switchover to `umbriel.nixos.org` as our mailserver. It's useful to monitor `nixos.org` regardless of who the underlying host is. In addition, it's useful right now to monitor our new mailserver explicitly (which we can remove once we've switched over).