### PR TITLE
Increase `for` for `DomainProbeFailure`

### DIFF
--- a/build/pluto/prometheus/exporters/domain.nix
+++ b/build/pluto/prometheus/exporters/domain.nix
@@ -52,9 +52,9 @@
                 {
                   alert = "DomainProbeFailure";
                   expr = "domain_probe_success == 0";
-                  for = "3h";
+                  for = "1d";
                   labels.severity = "warning";
-                  annotations.summary = "Domain {{ $labels.domain }} probe failing for more than 3 hours.";
+                  annotations.summary = "Domain {{ $labels.domain }} probe failing for more than 1 day.";
                 }
               ];
             }


### PR DESCRIPTION
Today we hit a stretch of over 3 hours where we could not successfully query `nix.ci`. Let's bump to a full day and see if we get that unlucky in the future.