### PR TITLE
prometheus: Catch false positive on domain expiry

### DIFF
--- a/build/pluto/prometheus/exporters/domain.nix
+++ b/build/pluto/prometheus/exporters/domain.nix
@@ -44,10 +44,17 @@
               rules = [
                 {
                   alert = "DomainExpiry";
-                  expr = "domain_expiry_days < 30";
+                  expr = "domain_expiry_days != -1 and domain_expiry_days < 30";
                   for = "1h";
                   labels.severity = "warning";
                   annotations.summary = "Domain {{ $labels.domain }} will expire in less than 30 days";
+                }
+                {
+                  alert = "DomainProbeFailure";
+                  expr = "domain_probe_success == 0";
+                  for = "3h";
+                  labels.severity = "warning";
+                  annotations.summary = "Domain {{ $labels.domain }} probe failing for more than 3 hours.";
                 }
               ];
             }


### PR DESCRIPTION
This fixes the false positive we got on the [NixOS Infra Alerts channel today](https://matrix.to/#/!QLQqibtFaVtDgurUAE:nixos.org/$Jrcfj08eep_DZOaZYVNSU90rQ9nF8jbwvT7hcqqEwx0?via=nixos.org&via=matrix.org&via=nixos.dev).

It also adds an alert for when a whois query fails for more than three hours. I chose three hours as a heuristic based on the duration of previous failures of this probe, so that we don't get false positives when there's a blip in a WHOIS server.