### PR TITLE
Fix evaluation warning about `routeConfig` on `umbriel`

### DIFF
--- a/non-critical-infra/hosts/umbriel/default.nix
+++ b/non-critical-infra/hosts/umbriel/default.nix
@@ -35,12 +35,10 @@
       "2a01:4f9:c011:8fb5::1/64"
     ];
     routes = [
-      { routeConfig.Gateway = "fe80::1"; }
+      { Gateway = "fe80::1"; }
       {
-        routeConfig = {
-          Gateway = "172.31.1.1";
-          GatewayOnLink = true;
-        };
+        Gateway = "172.31.1.1";
+        GatewayOnLink = true;
       }
     ];
     linkConfig.RequiredForOnline = "routable";


### PR DESCRIPTION
Before:

```console
$ nix eval .#nixosConfigurations.umbriel.config.system.build.toplevel
evaluation warning: Using 'routeConfig' is deprecated! Move all attributes inside one level up and remove it.
evaluation warning: Using 'routeConfig' is deprecated! Move all attributes inside one level up and remove it.
«derivation /nix/store/yp4hjn03fw471l7nz2c0h26vhxjgyx4k-nixos-system-umbriel-24.11.20250308.52e3095.drv»
```
After:

```console
$ nix eval .#nixosConfigurations.umbriel.config.system.build.toplevel
warning: Git tree '/home/jeremy/src/github.com/NixOS/infra' is dirty
«derivation /nix/store/yp4hjn03fw471l7nz2c0h26vhxjgyx4k-nixos-system-umbriel-24.11.20250308.52e3095.drv»
```