### PR TITLE
dns: Point ngi.nixos.org to GitHub Pages IPs

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -47,6 +47,11 @@ locals {
       value    = "makemake.ngi.nixos.org"
     },
     {
+      hostname = "ngi.nixos.org"
+      type     = "CNAME"
+      value    = "ngi-nix.github.io"
+    },
+    {
       hostname = "hydra.nixos.org"
       type     = "CNAME"
       value    = "mimas.nixos.org"


### PR DESCRIPTION
As part of https://github.com/ngi-nix/summer-of-nix/issues/179 we want ngi.nixos.org to point to GitHub Pages so we can serve a landing page for users via GitHub.

I haven't tested this, as I can't run a terraform/tofu plan, but it passes `tflint` and `fmt`.

I've hardcoded the GitHub Pages IPs, which I don't forsee changing soon, but if we prefer a dynamic approach let me know and I'll rewrite this to use the [GitHub Provider](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/ip_ranges#pages_ipv4-1) to automatically pull these IPs via a data source.