### PR TITLE
drop emacs

### DIFF
--- a/build/common.nix
+++ b/build/common.nix
@@ -36,7 +36,6 @@
       sqlite-interactive
 
       # editors
-      emacs
       helix
       neovim
 

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -22,7 +22,6 @@ with lib;
   };
 
   environment.systemPackages = [
-    pkgs.emacs
     pkgs.git
     pkgs.gdb
 


### PR DESCRIPTION
looks like nixos-24.11-small actually doesn't include emacs, so we sometimes end up building this in our CI.
Since we no longer have any emacs user in the team, we can drop it.