### PR TITLE
github ci: disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   nixos-x86_64:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         machine:
           - caliban
@@ -46,6 +47,7 @@ jobs:
   nixos-aarch64:
     runs-on: ubuntu-22.04-arm
     strategy:
+      fail-fast: false
       matrix:
         machine:
           - umbriel
@@ -61,6 +63,7 @@ jobs:
   nix-darwin:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         machine:
           - m1


### PR DESCRIPTION
We rather want builds to be cached and not having to be repeated.