### PR TITLE
Import ImprovMX aliases

### DIFF
--- a/non-critical-infra/modules/mailserver/README.md
+++ b/non-critical-infra/modules/mailserver/README.md
@@ -2,11 +2,12 @@
 
 This module will [eventually][issue 485] provide mail services for `nixos.org`.
 
+[issue 485]: https://github.com/NixOS/infra/issues/485
+
 ## Mailing lists
 
 To create a new mailing list, or change membership of a mailing list, see the
-instructions under `### Mailing lists go here ###` in
-[`default.nix`](./default.nix).
+instructions at the top of [`mailing-lists.nix`](./mailing-lists.nix).
 
 Some mailing lists allow login and sending email via `SMTP`. Search for
 `loginAccount` to find examples of this.

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -1,7 +1,9 @@
 { config, pkgs, ... }:
 
 {
-  imports = [ ./mailing-lists.nix ];
+  imports = [
+    ./mailing-lists.nix
+  ];
 
   mailserver = {
     enable = true;
@@ -36,28 +38,6 @@
     # Ensure the file gets symlinked to where Simple NixOS Mailserver expects
     # to find it.
     path = "${config.mailserver.dkimKeyDirectory}/nixos.org.mail.key";
-  };
-
-  ### Mailing lists go here ###
-  # If you wish to hide your email address, you can encrypt it with SOPS. Just
-  # run `nix run .#encrypt-email address -- --help` and follow the instructions.
-  #
-  # If you wish to set up a login account for sending email, you must generate
-  # an encrypted password. Run `nix run .#encrypt-email login -- --help` and
-  # follow the instructions.
-  mailing-lists = {
-    # TODO: replace with the real `nixos.org` mailing lists.
-    "test-list@nixos.org" = {
-      forwardTo = [
-        "jfly@playground.jflei.com"
-        ../../secrets/jfly-email-address.umbriel
-        "jeremyfleischman+subscriber@gmail.com"
-      ];
-    };
-    "test-sender@nixos.org" = {
-      forwardTo = [ "jeremy@playground.jflei.com" ];
-      loginAccount.encryptedHashedPassword = ../../secrets/test-sender-email-login.umbriel;
-    };
   };
 
   services.postfix.config.bounce_template_file = "${pkgs.writeText "bounce-template.cf" ''

--- a/non-critical-infra/modules/mailserver/mailing-lists-options.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists-options.nix
@@ -1,0 +1,134 @@
+# This module makes it easy to define mailing lists in `simple-nixos-mailserver`
+# with a couple of features:
+#
+#  1. We can (optionally) encrypt the forward addresses for increased privacy.
+#  2. We can set up a login account for mailing addresses to allow sending
+#     email via `SMTP` from those addresses.
+
+{ config, lib, ... }:
+
+let
+  inherit (lib) types;
+
+  fileToSecretId = file: builtins.baseNameOf file;
+
+  listsWithSecretPlaceholders = lib.mapAttrs' (name: mailingList: {
+    name = name;
+    value = map (
+      member:
+      if builtins.isString member then member else config.sops.placeholder.${fileToSecretId member}
+    ) mailingList.forwardTo;
+  }) config.mailing-lists;
+
+  secretAddressFiles = lib.pipe config.mailing-lists [
+    (lib.mapAttrsToList (_name: mailingList: mailingList.forwardTo))
+    lib.flatten
+    (builtins.filter (member: !builtins.isString member))
+  ];
+
+  secretPasswordFiles = lib.pipe config.mailing-lists [
+    (lib.filterAttrs (_name: mailingList: mailingList.loginAccount != null))
+    (lib.mapAttrsToList (_name: mailingList: mailingList.loginAccount.encryptedHashedPassword))
+  ];
+in
+
+{
+  options = {
+    mailing-lists = lib.mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            forwardTo = lib.mkOption {
+              type = types.listOf (types.either types.str types.path);
+              description = ''
+                Either a plaintext email address, or a path to an email address
+                encrypted with `nix run .#encrypt-email address`
+              '';
+            };
+            loginAccount = lib.mkOption {
+              type = types.nullOr (
+                types.submodule {
+                  options = {
+                    encryptedHashedPassword = lib.mkOption {
+                      type = types.path;
+                      description = ''
+                        If specified, this enables sending emails from this address via SMTP.
+                        Must be a path to encrypted file generated with `nix run .#encrypt-email login`
+                      '';
+                    };
+                  };
+                }
+              );
+              default = null;
+            };
+          };
+        }
+      );
+      description = ''
+        Mailing lists. Supports both forward-only mailing lists, as well as mailing
+        lists that allow sending via SMTP.
+      '';
+    };
+  };
+
+  config = {
+    # Disable IMAP. We don't need it, as we don't store email on this server, we
+    # only forward emails.
+    mailserver.enableImap = false;
+    mailserver.enableImapSsl = false;
+    services.dovecot2.enableImap = false;
+
+    mailserver.loginAccounts = lib.pipe config.mailing-lists [
+      (lib.filterAttrs (_name: mailingList: mailingList.loginAccount != null))
+      (lib.mapAttrs (
+        _name: mailingList: {
+          hashedPasswordFile =
+            config.sops.secrets.${fileToSecretId mailingList.loginAccount.encryptedHashedPassword}.path;
+        }
+      ))
+    ];
+
+    # Declare secrets for every secret file.
+    sops.secrets = builtins.listToAttrs (
+      (map (file: {
+        name = fileToSecretId file;
+        value = {
+          format = "binary";
+          sopsFile = file;
+        };
+      }) secretAddressFiles)
+      ++ (map (file: {
+        name = fileToSecretId file;
+        value = {
+          format = "binary";
+          sopsFile = file;
+          # Need to restart `dovecot2.service` to trigger `genPasswdScript` in
+          # `nixos-mailserver`:
+          # https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/af7d3bf5daeba3fc28089b015c0dd43f06b176f2/mail-server/dovecot.nix#L369
+          # This could go away if sops-nix gets support for "input addressed secret
+          # paths": https://github.com/Mic92/sops-nix/issues/648
+          restartUnits = [ "dovecot2.service" ];
+        };
+      }) secretPasswordFiles)
+    );
+
+    sops.templates."postfix-virtual-mailing-lists" = {
+      content = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          name: members: "${name} ${lib.concatStringsSep ", " members}"
+        ) listsWithSecretPlaceholders
+      );
+
+      # Need to restart postfix-setup to rerun `postmap` and generate updated `.db`
+      # files whenever mailing list membership changes.
+      # This could go away if sops-nix gets support for "input addressed secret
+      # paths": https://github.com/Mic92/sops-nix/issues/648
+      restartUnits = [ "postfix-setup.service" ];
+    };
+
+    services.postfix.mapFiles.virtual-mailing-lists =
+      config.sops.templates."postfix-virtual-mailing-lists".path;
+
+    services.postfix.config.virtual_alias_maps = [ "hash:/etc/postfix/virtual-mailing-lists" ];
+  };
+}

--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -8,7 +8,9 @@
   # an encrypted password. Run `nix run .#encrypt-email login -- --help` and
   # follow the instructions.
   mailing-lists = {
-    # TODO: replace with the real `nixos.org` mailing lists.
+    # BEGIN TEST ADDRESSES
+    # TODO: remove these testing email addresses after rollout is complete:
+    #       https://github.com/NixOS/infra/issues/587
     "test-list@nixos.org" = {
       forwardTo = [
         "jfly@playground.jflei.com"
@@ -19,6 +21,170 @@
     "test-sender@nixos.org" = {
       forwardTo = [ "jeremy@playground.jflei.com" ];
       loginAccount.encryptedHashedPassword = ../../secrets/test-sender-email-login.umbriel;
+    };
+    # END TEST ADDRESS
+
+    "community@nixos.org" = {
+      forwardTo = [
+        "moderation@nixos.org"
+      ];
+    };
+
+    "finance@nixos.org" = {
+      forwardTo = [
+        ../../secrets/edolstra-email-address.umbriel # https://github.com/edolstra
+        ../../secrets/kate-email-address.umbriel # https://discourse.nixos.org/u/kate
+      ];
+    };
+
+    "foundation@nixos.org" = {
+      forwardTo = [
+        ../../secrets/edolstra-foundation-email-address.umbriel # https://github.com/edolstra
+        ../../secrets/refroni-email-address.umbriel # https://github.com/refroni
+        ../../secrets/kate-email-address.umbriel # https://discourse.nixos.org/u/kate
+        ../../secrets/infinisil-email-address.umbriel # https://github.com/infinisil
+        ../../secrets/ra33it0-email-address.umbriel # https://github.com/ra33it0
+        ../../secrets/lassulus-email-address.umbriel # https://github.com/lassulus
+        ../../secrets/ryantrinkle-email-address.umbriel # https://github.com/ryantrinkle
+      ];
+    };
+
+    "fundraising@nixos.org" = {
+      forwardTo = [
+        ../../secrets/fricklerhandwerk-email-address.umbriel # https://github.com/fricklerhandwerk
+      ];
+    };
+
+    "hostmaster@nixos.org" = {
+      forwardTo = [
+        "infra@nixos.org"
+      ];
+    };
+
+    "infra@nixos.org" = {
+      forwardTo = [
+        ../../secrets/mweinelt-email-address.umbriel # https://github.com/mweinelt
+        ../../secrets/zimbatm-email-address.umbriel # https://github.com/zimbatm
+        ../../secrets/vcunat-email-address.umbriel # https://github.com/vcunat
+        ../../secrets/edef1c-email-address.umbriel # https://github.com/edef1c
+        ../../secrets/Mic92-email-address.umbriel # https://github.com/Mic92
+      ];
+    };
+
+    "marketing@nixos.org" = {
+      forwardTo = [
+        ../../secrets/idabzo-email-address.umbriel # https://github.com/idabzo
+        ../../secrets/therealpxc-email-address.umbriel # https://github.com/therealpxc
+        ../../secrets/Kranzes-email-address.umbriel # https://github.com/Kranzes
+        ../../secrets/tomberek-email-address.umbriel # https://github.com/tomberek
+      ];
+    };
+
+    "moderation@nixos.org" = {
+      forwardTo = [
+        ../../secrets/lassulus-email-address.umbriel # https://github.com/lassulus
+        ../../secrets/picnoir-email-address.umbriel # https://github.com/picnoir
+        ../../secrets/uep-email-address.umbriel # https://discourse.nixos.org/u/uep
+      ];
+    };
+
+    "ngi@nixos.org" = {
+      forwardTo = [
+        ../../secrets/fricklerhandwerk-email-address.umbriel # https://github.com/fricklerhandwerk
+        ../../secrets/wamirez-email-address.umbriel # https://github.com/wamirez
+        ../../secrets/idabzo-email-address.umbriel # https://github.com/idabzo
+        ../../secrets/erictapen-email-address.umbriel # https://github.com/erictapen
+        ../../secrets/eljamm-email-address.umbriel # https://github.com/eljamm
+        ../../secrets/JulienMalka-email-address.umbriel # https://github.com/JulienMalka
+        ../../secrets/OPNA2608-email-address.umbriel # https://github.com/OPNA2608
+        ../../secrets/wegank-email-address.umbriel # https://github.com/wegank
+        ../../secrets/erethon-email-address.umbriel # https://github.com/erethon
+        ../../secrets/imincik-email-address.umbriel # https://github.com/imincik
+      ];
+    };
+
+    "nixcon@nixos.org" = {
+      forwardTo = [
+        ../../secrets/ners-email-address.umbriel # https://github.com/ners
+        ../../secrets/john-rodewald-email-address.umbriel # https://github.com/john-rodewald
+        ../../secrets/das-g-email-address.umbriel # https://github.com/das-g
+        ../../secrets/refroni-nixcon-email-address.umbriel # https://github.com/refroni
+        ../../secrets/ra33it0-email-address.umbriel # https://github.com/ra33it0
+        ../../secrets/infinisil-nixcon-email-address.umbriel # https://github.com/infinisil
+        ../../secrets/Nebucatnetzer-email-address.umbriel # https://github.com/Nebucatnetzer
+        ../../secrets/andir-email-address.umbriel # https://github.com/andir
+        ../../secrets/zmberber-email-address.umbriel # https://github.com/zmberber
+        ../../secrets/a-kenji-email-address.umbriel # https://github.com/a-kenji
+        ../../secrets/lassulus-nixcon-email-address.umbriel # https://github.com/lassulus
+        ../../secrets/pinpox-email-address.umbriel # https://github.com/pinpox
+        ../../secrets/ForsakenHarmony-email-address.umbriel # https://github.com/ForsakenHarmony
+        ../../secrets/idabzo-email-address.umbriel # https://github.com/idabzo
+        ../../secrets/picnoir-email-address.umbriel # https://github.com/picnoir
+      ];
+    };
+
+    "partnerships@nixos.org" = {
+      forwardTo = [
+        ../../secrets/refroni-email-address.umbriel # https://github.com/refroni
+      ];
+    };
+
+    "rob@nixos.org" = {
+      forwardTo = [
+        ../../secrets/rbvermaa-email-address.umbriel # https://github.com/rbvermaa
+      ];
+    };
+
+    "ron@nixos.org" = {
+      forwardTo = [
+        ../../secrets/refroni-email-address.umbriel # https://github.com/refroni
+      ];
+    };
+
+    "security@nixos.org" = {
+      forwardTo = [
+        ../../secrets/mweinelt-email-address.umbriel # https://github.com/mweinelt
+        ../../secrets/risicle-email-address.umbriel # https://github.com/risicle
+        ../../secrets/LeSuisse-email-address.umbriel # https://github.com/LeSuisse
+      ];
+    };
+
+    "steering@nixos.org" = {
+      forwardTo = [
+        ../../secrets/Ericson2314-email-address.umbriel # https://github.com/Ericson2314
+        ../../secrets/Gabriella439-email-address.umbriel # https://github.com/Gabriella439
+        ../../secrets/fpletz-email-address.umbriel # https://github.com/fpletz
+        ../../secrets/roberth-email-address.umbriel # https://github.com/roberth
+        ../../secrets/tomberek-email-address.umbriel # https://github.com/tomberek
+        ../../secrets/winterqt-email-address.umbriel # https://github.com/winterqt
+        ../../secrets/jtojnar-email-address.umbriel # https://github.com/jtojnar
+      ];
+    };
+
+    "summer@nixos.org" = {
+      forwardTo = [
+        ../../secrets/edolstra-summer-email-address.umbriel # https://github.com/edolstra
+        ../../secrets/MMesch-email-address.umbriel # https://github.com/MMesch
+        ../../secrets/bryanhonof-email-address.umbriel # https://github.com/bryanhonof
+        ../../secrets/tomberek-email-address.umbriel # https://github.com/tomberek
+        ../../secrets/gytis-ivaskevicius-email-address.umbriel # https://github.com/gytis-ivaskevicius
+        ../../secrets/ysndr-email-address.umbriel # https://github.com/ysndr
+        ../../secrets/DieracDelta-email-address.umbriel # https://github.com/DieracDelta
+      ];
+    };
+
+    "sysadmin@nixos.org" = {
+      forwardTo = [
+        ../../secrets/edolstra-admin-email-address.umbriel # https://github.com/edolstra
+        ../../secrets/zimbatm-admin-email-address.umbriel # https://github.com/zimbatm
+      ];
+    };
+
+    "webmaster@nixos.org" = {
+      forwardTo = [
+        ../../secrets/edolstra-nixos-email-address.umbriel # https://github.com/edolstra
+        ../../secrets/garbas-email-address.umbriel # https://github.com/garbas
+      ];
     };
   };
 }

--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -1,134 +1,24 @@
-# This module makes it easy to define mailing lists in `simple-nixos-mailserver`
-# with a couple of features:
-#
-#  1. We can (optionally) encrypt the forward addresses for increase privacy.
-#  2. We can set up a login account for mailing addresses to allow sending
-#     email via `SMTP` from those addresses.
-
-{ config, lib, ... }:
-
-let
-  inherit (lib) types;
-
-  fileToSecretId = file: builtins.baseNameOf file;
-
-  listsWithSecretPlaceholders = lib.mapAttrs' (name: mailingList: {
-    name = name;
-    value = map (
-      member:
-      if builtins.isString member then member else config.sops.placeholder.${fileToSecretId member}
-    ) mailingList.forwardTo;
-  }) config.mailing-lists;
-
-  secretAddressFiles = lib.pipe config.mailing-lists [
-    (lib.mapAttrsToList (_name: mailingList: mailingList.forwardTo))
-    lib.flatten
-    (builtins.filter (member: !builtins.isString member))
-  ];
-
-  secretPasswordFiles = lib.pipe config.mailing-lists [
-    (lib.filterAttrs (_name: mailingList: mailingList.loginAccount != null))
-    (lib.mapAttrsToList (_name: mailingList: mailingList.loginAccount.encryptedHashedPassword))
-  ];
-in
-
 {
-  options = {
-    mailing-lists = lib.mkOption {
-      type = types.attrsOf (
-        types.submodule {
-          options = {
-            forwardTo = lib.mkOption {
-              type = types.listOf (types.either types.str types.path);
-              description = ''
-                Either a plaintext email address, or a path to an email address
-                encrypted with `nix run .#encrypt-email address`
-              '';
-            };
-            loginAccount = lib.mkOption {
-              type = types.nullOr (
-                types.submodule {
-                  options = {
-                    encryptedHashedPassword = lib.mkOption {
-                      type = types.path;
-                      description = ''
-                        If specified, this enables sending emails from this address via SMTP.
-                        Must be a path to encrypted file generated with `nix run .#encrypt-email login`
-                      '';
-                    };
-                  };
-                }
-              );
-              default = null;
-            };
-          };
-        }
-      );
-      description = ''
-        Mailing lists. Supports both forward-only mailing lists, as well as mailing
-        lists that allow sending via SMTP.
-      '';
+  imports = [ ./mailing-lists-options.nix ];
+
+  # If you wish to hide your email address, you can encrypt it with SOPS. Just
+  # run `nix run .#encrypt-email address -- --help` and follow the instructions.
+  #
+  # If you wish to set up a login account for sending email, you must generate
+  # an encrypted password. Run `nix run .#encrypt-email login -- --help` and
+  # follow the instructions.
+  mailing-lists = {
+    # TODO: replace with the real `nixos.org` mailing lists.
+    "test-list@nixos.org" = {
+      forwardTo = [
+        "jfly@playground.jflei.com"
+        ../../secrets/jfly-email-address.umbriel
+        "jeremyfleischman+subscriber@gmail.com"
+      ];
     };
-  };
-
-  config = {
-    # Disable IMAP. We don't need it, as we don't store email on this server, we
-    # only forward emails.
-    mailserver.enableImap = false;
-    mailserver.enableImapSsl = false;
-    services.dovecot2.enableImap = false;
-
-    mailserver.loginAccounts = lib.pipe config.mailing-lists [
-      (lib.filterAttrs (_name: mailingList: mailingList.loginAccount != null))
-      (lib.mapAttrs (
-        _name: mailingList: {
-          hashedPasswordFile =
-            config.sops.secrets.${fileToSecretId mailingList.loginAccount.encryptedHashedPassword}.path;
-        }
-      ))
-    ];
-
-    # Declare secrets for every secret file.
-    sops.secrets = builtins.listToAttrs (
-      (map (file: {
-        name = fileToSecretId file;
-        value = {
-          format = "binary";
-          sopsFile = file;
-        };
-      }) secretAddressFiles)
-      ++ (map (file: {
-        name = fileToSecretId file;
-        value = {
-          format = "binary";
-          sopsFile = file;
-          # Need to restart `dovecot2.service` to trigger `genPasswdScript` in
-          # `nixos-mailserver`:
-          # https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/af7d3bf5daeba3fc28089b015c0dd43f06b176f2/mail-server/dovecot.nix#L369
-          # This could go away if sops-nix gets support for "input addressed secret
-          # paths": https://github.com/Mic92/sops-nix/issues/648
-          restartUnits = [ "dovecot2.service" ];
-        };
-      }) secretPasswordFiles)
-    );
-
-    sops.templates."postfix-virtual-mailing-lists" = {
-      content = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          name: members: "${name} ${lib.concatStringsSep ", " members}"
-        ) listsWithSecretPlaceholders
-      );
-
-      # Need to restart postfix-setup to rerun `postmap` and generate updated `.db`
-      # files whenever mailing list membership changes.
-      # This could go away if sops-nix gets support for "input addressed secret
-      # paths": https://github.com/Mic92/sops-nix/issues/648
-      restartUnits = [ "postfix-setup.service" ];
+    "test-sender@nixos.org" = {
+      forwardTo = [ "jeremy@playground.jflei.com" ];
+      loginAccount.encryptedHashedPassword = ../../secrets/test-sender-email-login.umbriel;
     };
-
-    services.postfix.mapFiles.virtual-mailing-lists =
-      config.sops.templates."postfix-virtual-mailing-lists".path;
-
-    services.postfix.config.virtual_alias_maps = [ "hash:/etc/postfix/virtual-mailing-lists" ];
   };
 }

--- a/non-critical-infra/packages/encrypt-email/encrypt-email.py
+++ b/non-critical-infra/packages/encrypt-email/encrypt-email.py
@@ -100,20 +100,18 @@ def address(address_id: str, email: str, force: bool) -> None:
     secret_path = non_critical_infra_dir / f"secrets/{address_id}-email-address.umbriel"
     encrypt_to_file(email, secret_path, force)
 
-    default_nix = non_critical_infra_dir / "modules/mailserver/default.nix"
-    assert default_nix.exists()
+    mailing_lists_nix = non_critical_infra_dir / "modules/mailserver/mailing-lists.nix"
+    assert mailing_lists_nix.exists()
 
     click.secho()
     click.secho("Now add `", nl=False)
     click.secho(
-        secret_path.relative_to(default_nix.parent, walk_up=True),
+        secret_path.relative_to(mailing_lists_nix.parent, walk_up=True),
         fg="blue",
         nl=False,
     )
-    click.secho("` to the relevant mailing list under '", nl=False)
-    click.secho("### Mailing lists go here ###", fg="blue", nl=False)
-    click.secho("' in ", nl=False)
-    click.secho(default_nix, fg="blue")
+    click.secho("` to the relevant mailing list in '", nl=False)
+    click.secho(mailing_lists_nix, fg="blue")
 
 
 @main.command()

--- a/non-critical-infra/secrets/DieracDelta-email-address.umbriel
+++ b/non-critical-infra/secrets/DieracDelta-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:X3yYaojL6gq9TRvAd8OMMnU=,iv:ULH7wpkAHPQLGuYudsoNb0uPmzm4K7qDFWYYcMR8u48=,tag:vgFnwkPkXS/QeJvE+XZ2UQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZeENFdXpQNFA5aDNvUURZ\nYXprcVY4SjByNEE1eVF3RjBrRlQ3aXd0eFZBCnNvU3hpNml6OGtxN2RQcGJ5bjRI\nSlF6UWJEUmo3UE12d3pNRU9qVWFtQkkKLS0tIG00bVB3dEFwNnJnZWV2eElscVlV\naGZIWHVCbEZJMDAreFY0VU1UMUVkaG8KJ9bSidOMy2MVuQALIRrCzZI1HL0aQ1zu\nrogntkr9eKlqN6orMXsYEewHJ4cXrvR2A2OrWZHWUIS9OC/xh9qHMA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSVVA3NDFjd0hLMlhjZ0xW\ndFh4M01XaGgvaWlONk5MYjJNOStpOWoyNTE0CnVVM3FKbmYzSkJRaWtCMDRoMk9z\nSm00eStNUHhKTVEzU3VDTm9peHNZYkUKLS0tIEZYN1RnV1R1SnBhckhHd2Y0RFE0\nYTJqUGsyWXVwRWg2MjI5bGhYYkJwRU0KRZD1QazLtJzDNd4LS43z347pPxjBv3GQ\nw75Vzz99G85Wne1W882k+8ACVhF0OXCfmPYhZg/uq0f4HQGRKEVwsg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrV2xlUXh5b1pOSStoWjRS\neXdVSDZxUTZLNVJ2cm03K0NqZC94YUZmcmdNCktoRFJPaXZHdGR6WUhjaUpDb1Yr\nZVM0b2VicldNWE1PekFJRU1wS3NRaUUKLS0tIHN1MlprK2RnaFBJUnZMWkE4emFq\nWXhqa0lQeWlYYXdIN3IwNm52ZkdKU0EKQjJnpZY2hEtXgEAlVpoEsz75fv6xP/Ls\nonNqppZHawRrCMEonQ0st71/bXiPLfvlTydWd8Gm2sh9x8Q6iCIXjw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:32Z",
+		"mac": "ENC[AES256_GCM,data:EeeJ9xKUEbNAPk6dIEoTkZfmzuhSXv6o4aMDrlAMtyM74FZFd4+UgFMWX9jDenMLOwuABf+V8n7uwRG1F69irMElOUHnRFWddVyNd99xJ8qNCmcOWTozDIoWEPC7gSUJklioPe/H52oa4x9MB3mo0tQco5OX8cCIHhMFfdZsetE=,iv:YsY+UdizldTnAf1NYvW9lA5D+GLiwN4AJiDWHIsUikE=,tag:VSo6ceJDowM3s9etW92DAQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/Ericson2314-email-address.umbriel
+++ b/non-critical-infra/secrets/Ericson2314-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:u/wikuNZRqFUN80sb4aOKF7A,iv:06zg9gnBY5X3nJTh1pYAkj8LbaojO6FXn48JAfsMojs=,tag:ZMfs9E2X7VGP1C8O6X6YtA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSWndNejZpQ01GcmFzRmky\nMVNmaTdBd2FaVTE3MnFncHZzVnIzekQxa0FvCmdTZjVzQjlMNndNY2Y2VUlEKy9D\nNUtpeFI3Zm1zUzVIUzFiNmE0cm9ScHcKLS0tIEF5bmx1L0M3TzNUTkpUUXVnanli\nVDFsakR0eCsyaWxoUFNvYkRLV2VsRk0KuJwyIOPDB5e9dDDWW6FNbDqmuyY/OBuG\n+g0Y6h/jtoRmgm1As+RK3GE5ZIO7wgIziiliW7lq7+wDo+ywttfvcA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTYkd1aUN3SWFrc3RvdXU1\nWHRQTk5Tamw0eXpiaU53UXhwM3cwOS9wTUVFCkVxNWordzFTUGg4L2ZpTFFWSnY1\nd2dqWVM1dXFpSVZwVldDa00yZm5MKzQKLS0tIDZ4b1RqK1RJdHd5R2lzbDB3cFlC\nNzROY0JVN0lCemtNQUR2emNzRVZ3bVEK1PXujfeLj7VXtmJV0SSRp387WRjxq/l/\neTIoDw1GiwIesPcer/+a22XV5iPkOMGcgxUFZG9QmzhWQO1G1FTOdw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLRDFmMHFNYW9NdnJndGtL\nWmlRUUI5MEtIekMvVHphdVlHK1FxeVBraEMwClVOQ2JOYklPYWhrOGRSdEJwcjJj\nN1dUalVibGtTZmxFK2I2ejVXYVJoS1kKLS0tIDRpaCtKdnpBOFZHd2pWQ2JUNG9l\nWVBjeGJUN21EQmt1MzZjNUV6UHRPcjAKEv10tHiU1chCx4XA12DRXcBrL5Gu8uze\n6ZiUoKhihO7bSBpw4Qbl9klCkZyKQ+yHOXBCrfr8XGGyYO/GLO8bQA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:24Z",
+		"mac": "ENC[AES256_GCM,data:3/oy9v0leIbu+MBH9+mH+qhiiWYzmQkWAAT0HHPutRLG7/RQGIklmuVCYNAvmknWogpI3lBrz0g1eyjZVdyylQGefWG/7mxcbYI7UoyAgmfUdfy7N5LnagD/Yca6EERekrK8hzpKDHeQeR7TVvUfXoVn1eDYJCs4QpARC4gZwTk=,iv:r+AOzfsRgyetuwDu9vNrqr5NtiGMShrGhh5Lo3Vcx9U=,tag:2UAgw0kjQOz8wa/D2y0jbg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/ForsakenHarmony-email-address.umbriel
+++ b/non-critical-infra/secrets/ForsakenHarmony-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:/q3jAh5Gbh4t2rcwhA==,iv:C9hFbszs+fOJjvi4TAVnrXf5zKnmmtUZt8W79GIkpXQ=,tag:6KGQdgeidkplMbh5glqr0A==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2c3RJVENPLzFQUnBQWmYr\nMDlUSlJOZU9DQmtKZXF1K3V2bUF0UE1nclhzCmRVQWVhV0pNVjlHM2FXcDBEZ0RS\nTG9JcFc2VHl5Y3ZlRVdlWm8xVkozdm8KLS0tIFZteG10L0pVSGJoSCtWQ0dSVm5r\ndllWb3lNZzhRRTZualF1a29DODI4QmsK/QsoEBBDbcozYwxH0KXlULWt4ZDk35T5\nEGnaTTmLZt2HWouAzIAhWAIP4r/1ITBV6Sp1PpsurzEzAmXG7DF8Gg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCVVJWYlpSMjcxVFJjem4r\nVW1kQzdLcExNZk9ySklaM21Jc1N2djk1ZlRFCkxCWkhlREFCZUE1YStUL21ETGd4\nV1UzUGRUUVpYMVZJcURDMEs0Q2dWMG8KLS0tIDhkZ0RpQlphanNmUkFaRUU0TTBW\nbUZzeDdBd2cxcThIbm5zOE9rN1NsdDQKRBNqF/GmLdmuGEaakXA/RyOe8ExIxhRR\neivwaB2/pFVE3SwMaAGvx/fyzG0Ul0mD352jyn7a4/XKPTeWqPVwng==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQXdudit5QXhJYjFlSHc2\nQjByT2lwbmYyWUVxdktVNjFyYkZuUTBPL1hNClpVQXY1ZThXSjliRi91M0JGOGs1\nOVdKOU1pUmZPTTBjajJIb2lCY2tzMTQKLS0tIE44TURVR3RRVWY5QTR0MEdieXF3\nbWt0SXNzOGRVdjc1akxoRWV6QzVYL3cKit7meiKwcYw77fi3F6U0whUcyGpkXAQO\nBoZqs6pr4iDCsWAFVpGV4hfqXNLhrzBKSmUxVxCpSfbmUb4ZwZEVWA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:18Z",
+		"mac": "ENC[AES256_GCM,data:Qo6ddwfmbMbBfv4ScDvhv5Ol68hc3Wm3KviWxO4iCjKjidHVMAmJPr0TDJtMR8e7e6ywBHcIPsGOCh0GJ7P53os0Pz2S79o4iXDx5hykvoFmOqWGr9INSFwAe8VwDYE1bt80Um6W8twCR5Y4Z5FC6n+2hWQA/3iM+KngctI2pJ4=,iv:1PR/uwLBXps+TzAjwef6g1aSkcAdyO/EYdZrRRFH6Jc=,tag:DoqtX9yPh9KeQA4Ysrv83A==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/Gabriella439-email-address.umbriel
+++ b/non-critical-infra/secrets/Gabriella439-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:C0rILZtiz2wxslQbHqXo0kG0UQLc3BOFkhI=,iv:1l9l2IbznCKZGtfmqj/SLwS4f3r6uC3DRdgcohhEh54=,tag:ndMxeQNCDd/DN3ysVdqgpw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6OHgza3dYcTYxUURjTHhi\nUWJwVjV1ZVRVV2orNzBXank1K2pqUDVjYWhZCjNTelc5ampmOXlpcElNWVhxNXln\nSktBdkhJblRpTGlHT1U0QU1raEhEc3MKLS0tIHdGczB1bmM1NzQ4Nkl5YUlqU0Jo\nU1Nkd29XWHdXL25ZYlJzdjRiUHVqcncKBDFKH31IKCsEvGRw2x/zO+1LyE6nWsyq\nxlMWmRnJJbu9pYNs3qzIUbGlD0pAaLZigBIMEMiHEDUeSeVHKupQkQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQU0Z0MTRtdThxWjhianJz\ndEJQZUxXWEluU2xLZlQxaDBOQnlBNW1Bc1VvCis2QkhZNHR4Z0lIMUJEMTY3cUFI\ndVU2VGZhL2RKWkozZzlwbzl6VE9iMGsKLS0tIDd4eEdqVzFuaVoydlFwVEdlR0I2\nZFBWZVgzaXVPTFpDeDk1ZU5tcld1TGcK/c7c8HsbTrGeG+92pWmMn3YPpNvUFx1Z\n2Xfm5Zr3/VdTA18BN30uBva5oYOCiDIiXgaQrT//DDZNQDPhJKlWQg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dFRYbEhqcC9xTWpncU5y\nOGVTR0RHZXZJSFFtaDVnN3F2R2g2WTJ1YkNNCmhPTkVTdEFrRFlnN0Nmc0lOeDcv\nZzdwUlVwaFBKRUNYYWRjeUVDUU9aa0kKLS0tIDJtWGRmdUxSMlA4a3VDOEtmM2hp\nMDNiUEdYRms2VTRteHdtRlBTQ3NHcmcKB/ACXZhqxS9yghBBwuTmkR5cgsakv1I4\nzPC09vPIS1q7amMHQ4zhnl00tykl3AwfSOGO9wTUBSpGu6byRPUOWg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:25Z",
+		"mac": "ENC[AES256_GCM,data:41DiT3lGEreAgFAid7nukcr4cPHIwbmMwp+97dyc8e2vcuB4hi4DCMH3HF5G6TXMF8k0WE2fxFc6+lN7TyP2cbz06YrrrZaz+oDcMh43rvRmwBmrsXSkh5B1dlYlMHYQ8qQrq4wqa9JN0gYuA22vuoEV/fao4VhNpnJm5CubTxE=,iv:IF03wTAIfmRNym6yCR7fMraYra8QVHhpCiXRFiaev+Y=,tag:CDnRSoBgRJWHdNr86cc9ng==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/JulienMalka-email-address.umbriel
+++ b/non-critical-infra/secrets/JulienMalka-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Ej0EzeFNfBWQGrOJVQsEjWcv2g==,iv:eF3tYfHWqlbWmUj6bFWdO1jny/X6iLlEThcb/NCat68=,tag:7+rV31Cq915d8m+khSFG6A==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBSDVDbW1rSzZWczI0UVpt\nUkdiZ3d2bzJjdFJqbG9lQUVoZWNSbngzR0M4CmpUMjBFUUY5TFRadzJmVmlwN0Y5\nOUQ1ejdnQWppRVRoYndZRkFCTU55dEkKLS0tIG54bHpQeVordFVaeGpKTkFkZDNW\neDBHZU0rYWYwVzBiT0NsK0dkODc4bUEKbhUkjTKp2iIu+4cIdQh7eXzWkjkwoLZp\nbK1bsn7TVIBKA7WMXAbwU1DjdBhnUIoslHFWC/WPYP2J5gCn7BUlAQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6MUF4ZmlOUHZQd1dkeXJY\neWZXdmxiV2p4bkhucGpmN2ZNcXoyeFppbkhrCjV5VEY1c01qRkZQL1FFUW9NK0pE\nRjgrQ28ycEpyVW52SElpa1YzK1pJcXcKLS0tIEh3cm52QUlic3JIUXZBZmR6TjNF\nWi80dU5BQXB1VUxCb0RaeHI1S2E5K28KVgysl9qLqhIImVE85wrz+9zmlTpljUHj\nk6zUrZRHNNH4VFn8vTxq9rrEdhillB9Z/XHVwBCGLxRGpK4g/eIN4A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDNWw0R1FQbmUwOWhTSHNa\nQ1V3V1dnbXM3alJFSldZNXF3ZjU0MUwxU1dBCmo2UkxSNkNxY1U2aDdKS1pIRFFO\nUm9qRy9EL2ZRb0dTeHFRK2d6VE5tTDQKLS0tIG4ydjNTZS9zUXBMSUxuS21lOTVn\nenhKYWMyRnZubXdueW1qRnBaU1Z2bU0KOC53jzkMpXg6tHBEkJibiBdLWTyxMOfi\nees2BrLkVV+XSGP7oayNUWyz9sgjLgGfQrK4UvlQNzcXXf4EiPqq/g==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:08Z",
+		"mac": "ENC[AES256_GCM,data:Io0XcHKNfVbW/0spjF3058QtaG0KgS+4o6YZWlyCU2Mk7x0TDPwrw4ldCF8xsaW85ybEKHs3ZQCRbmacRPDtGVcFWZKmxWs386Swr9rSMBtYA+AsTII+Dgu8ydObCeFisVDwRfLgWdThLCji11Dg788xJPIsD2odswiS/EbQPVQ=,iv:8tb+CQWTlOd0J3PYFsTdr1YC6ppdM+4Fb98GWr/aCL8=,tag:y/oqwJv97h9BSGC9a8Ieyg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/Kranzes-email-address.umbriel
+++ b/non-critical-infra/secrets/Kranzes-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Rbt40fvOkd12tUOrdattVlc23zCEHZkDjhFN,iv:9tKOblb08ZdyIBYzfSNGIPZWQLgiGy8QLaRTVBzUk5U=,tag:69JCHM3Q+d8sPbS8QrtOFA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOUWswZVEwbkZhOXFRUE1K\nYm5reW9UdTZaZ2IyOWxub3pXOVBDSWIzUEZVCjB1aElrb1JXUmtMcUxPaHZYQ3lW\namFuY056SGpuRTlDRVlHOTJudjd6c2sKLS0tIGpjMDYvazE0MTBjQlhHUnVTQ0kx\nci9Kb0piSGtzU1VFWEZ3Um54R1k1VjQKPqMA8/TCkOyoCXj4IBSmE8IrEGLK7xRk\nwCA5ZAQrpCdx98H4yxJv9V5q3sozrKafmluu+9MuvFlV9GR9Sl7PDA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpRnRGaWo3YmlFUFQ4Vld2\nRm9jaVQ4aVk5N3REQ09yOUF1K0FXNSs1dHkwClZwUjM2dVhRMkNCa3JVamU3bGdh\ncDA4ZnhzNldyQ0pDVXlFaWN6RHJmd2MKLS0tIFBJSHhsWVNsajBlWXZkRk9hbGw1\nalR6cFBjc1RPRGFTNFVlbkhaK0Z2QzgKaTyBrdj9pxrW8v6MuYVNFj+fwseHD5JR\nMNbOAsS8J07znV5hHstn3j5ESaLd4DwyZgSAPlryEIQhG+NPVthBgQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGT3dIcXI0RXBUOFUyRk4v\ndkdUY0F2aExHRGlHdTBoUlNCaTRLeFFha1JZCmM1d1F4NTlicGgzWG1BaWRZOGZS\nNkJhbzg4eUpIRStZYiszZGpHZnN1OG8KLS0tIHJnTUJZWkJ0QXRJZnlhT3NqL3JR\nVmYvZUdUa01wNlBRUkcyckdvR3NIQ28KvUhddXSOLOIdD2xSACfka/IgdTN9db2W\nMNlkhumZmZYwFoCwyFi3WlYpxUHgwywLW627rDKsK6lEWGHMHgiing==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:02Z",
+		"mac": "ENC[AES256_GCM,data:HQRWdn/UHk0sRhCQF57nTY3AGODVCsq/yUXs1g9B7RD1qTAH+CBFq/861xn40Q76tKE03qil2ucZJ1dPSNBGwk9fuIfXHytumg6Lr2Fmq7m0ri1X5vxGs09Nw7AcQ1dJcnL3H3F4wDa0C4jojSBnh5JSD3Q9w8CI1EbEj8xuyYs=,iv:cny74YHIlI6AYrwfDtPTizd64LJc/1K0HmfwNKWD0FY=,tag:RuhZ+zbr5B0ZZgOChJGdlQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/LeSuisse-email-address.umbriel
+++ b/non-critical-infra/secrets/LeSuisse-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:h78IdHjkj0APVFZdq8oFzw==,iv:6QB2mRaGYvQjCjO6QKcnuvfO2QaLMd9twdeF97uyccU=,tag:udGErtYAJX2wlumAThxpuQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlczgva1Q1bUZpMmtuYTdM\nd3gvMUZLM0VhY1hoamN3WVM3OGMvZGpaa2xVCmtyaURwbVMwYk5nU0pTOUN4bndY\nakFFLy83WGtTM0FqRXR5ajBHQU9EZFUKLS0tIDBFWHBVbzRzRi8xZVp3MXh1MGlK\nNTB0alRIUG5xRlZLcFVwMCt1UEdWZ0EKdRFNMI7yxSAfsLnwQw9M+0XdILgWifZu\nw4Wm7zjSWgoV9rHEm9tZWidXbJ8gfEFsqP0Gc3vrs3b8O1n8RvBTbQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaREZqeVduL2JBNTJ4Ui91\nRWJpUnBIR0MvQS80MkQzUkVjdDc0aW40anhVCkFPZ2hjYWJzSUdXUDlqMVlyUXIv\naHk4ZHJrNXNZMDZVdXJHbytnY2FWUHcKLS0tIDNPeXVuVFlTQXpSRHpKVVEyVFYz\nNExDL2x0OCtxTkJxaCtMUUU2N3ZFOUEKjX/bLagzQUoOsQ0zXPkx2/G8TpucsVEc\niP7lOnnqefIF9YBZfWrLjdFjlAKBlZW1sokDNiFfeNlVXLv3nXhmQw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzSUwxakk4aGRQT2FyQ0FG\nSnNGODlrcFY1YXlpbHNJUkJSZ2ZjeW56bmdnCjhCQTBDWE1oWTlkY2V1bmc2Y2pR\nT1ZvUDZjSlVMVStuckV1QnUvS0wxQWsKLS0tIE9saEh1S2Rza3Q0RDJOcDF1cE9U\nUjdnaGFHd3ZVb1pMaXlWZllJcXVVMFkKhSZ+mABcFxPsrbtxhnRv69m65IJFNIAD\nA5Ovz9AVu1KZiWCe3obDI7ImvGK/P1kYxgtcxOZAmPqYj+8AWN94vw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:23Z",
+		"mac": "ENC[AES256_GCM,data:V/Qs+xRtrcBYzDDANHueSrNIsHq4wT1ZOrQDJff+k8Si3Uaw9D7yGsZHrdFj+wuAt8u45WHlDZ4C+4zyNWJU9PiengAgQdRWl3z92LrFWfBFsvbCwZhcB/C/Z/HtpnNxV4eCnENnhEiQbXClYpndFiq9JRKv2eWTRbLzf6jwSeM=,iv:eC++s4t3iEcREtREiacb393DcN8IQhgU7rbdKXQMSwQ=,tag:/1+oiZAmYHY488iPPGkwYQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/MMesch-email-address.umbriel
+++ b/non-critical-infra/secrets/MMesch-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:/MyKjCi/ikz9u8TCJ0c7yhieWtF1Pq4osnE=,iv:TuY8UnNiROVHbrah0DdOs1FP8nCEwPlaZro+y1c1XiU=,tag:QJ8AmBoVI0mPL6WMt++UZw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJRncrOCtDSzNMRFBjcEZF\nK3ZpSDVlUFFBVDhXcGJDV3ZFT1JoZkhWQ2tvCmxXK2ZqcG40eUtqU09DcWV5ckJz\ndlVvdHJzYU5RRkN4QVFaYnVPc3BPdGsKLS0tIFJoSEJCRDBRL1dmYTc2Ry80cTFx\nYXJIZkJGZHkzcmc3OGUrUklzY0t6dk0Kat3DEijf/XA0ixOAr3cwPlh2Zbu2EeDj\nmXB9fH79JY2sh8+JQ4x6sQJMQnnvG7rPK+8x6H3565HudUpOvVSP3g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiZWYxM00zald4TTVhNHgz\nTEFkd3pGcHcyOTZGRmhxWjQzVENLdFoxem5ZCkJhVFZoK0xHRTNRWGh6Y3BGbG5k\nVEVaeVc3dDNnRm1oZXFKTEREWGQ1VEkKLS0tIGpwRkNUaGgvc0V0K3k0N04zK0hB\nSERwd2NsWDE5THZ3NkJGR1hpVUIvaVEKgcM7kURq8DiYpZ1bLfdTfeqSlCgope2h\nJbzdw7pvgyLr6hsa6+sudj13qVy6rEplqC6dBsZ7shMqtmqRQLauOg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRbGg3RHZtdUVsK1pVb1N6\nM0l1US9UQ0tadVBObEVMN3NpZWRMaCtKWFRjCno3dHpuK2liNzBKL1lESFozSnpV\nUFBscE00SXdBN3JlL2FMR0tmMExHU2MKLS0tIFBKZ0ZGeE1oNVlPRW1OTWJRb0FN\nZ0VCR09WWVhydStqbTdrQXJBOG1sb2cK6MqLXg540RT2LwfTRyrZbbqMKemtLo+x\nYffXEJIq8aRedMCV6a2MAyi2+OXGTNJGJsRddwP9vCkG0W6qOVRdzA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:29Z",
+		"mac": "ENC[AES256_GCM,data:lCKzgeTe0ySL/llOVXjybNMQ4SaAZfxx9q+UQFBQJeWeSWx5VpBAj3D0OjJA8URrIBJEvLublcM756yiN5uuOBmFUILrx2x4hc1FrFjcwlap7w2/yCkhl/e8LVXJnXlE2Bxc1hkkF7NBpFRy4BTuHM2HCFmDSG6tnBrqeWOizAQ=,iv:a9B+wZ+f0XvLcjbYnMkKulUBKaJhBA13tmVyMwTcVHU=,tag:ApPc5CmMlU53iXCkBhFJSw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/Mic92-email-address.umbriel
+++ b/non-critical-infra/secrets/Mic92-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:TvG6EEUzxziXHkm9Io4pqXg=,iv:vcS7p6p7q+v/NPT9Noj+DzSVQHaVQSqEtUx4ZIeq5kU=,tag:BqcA/NkWJee1MADjHoj3qg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQUdtS09CbEEwSEtrOUYv\naE54MjJPWUVoVkFzQ1BzaG1oTmdlcDRLTDFBCktMK2NRY3ZaejRKTWRUNStOTC8z\neDFTS1VrTjhWekl5K1V1NlcrWjZXMTAKLS0tICtnS2tLY012VFR2LzB2QXlBT25n\nR2JFZSswTysxNXJlbFhaMHZ0T3BlUHMKiPRqvaTAfyCOQRcp4t4VhxXIQ3ULzfPS\nTDv1bnUy6TKHl2ax5KZus0VJos0Lei/nOT5aN0sujG9PV3atq0hI+A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4RGhRZy96VDhCZTlHWENR\nZWFPY2s3RUFUbnZYbTRkVmJtOG5oU3ZuWEVRCmVaZlcrZlduR202U3ZPMDNnZTVa\nd2Z0R3UxT2E2aGh2QjdLK3VGYitwbmcKLS0tIHVaUFhtTW5nZ0tJM2NHZHcvRHdV\ncHZFc3NSL0tiN0RGU3RsRGZRM1ZsSEkKSZDmFRP/LtNMZ2hxCLDBh+m+BKzCKdXE\nlSL6Vy1o+aMH+wgM1mQQ0LgDRvPBdIuFkCFG7yVw+B7+sicJZy4CWg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBub0FkYTBwUkZkM0RDMDRm\nZTI2WGtyWkRrc3VEMTdIOWl0WXRmenp4aXpnCmZVdW5YY0xJTWtDUFBobUIyMjh2\nZ00zNWlrZ3lOVlJGY3NTOFZEMlc4N3cKLS0tIFRETmpydGVFK2NkaUV6VGplN0U0\nQjRyb2ZVTi9tTmNCN0hwbE0zbzAzZ2cK3C1glQ5B/M117NTebH7CsG8e8qgH+h/k\nm+TuuuR6PDYD7nYGNttLRB9X3UTTbzkyqqD8Rxc3IQqGr9abAMaZ/Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:00Z",
+		"mac": "ENC[AES256_GCM,data:/86wMc+s3MNBI7Vg+e6FcJMxd5ifn7Zgu+AksxtikdmsC6zttkx307W1MFAVZvdWLuUO886NV0pKfsPnDNVWNK1tsujN1Y5PRbJP3PUa/utTC1aCA7cQGL9Enu9/q252OB7YEqS8BXUMFQrKL4x3Atr2om8uf1gTgzBM4aLXN+c=,iv:LAWUu09guUq0QWY7yi/LB75tVuJRwl4DCXK9X/mlBRk=,tag:A//45Ms1Dx8fQ3JzOfoaWg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/Nebucatnetzer-email-address.umbriel
+++ b/non-critical-infra/secrets/Nebucatnetzer-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:+AibStUNqlK15znxZ3+wCK8p2paf4Vm8K2NOqA==,iv:4grF9oXAfvUxUUoKzs3dFHgnk4P1mYqX3RNzSRHNmxs=,tag:pd6G1ocabxwUgGTdABHExQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmb3RtTTlUV2FZWnlUKzQv\nUTVPdnZPYjBwK0FHYm95cjBLeGd0UUZobVc4Cm1qNWc2MVdKMUhJakpIbzdJcEtS\nU2xFUmFnSUlwSXJUaWxCZGZ2dUN2cXMKLS0tIDdrbytXaFRhUWp4VkZodUgyRm9L\nVHJ2djZWTVFtcHNKa3NleWowZE9MbmcKotJzRU02eep6AmhHmynqYqbjJj6kDZU4\n1G/jp6r/y2mFFyO3JjPcWhzEdjhiUn959RSQPQWvCnPMXqP6vCdlLw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaU0RVN0RydWF5UDNYTFJy\nUHB2RXVKZUlBU3A0WlpDcGQyRG0rMmYrZ2hBCk1xeEw5MmxESVhxZFNSMjRsR0JX\nVlJHS0lkRlBIdGJBM2NrUEU0NjhFbGsKLS0tIExYNlVmMXcvTkVLYnNlRjdTUUhu\nakhBd1ZDWXVpSFBSUFJXK2ZOeVFXbWMKkvtfrZb+HeuaysRJtViS9Rsh4hrdYARv\nHH8xe1QJ6N9V5f92v3K1VOvUHi3dV6q8QC/hWWsIVzwK1XzKDKxmrg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAreUJZWE1yOWxPN2plNWsw\nVXYwYzNWSXhOcE9KWnhCOXlnbjU1K0NEWVZjCktqcUNQdkx1cjl3cndKeWV3UlU5\ndFJNRXFMeFJZSGpBL0xza0IxZjc0VjQKLS0tIDhJZWRyMFcwemNaeEY3NjBOdFk5\nWldRUlVCcy9TQnd5NU1pL2ZONW13bzAKoWgEKqexTLE8sx92qajrmLFyvmrcRs7R\nbXvwzMchw5ijc7x4B+tXbs98ooPjhQiU4X3F5TU1Preg7O5gdTvdvA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:15Z",
+		"mac": "ENC[AES256_GCM,data:MutcAk/0+yZW1xqBFRPRFgxIJRLZq74WQejccmADhj3B16qKSvbYtMoRhHEeBFW6/8XdG+DWGXaHglyjWtyTWcWaTaEMBDkEiF0aQ5m6EiVocsUUxTacVwBfDzqRBK7Hj2bjPQ6MJqEg51m4OqQ4ENiRd5txcDip3TrrZsnHhEk=,iv:4AFRY+3PfNsDqNgWitLNGdk+ApICZqj1WunbImbbByw=,tag:6tOYpHXjx2rNRu36GWgTfg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/OPNA2608-email-address.umbriel
+++ b/non-critical-infra/secrets/OPNA2608-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:g/QzTQ83lXwOPIOj/UJBP9XNAXgfJyo=,iv:ZuuVzmJcO7odz3VsQm8bEfHLLC7DB44VaCp/b+Rd8zg=,tag:c10FqzzgIdGve9IYyVj3/Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFSlI0ZUlrNmxOWW5WTHFw\neUF1RU83QmVNMUdzYVp3aVBYdDhrOVlwcUNFCmh0OGhHTER3K201WFdPVDJDeXlw\nOGd1eVo1RkdTQ0RKZnpTL003ZTdKU2cKLS0tIEpoQTJvTyt4L3J5L1VsUzhLZDh3\nZTRrRjIxemVnaFExczNOUjVmUGk0ZVkKTz0+89rNg2pAgn9Boo9uVgPPDiGi5iaG\nY800GIfqJTQxsHbDIhoX/X6FKkMClrd/thMqFK2NF/VkxnOC5Ta5RA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYMGdjSXI3V2d6OGx1dURp\ndWNHd2JFNkJHRjF6cnNOQSsrRUluSzVHM3pnCnB1QzZRcVhLdUN0MW8zaGZmQ0Ro\nWEtuMXkxZVE5OStTaC9udUlXV1hwOFEKLS0tIGxkbnJPRFJSaWVqQVNZU0hwNTJF\nNkFQT0VHOVJ5S2dMY2cweVZiUnBMS2sK3i7HnWczY6XX1ruU5fGuQxvM/O1mkcvz\nquZsfUIAdTfAbtaa7kx0GTnyP8t64cLZNZH/0iaJCYPWVlXvYIw4AQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJcDVLWVY2WXJkWkVTM3Ni\nVVYzU25xYnRPWldFTTFldmd3QVNmUGRxNEJJCm8yQ2RvL0I0WG1hVndKRWVnbGJW\nTWhzWkhqYW5OUStaRzIzWVFhOEZTUncKLS0tIDJiUHZnb2ZtWnBjME1WWUwrMFRH\nMHFEaTFBWFBFMVlQbWdsbzQ4d0lTdVEKuIDY4/clAPG8FuChi91SclDmrf2OV7fd\ngvYWaWdIv+U3UaaolSsDHb/eN6zw2tP7LXgkwgYxIxeoGapJ2l3O6g==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:08Z",
+		"mac": "ENC[AES256_GCM,data:IrPWaDsLofVFXL1H2y3LzltFl5Td7dYeUtcciz4gtGkD6ZRtO2JVj6NCWveIgE3tEy7M5CxWpFneOQHiZJCVLXosBph43n6f62q2OX66MXWZ+5QNdJ9eqDV853TJJYuFOxPFe1BmROnALnZKOrTPiPVYCBdm5CDJONKtkBwIClQ=,iv:gyYdfY81Gw7fanTQC38ioUZE2gsAWliC/ahYMc1AEiQ=,tag:tnXmVCRvX8OxBhjQljr/qA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/a-kenji-email-address.umbriel
+++ b/non-critical-infra/secrets/a-kenji-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:5k202eaaTleSbcK4+COHEsaICQGoNXb4,iv:nsMrI/YhjJkvP9NtHEm3bgZiZVRxmCiHo9WncdrKPa8=,tag:RLkMixG7JcLF/Wgjj4+N8g==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBMmxlRFhEV0dBK2VrRng3\nbHFSZ1duajZPa3pEaTNReTFQYmVLZXZsTlZFCnY2aFpNdzVaSFFqV08vZVNKQ092\nRlRWWmJMVEZZYXIzNkdURFFFMVFYdVkKLS0tIG1iUUg4YW1aVEQvd01Gckw2TG53\nYUUwTkRHa1V2aExIdzcrckRucEVCcWsKpeLfSDvPzfvoWI+NUYnYgwebISzKTXgU\n4046ER4XCfbTHaB2tnP4xHuVlCS95wP4IsYanyyP8BcPSnrbXwQQuQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPc29UVGxSaU1KUTFSRGY1\nNjJOMzJBMFcrVHJ5QWdtaERUTmlnR2VkSWhNCjJXem9KTUJtV3VjdXZRc2dUU3Qy\nczNIZlBYRFA0bFJXK0Vobi96WVEyUzAKLS0tIGlaZDBlZ0NNaXBJdHVrTktCT241\nSjdZamE2ejFNaWlPMFpKRmlPVVpFY3MKlH3c3qw4xOSNS+CiCezUkKEgB19zVo3G\nzVuZSm0eFzeuBxOCquqJqBQchgegoKdeNFs+75Z3otbZr7iIjch5KA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAveEZXYmFWNm50ZGoyc1hM\nbUd5TllwT2lwVHlsVlJDcU1YMDJRNGtMWGxjCkRuanJHNTZJN1dCWkNsRDVrdmkz\nRWxzUEhmTDNXMWxRa3VpaVJ3RHR2N00KLS0tIERId21QUSt6RHlnTEtSTERqclF4\nWW9mUi91ZjFVSXlveFZRamUwT0lRMmMK1ikxhLbVSFji2LNspHPlWKDjbbhQArSE\nf9O7sWh8BD2v/gGokpAh9XczDMvOGteYOHb5plAZ5AFZHYa1xfv5eQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:16Z",
+		"mac": "ENC[AES256_GCM,data:4nGSwf0fv2sdne/F5XW7Nv8PAR/9/uHfFaik6y/2MgyCThR9+md/s05JTkoX7NjKwFZa4ylNetBfCDHe7c6PD+cwpLYtQIKtXZjrrz3ejM5KhzSCk2ldszXZZT4RN0OL1f+hhuclWcy6CDsN46vGtwwQtI9ywSp2m11F1sBXbmc=,iv:eZE1Y1xlwhaK3ECSen6eXtN42A4y6frxGA0oWOeJoG8=,tag:SQ39eKn1RdN/OqtQUL8VdQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/andir-email-address.umbriel
+++ b/non-critical-infra/secrets/andir-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:jfoMFBsk/LrrFBuOTWWJf8HnUQ==,iv:EjLtt6TnZNBWk3bNFBegZy7tERMF1iSp4Uyx9P/TK8I=,tag:3iPZHTzExMO14Ez6G5C+sA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxaGtURXcyVGRYT3lGb0g0\nZ3NSZHo1d2RZSWU3OEFQUWNHZ3hyRksyWmxFCnRQb3VWajY2ajBmcFlJaFp0ZGJW\nK1ZGOWVRUmFhbmkxVUhXWmZiVUZ4bzQKLS0tIDJZajdIWDBpNUFmMWlZTEdjSWYy\nK2ZWVy9CTXNvZVo3cXMrRVp3K0tTcmsKjuJ4jmR8wesvPnmigcF6F1oLDQzxV51T\nDRGwFVgFbrlNuHCnG0KeB4vQkGdbRV7kleeGjhbj4DOzZSuKrCOqLQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxeEVHaVhOZWIwd3FFNmVk\nUkc5bitBbGZESHkzaGpOZlBkQkxDODZtQjJNCmRrMHJWQkYyVy9SaExXUk1aRWVl\nb0NjUDcwbmh0UlNITVRmUUt1OFNKTk0KLS0tIGFTMzcxZUZjYVBtMFAzVGV4aERF\nL1ZhMEh3bUsxTlpQQkd4VVpkSjVsaEkKHaBO79rCdaFPvTuOyrzhGIMsSmVZ8HEY\nUNIx2ZnH0Msxwq49DYaXwYHa1eJsrujVe7SZz8xRSx94mxKjLvd2RA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2QTJ5YlFiRjg2SkR6cis2\nYVZZS0IyRTNTVXprRlFqOTVKV0lycmp3aFdJCjdnaE51dlU0SkxJQ3hXTUtlVzNK\nRGExcFIrM21lVFY4RmVZcGFOVzNHUU0KLS0tIC9md2ZVaVBETk5PNjhVN2h2cWZN\nWFV0QXIwTjk2V1VVUGc5QWxmaHFxRVkKCYHAKhJgvVP3xYeXMZ5qpKn78OkRlSx5\ny703es/fJtRkV+U2TZUM/33gKlgJd9vfZRPC5NsSCFry7Q0BwctQUQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:15Z",
+		"mac": "ENC[AES256_GCM,data:wneBlpjjTzeUQwK6YdWx1+b9OcGB3d38p0Dh2SUzeFOX6oYBCHkiPr85maMmR+WlKGP/YS8aXavUgodXPMsDkQuOejiwt91fU808LRcW3E3wKVJJwaSlMfyfrDIThVJvpSCLo/KX7GUWF14ycYr0cQTseeQfeFDAdJmwRrID6Yo=,iv:cXMaAXygnDUcXnhel0WrZHTHLygCt34M9vK8a/zKqw0=,tag:iYFrtIgPGkcMW9fTpwZm4Q==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/bryanhonof-email-address.umbriel
+++ b/non-critical-infra/secrets/bryanhonof-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:oUF4X6GHD5SJJvxc6BIUIK4yAGc=,iv:m3FFgV0mhIvh+J4KaiZ0Mlr3T1DZqV41bz+6Uq7jzgQ=,tag:l5gjpNOe5O3Qmov2wX5VQQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpKzRYM3ZVMU5PbW13dmFj\nSHMrV1MvZzVKd1RsOUxqQlYrcjl4N0JUUlZvCi83WnRvVWZHdjNlWFVUU0pmRmw0\nNkZ1RytUN0g1Y216WnRHZFQ3QmpXQU0KLS0tIGVFZ0hzR0I3MHVqNnIzL0hLTDN0\nQUllQUJRYW1KVlVsQmlDVnF1bFMrYlEKydk1t2eMK7/CjFSYOvq1Hy3kB7J4HfZ4\nGLw71kh3fjeFQQJtL0Ozy8haLfrYrRo7tqZxz+475fbyfLQoHBLQgg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzdUJlRTFNNEJhV204dEVU\nNitwWVowZG1aSE1aTy8xSXpXQjNtVVJ1aDJRCkVhZFJNWUZMRUZtS2hmV2h3UHlK\nMm5sSFptWGIveEpMN1VuYVFtb1BXNmcKLS0tIGNBN3ZTTUVmQWIzTDF6M1IxTjdl\nRzc3TnErdXZ5aFUyczZyTURWL2xyWjAKdUV8zkD4BiO57G3DJ/K98YUprtl+FZRi\nD2la8idltKl7K5zWbCQ5ywqJiI4dDNY/Q9XmPjoM5Ej0RMWo+n2XlA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZU2dPbm1PVENuOW51WEo3\nTTBXRTBhMllSeTBxYVVBR1Z5YW9PM2dEclZZCjlKZEFXV2o3dHN4S0w0bmVKWDMv\nS3dobzd3a3ovM2RCOHRNZlJwaXEvK1EKLS0tIHg1Smoxdm5DUDRWR0RLTFV6T1ly\nUEhMbmh2ZjhUOExjNFJ1UG9PVkRvS1EKWYIumny7HOXcr63byGgiMZXsLrMhtBpQ\nHi/n//KeejwIQVUxDfOTENmEZN+ShwQ8rzFTIYB4145m/+PcA74mMQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:30Z",
+		"mac": "ENC[AES256_GCM,data:bdGxTwvyMeUmomVjvPwqZdIiBFJXq0XcC6RzlhLsK5qv2EhGel6T97zDt/At6uNJwB5YScymxZuu4vpNVGdXFCAarxeDZ0+2WitMZLnSrj5Aqfx6refj6j+AgsvcAO3DuP1T7wdtvtBO0bCvorYAmBE8CsUpjxPgin2X+bFt3rc=,iv:1yZg8d0yMVPoZNlQY6W7F0pGI4j9WsUpfrFimPCOPnU=,tag:zH6AZJIlNoQxxvAIYoFO/g==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/das-g-email-address.umbriel
+++ b/non-critical-infra/secrets/das-g-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:NXChftwP/orYMVTkcb6QwVec4AYi0U3lFM9L2tvSfCo9MzY=,iv:XtVrvSW2cs+yGraNNjWHrUXhixa/tzGij19E7jiHiM4=,tag:sAszvSOVCVbE3CIpCNZJrQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmendNMVo2dkpOSGY2cHNx\nWUxzTHptZmExT0krVU1NUFZLRFlUMU5pZEJJCktxZmVuSytQby9OMlE1U2I2dko5\nOUVQY0E4cUdXNWE1Tm9wSElPZkF2MFkKLS0tIGRGOEg0S0cxeFdXcDh1NWxGRkt3\nUEF2VFlmaVlaMHVrVDVmY3NUTnY5VE0KE7tc0n0RNuTkCVIKcz5usIEY57z5Or7n\ndcrA6n7F2s2rvVEU38Gij7PNThL7QQ02TLDp7h8oV2XZHgSPTgxeJQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYT2pEaWlMMjA4eWswVk5u\nNG9qdFFuMEx4YThWeFdIc0krazVNSnhJQmlJCnlnMGFsUmtPdThiYVZYMU8wdnVy\nY2hPd3ZMSlZML0M3Nm0vRlBGTkMrZGcKLS0tIGF3ZzFPSzlEcWdReXY1a1ZKclk1\nRlVIeWtNNEU1UVA0MHU5ckU3THl2YTQKUIZLZ4jmBmJkGbN1hJCzmrNiC0RjrsNE\nqhOTzMKiYo3gFm3DZ4NyQteNFLNo8UOjsPH70Ig4dcTqD+UheAwEMw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZTlpzMlBGb1BOZEJlcVNl\nRXluN2wrYU1CWjFHeDBzdkxrWnhibGs0b1J3CmMzeXVxUnlMVXhjRkxSNzVpZVV0\na0NBMjZjMjBNcUorS3pSNWRpNHhjdjgKLS0tIEFrMlhMVzg3SDNhUkNCakRWUjlS\ncmptVjAyVDFTbnBVUkFMdXIwbFhiUFkKlwPN/fIioTNdruLy4qk4tBLH9GepPodd\nKLvCkjVdTy/dAk5vi4f0dg2rlqiVXSvwHp9qyTaekfrhs/gbP2cXlQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:12Z",
+		"mac": "ENC[AES256_GCM,data:GSuOKKl0u8eujxA0UKQI5M70Eo1KBmI2KyHM2g8OQXsUWqVStjekUn4DKoyTi25Z57Dp+bsxVnhK+s4Em2dZy9U0uPxisbUU94bV5wt3AYXP/UnqWb6of7EVBoSCsdc159qpmp2oPVTWCASbAUlUWF6GBCY9KAKvm/uVa4e0MW4=,iv:AjYMAlKF5vy8t/YizA26f0IvSXvsv5K8VtVwmUHH6GU=,tag:dZ25LTnpEa8AoXLiDeVEsA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edef1c-email-address.umbriel
+++ b/non-critical-infra/secrets/edef1c-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:olK8g+ZfUzQioDE2,iv:ar2uCtJq8TsHG5wwtav1bqeFdOpsnPTOvPQ8Gmxso5c=,tag:qqNpfWcM799dDM2wIKEosQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWSXg1MlNzLzBTK1NxcGZF\nY2pSTWoxVHZlcVRyUm9FTGtwUWNjeFFMeFRBCjBQcnFpRjk2OGE1b0pzL1VoS1M1\nTmVENlRXMnhCK0VERDBQQVpnQlVqNWsKLS0tIDBKSlpSek1YdlI1K3JBeGFHUmMw\nbmNHcm9LRE5IT1lOODk1TDliTUxtMEUKQ7joZh+ltgsWfpfzMgpOHm9CcVcKxj7f\naHZbpwEPd6qCQ+9Z+FFdr9wenHTFJ5D1tXrIoJTo2qzk+VfaQYKUUw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1RXJnSGtiRjhRcFNLS05R\nSFJTUUs4enlaNldTVlY1SGlOSmkrVnVBUFVjCmxkWWIvTk5HRkw5aXZaTzBxOHJp\na2p1bktDUUlSbUsvT0dqN3V4RU1qa1EKLS0tIDhlaXZWcTlrNWUzeGRNMHBUeXhu\nS2FSZGZ6UC9oZDgvV2xyYUlPSklOdEkKZtXolHiy8mMpiXN3fYVGf8LePUPCpZvZ\nbT+FG79LvD41bsz9SrH+o/FmmMOjwcAbZxdw4e1h6ftbxPCmNrrNtA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3RG9vdHJqUW1jdk9SdDFP\ndHBDZ0dwTVB0ZGFxb0c2bU9GZUJLL0M4TmhJCk1sNWVsSnc1RFRSeXhzOHZ1ZVpa\naTY3cUlWNGhWRHUxOHhZMUVoaC9tY3cKLS0tIElad3k3Rks5YWRTdllVQTJDaFJH\nWHFZSGtjV2lDNHY2QWVwcnJGMFhuWFkKC5dcccogfUd1oY/iafRzGdSS5PpKdzZV\nBwOBN89fshSPGEU29AySd+qXOC0WXZ/iY3tpH86M69sDrrUYOrGInw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:59Z",
+		"mac": "ENC[AES256_GCM,data:bOfnrINsRSacHJe2sdGge4JseZIkKoBr4uDbYMo+gRpXUPsEXr8G4ilYN8PTV21nBhl64w1hdwlcCTz3Ret0ZS73HVlDq7dzMqRftdePam5QJxrL9kn9tqIezvhiNoulzcPQ5LFta6RbcCY405IiIfDNNv8XFy4yLnq+fJpnCSM=,iv:xqAzo7L50+8XMTVoT5r9Lu3A9tfjQ1/hoB5Qv2FGXwU=,tag:NdHPOykcvNGvSSwGCwJoCA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edolstra-admin-email-address.umbriel
+++ b/non-critical-infra/secrets/edolstra-admin-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:BfqImaH+VSFNxZ6VEe+ZDiTYcB/WKTD3,iv:dQB5Wh8KB/txZjQGkE+8JaN/DXk3XX05VIBYwd/kXys=,tag:EFfGz1JiiA6AN8kku7m1iA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Q3FaMjhvNWdFcHhaQWlS\nMng2TngwSjZOTm50QWJEZVZqV21WRUR6VmhZCitPVWgrVURwZ1hLMm5QVGtjbzZ0\nSWM4eDJDemx1Q3BKajZEMnN2UkZraU0KLS0tIGQwOUxxTFIyTHVZNzlLSlRZblJF\nYlFVSWt0S3RabkdHYVMxNFM2VjRGaFEK/ITaVlCVUVLeNooHFvmdffVlVn5Mm2Vc\n6gH90kMH2XRPaojpMN0hHOLSYgD0HYqyOTAlhmqaVE8/OltAlORD9A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzcTZJeDB4aXB2WHZOQmQ0\neU1oblpDVUFIK2ZLN1ZvTXloMUcySVhhZUFFCngrekw4T0dtTnlRczN5eG1vWmkr\nSVA2QWk5WDUwaVRLekkxVFhEZHUyTTgKLS0tIExUaVZqY0hBZ1o0Z3ZYQk9PQk9u\neWZYamNXVWFFYmxsZDNDKzRqSmt0QlUKzRivObwIkjf5TgZ3sbX6btEVVSP0g+rN\nRPP/Jmt4GC89YhSEzfDstod+m4wfeDJTiu1Oj401f77suDisZEazoA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwdHJNL3hHNElaUSsvamVn\nVitQclZsNzRLY2RsYWtoS0krVHo0R1dleFJ3CjVIaFZWVEYveDU3cUhyNEt1Rk14\ndmxRV3U1WUR4Rzh5NUNQakRMaVpJVVkKLS0tIGxlSm9HWU5DT2VGK0FzcmVwd2h1\nQTFZckN1Yng5Q3hIbkU1RUlnQ1NJWUEKS2a2qdZQ550diz9f3TuHjxhf57wkuWJ7\naSJ0nq8wfuubmYoZmdhf/YcuLdEnz/XYO33tPqyLef9yn+vJpU/Tbg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:33Z",
+		"mac": "ENC[AES256_GCM,data:z91Y3V3j3cGwssk+VBW7gCCUfZ6p93ef1TFTaDtch7uCgtOXXmMcD9UxF0NNT94hCih46kWtbwYvPU/7LgDKbjmV2C+ILHrD7z7RHRU3qteoybIR2Uk+ORtaec1vfjt9Qeqf/PKBckx3/uXvufKP5cpMaIrsLKNROTHvLgaXjcE=,iv:ML/pctW6YQQTkAYBZhT4D7h6VoHLL1AFwUE/3BSi7Vo=,tag:FgUigE6ph6389ajItAglqw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edolstra-email-address.umbriel
+++ b/non-critical-infra/secrets/edolstra-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:P/ICBtclLOI2y/G0z0d7cfUW,iv:WM401Rq0v5spCCCaRZCdX3/3qJ/w6PM+rsJ/NyrLJ6A=,tag:+Xie8cztUsp6OmQ6uDneBA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5UUdLa05kRVZXazZQRWsv\ndmtBa1EzUEpicXRZMGtaeWg3VzNBalFGT1NFCjc2WHhkcSt1b2hRaHNsZE53YUVj\nOWZqZlNSdXJrREYxUlNSQmcyc1VOT0kKLS0tIEdFRlJPVWh4R3BXSGVNQXBLTFdZ\nb3VqR203UzJDdVkrZllVMnZxKzR1VnMKMO9pZh/ukJslEBGIYioJH8DJV4i2O0BF\n7D64/8ETSaOAIVzt8yZOpXvRjIwxbsEkNoQSf7GGm5ynmCzfJ7V6aw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2N0VncXpkejZGTjV3Vmxs\nZVdBaERCeERaK1VtTHFObk9RMlYxaXpUV3owClcyelZ5cURmUmNUaHZtU2NhN0lZ\nRjFWZTRIdHdQNDU5ektHbTl1L0s2eUUKLS0tIGJnUU9mL2lQa0R4eXg2UkpYK09x\nTXorMUZSakJPVGFSVXNlQTRGZlV2dk0KZ/qJoRpK16fjbG2wNQ89UU7Jz4AiX5cT\nOFKZ1pQTaUu4BLVkXebnPpkrjmpSwxxOQ5cCEbq0AQkzSX54UbkUHw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNOUQwcDE1VVltc0VYMkVs\nU01vaWg0VUxhNnBiVmRoUUpVaVcvZlNsWVdVCjZRekthWjJ1MDU0UGNXd2hheXBn\nSXpTU3RUOXY2V3F6UnA3OW1SMTFobDgKLS0tIGJXWUhyTm1kMGsvN0lpdkRSUmR6\nTUsyK0NQS0QxYzQ1clg2MTdKVjhTeW8K+QgNV6Iy1BOq5SABcYOVq06hNpW+k4mB\n/WIcvefIjDDg2QAYZkW2LjWnBLjBi72U4VKFmj5UF8zEUFZeRClLGA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:51Z",
+		"mac": "ENC[AES256_GCM,data:dZeSkgRXajdTJuSNst1TTUXBabgcaoL5AwhMsRQVyasVyjpVXU3RRmqdHU4/EZEIpLs3pAFBx05mX668h98tIudZkheNAhoWhG1FIpzrA4AacGUGYCbDmCQ8z2sM1UKTJFv6/lM2VMYGGGsADqXL4u9omAOIQ2AdLElNp9r2prA=,iv:tfifFZ8n6o/ZkNFCFeEHaBoqM613xNaYXVfyeyoHKsQ=,tag:wZygpKvhVGyqaF8l8f7UZg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edolstra-foundation-email-address.umbriel
+++ b/non-critical-infra/secrets/edolstra-foundation-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:jXei86Qti7mGFUbtSN+2bGkj30JgLajEMYkOQhI=,iv:b5+lzos1RJEWNH36xCwQS/W1LHPsrGd33zh8vuLw0w4=,tag:D4fGtRAeP5SaYtbtB5XE/w==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBbzJ6U3ZudWJpNzAxUEVZ\naFgwR0FjWG1jVEVvMG5ab3p4WUx5bjBzNUZvCjhDcUpWQnNKRDRoR1cvZkNrOXYr\nOFdsUUtFcWhwMi9IVSt5MG5wVjY2cVEKLS0tIFBsZzYxNTJmV0hBRUdYZTU3RmNv\nUkx4cnp5U2MzS015QTRSTkpxT1NMdzgKgbfgW0kFAMf2QlwSpdvLJiSmg6040DYb\nZvcgVXkNizcYvn2czXwFpMEOPptiA+OFUeVXYYmx6Sgo+BgUbjKDvg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWbndxelFoUkFHVmFpVmJ6\ndXNvOWxXSE9QaEgvMk41ekRwc3VsQitrcmg4CkVHME9PQUM0My9ZRGc4OGVIb2Nx\nWU1EL0xpNytNRXdUSXpEUjFlc0dYV2MKLS0tIGd0L2VRS2ZmWjVZQmpEYVRyQWtX\ndytzVlpMWHZHWkh3cWhhRzFkb3VYclUKFT9ISZNBJ/0hu70M3Zz1A6fl7bTmRZOo\nVNsz9ydtnZMjsOOhaQi6zI2HdTCLEC0HoI4IqXza/6fCXbJ00IDsGg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONVdZTmwzRFd2Ym5DUS9Y\nZUp3ZFA2VTZYdlhUZnE0dmNDdnRIYnVyODA0CkFSWFE3dFdQZUNFUExnb3BYVHJ0\nS2NkeDM4dlp1dlkrVFRhcHJpdjNEZWsKLS0tIC9oVFhHQ2ZsY2R1RHhoeUtISjVP\nS2RqbEFVWHJrcG1LUzFXUWdGVUV3V0UKGQPDl1K4IWysN4ZFfx19ibgMUw/Fuu08\nshhbKqTHwjDwwTzwoaMkgh+2AjmqP0rwFr8hd+rZcN5fPimdIEhsFg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:52Z",
+		"mac": "ENC[AES256_GCM,data:Q7CCyy17DXioU1i/1EZH4xfxlvW+mLJq29BvH2WfNeR/7/dvp0wu78+YJXohbRzaMkW7wqIKCBwvaH6OG0xVA+nGunlLoLdyUjePNuxr+UG7T0G3AqbAvOPkqKDkmFnVWeR2kqOdxlaVKeyF0IpRfaHUo40alKN1/ArMNGNUfls=,iv:WkJD7WjBcGOt7aDeCD3fv4eXiJGcbMOfKvH6WqG1lu0=,tag:MRSLaG6y6/mokYSBSIbVBA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edolstra-nixos-email-address.umbriel
+++ b/non-critical-infra/secrets/edolstra-nixos-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:cEwanrIPn4kMbhATtDdhhqXMzWwUuonC,iv:UxnLNXq9ceCUKmbxcN2JJKEOGlJzFByTUg216SfLaY0=,tag:/hJe1R7g81NoPLv6YvUqnQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGN1VMaGgrSUVsMmd4VXJa\nYUx4TVhyTVlhNHdWanNneG1rVGF1SXIvRmtBCnZzUExHLytLRzU0aE5XUmVTN3VT\nRlNtanhnMzR2UDgzTEVTMVlVMWdwcTQKLS0tIDYrOHg2dGF4SzdyWkkzSWhVRUg0\nUXp4eXM0eGVSMEhoWUFhYWRqckkzTkkKXv/JURQeYbcjcGrNOOeb/aOS+g2fxLfa\nGd9i9dmprOmc6N8zftelHsz8jntgWmg3vhydqA2BvociWIRyBpZ2TA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvZUpzbzQ2VVM5d2M3VEhj\ncjFTZFpiM3hmWjV3bVd5ZHdDWGlWYzBQUkZ3CnllSnFaSWg2WkUzOUxwcjZma25q\nVWJ2WU51V25lQWdsenNlcEJaRUJ3L1UKLS0tIGFmSTZ1U2JPNmpSR0NXMlZUVGxF\nV2l2cUp5RUhZZW5INUUwZEdlRDhMWWMKvT65UzC4aFdI4TFyO6aFrmRZdrfN6TWY\ngjV1sbudsfScL6C2pgech7RsWyAfX5SybaEELUj6l8cVpYa48RnLXQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5K3FLczJXYjA1SUlWR201\nd1FZU2hUeUtJbk9SZ3AyZm9qazR2NUpLaldzClUrb0xxK0dPb3YrdUgxMnJBYmtU\ncG5FeWJNMjA2Y2FrK2J4cXBTYTVmSGsKLS0tIGZxQVc2aXR4ZFhYRndRbmxld1hU\nOWNpdVhaQjZIK2xwL0NiN2Zoc3E4UncKRA7Fx6RhhjOkmvAN4MKwvU7oEjsoP6Om\n9dxC3/R5jk+p159PCZg8IGdv21cfPoMEsRHC6hX3VD71+JTA7PpSag==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:34Z",
+		"mac": "ENC[AES256_GCM,data:Z/bwrdNzbRLVzdNGUjzH8Oex+mEFD5u9VfC7HsKKG3UcKvia4tQDj+gb9B5BnTP2oU+SWlRp2RFc0erWHL/Cn11Ewjj2K29n/qmYvTIyWxMPetGYcuYxAq0AVLMFbPQ6BkqxZxteTOOwBeN667PjcxlpJ8RfYHCDADNCvw7r8J4=,iv:GEa/jCjx6ODs4Cg+lGqUSuQm2j/4jhhjdEhQIF8BpZI=,tag:CzQS65MCba3+X7cIewf3jg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/edolstra-summer-email-address.umbriel
+++ b/non-critical-infra/secrets/edolstra-summer-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:1If0PoaPxK+sJtOAuf6PQb36OmqfZEP5GQ==,iv:riQ8eyLgDqncfveonjbtYA1/1LZP4vbnS5NOUc/kEAw=,tag:QKMOE2Ys+AHB2E3cZDfnGg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2WDJ2SzRWNDV3R1hjQjVj\ndVFnc3dVRVFlUFZNZkFmdThkZ1QxRTFEOXg0ClptcGJHdHhHQS9wMncrdDZZcDZn\naGF6RlNoWEFrc1ovT2tYY0I0Nit4NDgKLS0tIGkrMmloYmt2OHByMWxocXdPSytj\nLzBNL1dnQUpDOWhMSHIvZDh1Z2xVNkUK5tzxrjBCTTBPGqUxGKeQY+FSseKLens9\nJvIXDhWAFkC8xJLr8D+/BGZRFZIQEbk/5hOLv0bsjc/no7Wrs6Zlzw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRlpvSWc2OHNJWE85RStN\nUHFGazNnd0wxZWN5c2hRL3lJSFdDNENBSlRvCi8xRk8yOGE1WHdwM0VsdG0yOUhk\nMVRSK2tQZXFYRGtibHd2NGNIZkVsd0UKLS0tIEpWb3BNNDQrV3RJNzNlY0Q2Q21I\nZHlvdUptRzk3c3FnNmFEVnFSdVc3bG8KmncYZ8jB9sPR0pC+OXoBo3j/1bitzQjH\n3fAe5a0yru/LJxWloaCgD1ipY/QAePRWrL4B3PjDp4J9Wzzy1KfMRw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1SWk2d0VDb3gzakFBS1Q3\ndWpGK2RDS1RuejM4VXNlTDZSWXYrWGxhZHk4CjI1UzBXcE5KenV3dWNTOGZTMEtt\nMUwvZEUvc0JET05QRVNzMC9FQkVEWVkKLS0tIFRNaHlKdWF2ZE1XcHJQY2JFOHlF\nZXcxbXJTNllITTNkbkFpVVBBc1JTd1EKB/3xLQcgdBejEQWI0YwdoYhCUsh5HiYd\nd1bn6Y15kOHGbhjNH8pwhuRN0sJZSfd5PqWoMdF8X8d0oMUcLH4PCw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:28Z",
+		"mac": "ENC[AES256_GCM,data:iCF8Wh4FcWtAl26fNUFQn7cduq1R+AAzfOV4SjXC3MC281h1Q9PxIcyXkw7gGydTpriLn2GDyN6mFFayqhfygGN98on7DcfUMEWwULOTa/6NhlYU5+q8jVgHtWXuNzc9yfVYssfkb8rM44rVnDzIfevlJ+3yB8s5MifgiOHz6Wc=,iv:Ge2YkGE+YBIKDK/mhW6fnvMY/GPZQHv/lpw+nbpK/HQ=,tag:3uJ0+aBvOhjyH8IL8XfgBA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/eljamm-email-address.umbriel
+++ b/non-critical-infra/secrets/eljamm-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Jr/iM/umH7KNXUVwlcz+FG11aoZqtzY1OwrK,iv:nDSevi0R1uQr0GtyK3N/JzkPBA0P3vWXo+aotA7ZXzQ=,tag:pr/sGuqsPB7o7Z/2hOh5xw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByb2I2ZlpOaXcxVng1U2N3\ndUhEQlRNMGxUQSszN1RUZlU4dE8yVjFyVzB3CkJTQ21VUXQxTWtwNHlLT2w4ZENJ\nakV0NXhXd1piNzBIZ3h2OXovR21IMU0KLS0tIC9ZclY2NWNzUE9SWnVQVkhzWmxR\nSEo3aTVnSWp4TUpLb0xvUkNJeUN5dEkKUpoG8QfHNIPQUbbzXunDPbXFXLJ3s687\nqpezYKPuCPGV+rVG0KB4qIyK1bY6DrGBUDmi1lir50afn0VZz91U9g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyWml5ZEtpeGRhbVIxNG9a\nOVYvRUJmVmZERFpRempJT2lwandrV2pvc2dBCldxR3dodHlCS3RkNlRBUnRXZHk0\nNXhwRC9xZVNKVTRaWHZBalF3NFRISHcKLS0tIFVndW1vTmE0ZjVtZ1BsSUVGaXly\nV1gxNEJub0M3ZUdobmtTT3JGQ202WmsKqveesr/zVsXxKZ5fPrLadE46orR62sEb\nebS3ogzekZzMaGbfmdvCGdMmVVBMtmTS5Z5bXQA2PmZ0STtNdXTz6A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGbUgwbDRQNTN2Mk9sY0dW\nYmp1anpXRmZGMW5lYWNqNmphaFl3VnlySndnCmdaYTB5dFdaT2xCNkh5a0Mwbk4v\ndWc2TG9iZlNUM3BKcUJPVk16ZkNLVUEKLS0tIHlycTUxZ0x6QmQ0aFBZeDZLQzVJ\nekR1UkRNQVVqZFJ5U1hENGk5bHF2YW8KmWog4ncsOI+PG8cQ5xs9Su1bnyod81Ay\nctuRV7aTJbI7vo+UeNFFu0I25sNeK5n3ehiYmaZg5DiGQtTc7xTqqQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:07Z",
+		"mac": "ENC[AES256_GCM,data:8Gj8Ns4zhsS/wZzpCHhlbXQ3kxcAsx00saGdPFzwDolwDpedQFYWLrjn7ePjTvOKYe/11Fl2I62MaRWNXnHdTNR/tBbFVKMMRmBBCOVaUILOHYIQK7eFS+vuXSIwXng0mAcHbxf5wH7l+37+KOw6F4kLoFLhUtD6pMXtOhzEHrw=,iv:1A9aTfOc0HkOKMazsrScdrByXCHkUyOT4KTHyCn9bWI=,tag:lc1gMPQXXj4BBpLBBnq19w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/erethon-email-address.umbriel
+++ b/non-critical-infra/secrets/erethon-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:8wz3IgHF3v8kx/fUgAvzU7g=,iv:SzwxjbwdVZKSK/RPbfnqjYdz/w/pCn+KhFZCuJNaoi4=,tag:0081LfNklhDZrsQWTG7i+Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2RnpoQUZvNFR5UGtZdlcr\nMVozdlJucnlLMlp0QnRVUjh1dXlBa0JUNDJvCnBiN0thQ1ZCekExTm5BY2JjNXZX\nUEw5dmpxejU0MEZuUGNxaFZuZlBnek0KLS0tIHZsbkxKYUJWcnYxeG8xOUtpQ1Vt\nNHJJdGJhVUNkWTJjSGNRM2liaHhpWmsKC2ULJjq6AGxHYio4kjH+Cdm7TFjNe/cw\ntPBevm14+mGjIJIFIzKmDktXcK/6j7Lsjtw6k+9y4s4QKcAA3pDo1Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5UkxUYmVlZmlRaUV1MmFN\ndkxCWWhqYUNoQkFFYUNOL0cycHJhK3RzejBrCndlQ3gySTMxa293ZVk0bW9SVXpy\ndTBrUTUzVGdPSStjYWV5USsyTEFZMW8KLS0tIGNwVnhVcms2ditRcDZ6WnJBeDRu\nVUtyWUo4bDZwMjkyUm1KM0IwWFViSEEKp0jRM7Rh38lcbdW9mAnNMyoibeQKX3k6\nAGBefzGA2ueJrvMdz8DCUzAKaTNJRqPgzmWBWw9s9WSxFrRNTrza6g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDTG9Dc3llMmRFUUgraHNs\ncmkwY3ppbjBMa0N3NXN0Wk8rWTZKWkVSMG13CmRCelVHbk1xa1JxSVpQU1BXdlQy\nZFhZbmlKTWNtR1NvVlZWUlh5NXRjbmcKLS0tIHNmbmIvaUQ4aVBaS2FRMnBKT1V6\nek55RUhsWFdqcjNRRmVjQjBFMlpCeG8KRiLrWjJj0tnDJk0vVFjt+yufUbLF6Iih\njXouClY0ufpCx6orVpRbfC117dutM351zF3rM7fhK4SlEVNNAAl/CA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:10Z",
+		"mac": "ENC[AES256_GCM,data:BZO4mI7U1rxErYtZC1q9EGgTzkG2rmxmGDWtht1jAIVn29YOaG5n2vKHb0n2h1ymxKCffJ1sSynU3PzNNMskJmyw4ZGG9bechMf/gPhBRNio0UckUtNHrPfEOKWiaGJnIe0vDa3vfPy3OCdG6TE9YFz4upkixJNQifZfghAtvAI=,iv:9jBDuCUFbPogugEhgI1VtpMIa603M3AFjqCX1N/iTOY=,tag:Eb1krdS7s0A9DZKmHKvKWA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/erictapen-email-address.umbriel
+++ b/non-critical-infra/secrets/erictapen-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:jlZU+cghyHVJau82xDsbNE7OfuJgsQ==,iv:X5Dr4074MX79EVYc1Pd/xZ1oaJjMQ/T2hcv5vXB+63o=,tag:+d0tLDc3spMCrJkZ2g85Nw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyeldNODFNU211WFVrSU5O\nUjdFbUtOblBUUUlQNzUzSzRBR2t1djMwQ1dVCnVnclRubzBaSWhXaGZha1UvdjZQ\nYmsvSkNVVVVFK2I0T3FBNER4bW16VmcKLS0tIG9ISEZycnB5dXVvc216NGdkUWo0\nNG5xZmVIcHNxN1ZMaVh6SnNzS0Zhb1kK6YZUsv3fetyW6jtgbUIZkzVmXcVZce+z\nwvxuPlV3qNEtV2+oOLlLzZgB1RFxhDS4sQu1ya+l9OLez5nRnOqC4Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNcWcrSUU2c2NNQy8ybnRa\neFZDUVh4cTVQaElCd05hcWNzT1JFVjRKWWdvCkVjeHFHa1JpbGxPYTROOXNOa2Ez\nays2MWs5c0hiWjBiaitnREtKTUpKWlEKLS0tIHJSK2IwY0pJb21UU0NtM0tPb1g5\ndGM3NHh0T1kwYnh1by9jZ3hnNXQyUXMKP1HE1msgKFLpc75zGvcZhwIAspMByupJ\nmv9tzpne+YAnh0/pG9rpP1gjpv5xwi4LlmXh/XAVcpCYD1G+xcsWpg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNWmFTL0UrczljdmJpRmor\nZzdZSEM0SE8wWlVSZHVMZnRnUkNrMlBZTEZrCkJpWnpWS3JVdGErN1NKR2R4OUk1\nSU5HWE82aFVibDk3T1kyeStRUGt3MW8KLS0tIDR1ZS9WVmdUa2tHbERUNXRXT2wy\naW5lLzZiRXJ2cUdhNHk5b2tMaSt3ZUkKfzmPIe/+rcU3uzyGavi7ni807qn9kcfm\nGM6EkgkWGfvzSJBPolmLwJKaCE50SBFOiAUDoIIw862VVAFId/1ZLw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:07Z",
+		"mac": "ENC[AES256_GCM,data:W9l/3ka5y4ZnUUPmW7dn6JvsQezkOzFQwK4s5dGVDybOCCJUZ4D7n8IeyjyETNgaaCmYTS5Hgba5Jl8/oVOiDf7slvNExgeLTKnlvOz2UGX74OiIYWAzWKvLXevhGnP4iomWeroelyV3ExDog5CtS53yHIfehTp7erl9fgEZlEo=,iv:nCHstGe1okaJbxXDFqQm1tJzcIkhTFvn/OIRUwiO7Ag=,tag:ospYuz4anLsn+9gfTYVFOQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/fpletz-email-address.umbriel
+++ b/non-critical-infra/secrets/fpletz-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:TwKe6eoIQX2ULbFrmdAGo9W2JrLxBjkD,iv:BWrFiEWm+53aNYLpUt7BCpFtP3fU8jD1F0i/dUeHxX0=,tag:9nT3daGDNYPmVSoP1t8lCA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0blhBNEFHSkdOdDhxcDR4\nUWEzYzNWS3BOUWMySjduYnN5NEJ3ZkJ4Y2d3CkdqMGdaQVRORjRQZjNqSUVZZnRv\ncTdMSXZvTWhJMEVVY2U0UXFRRXJuOXcKLS0tIE5tQi9QeGdhM2NuVUMyR2lQaWln\na0VNNWRjWDRSZUNoWXVrdVFjUDZMM2sKjIOFwxgh2TGVD/dqYLvZOGEsxrXqc4Lr\nMp4BgvX31LW8TlBJHZ01jj4du2ZRO1gS8JIVaBS7c+9O1CNU0xPEpQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3MFplZW1mcVNCcVpuWlI5\nN21vWTFrU2hzWFRYTHRlTWlnV05WNTArMHdBCnZ0YTVTeG5NUWVGRnFkQ1ZaTlJO\nOVQ0Z3NwMktFRE83NC9uK2F2UHBRc00KLS0tIDQzeTJaTHU0ZE50MWNxZU1lRTY4\ndWdoYndjSWdSdVpDVmN5a2NuZGVtN28KqYBSE0VWvSJfyEYhav4jEtidpzxTMvD+\njidc4w4ohcKTTQcwqdjErgnN9SxmvD3mKwQkpZNMaeIOifbJ4Ft2eA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZM2JsQ3BVU3h5U1ZZNnBt\nb3NEbWtrajhLT29pS2tXMktUYm1LK3VtN0g0CmtvbEZlU3Yyam42TVZlNmEvSHhz\ndzcvTHV1VTgyazBVdEcya3N1Z2kvamMKLS0tIEZwdjBjUENFTE1lOWU3THVwQzUr\nbS9ob3prT245OHJUQzVCajdqaW11ZzgKWMtJCLGgVOZsApE+IITmxkzIKRSyvj/8\nH1C5rFYDx7oxJhk1i3s3P8r6at4EwbPgVIMzv3jHsKNJPq3IBk0WsQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:25Z",
+		"mac": "ENC[AES256_GCM,data:dsUwWqUS/s3212ZMWB/mh7vLiJX2WuCvqbrjF2Frm08E/0lDoZwKPchZyxzm2sI2HrNEwAdrssKPrqx6WSdG120RCsAWvmu94ci3zM4cELi3sIrs5LRUCvCKAQl6Ag/pDLYb+82KfW1sjU9c3KEPeNUQ3kw0C1T7hw2XkKhFtPI=,iv:KWaRRwxA+bH9LOrLY1ujggnqYigTSci/q3CphO3+dEc=,tag:ODLtvkN/LuTg97wJ5qBn3A==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/fricklerhandwerk-email-address.umbriel
+++ b/non-critical-infra/secrets/fricklerhandwerk-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:7zputbXLkUSid1C7L2Jw6SOae6A6,iv:5X2hARj2o/fqTn5p06vf8+TRxveocxRRPBv04v4cmZE=,tag:ZTmAaepK96qFIkX7Urvz2g==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByeVpzYVFZTExBUFdhSEcw\nNG9aS3l6M1V3N0tIek1FZUtsZUdwUWtnVGlzCnJSZjZ1MjRBczVEUFU1UHhHTHpE\nUFhickxYRyt4aEtnTGRJd3FMY2pwTmsKLS0tIHVMUGluMG5uQi9DSk5manRCaWlD\nM09pSWhxNTBvcUMrNG5MRGxyL0J4ZXcKihew1XLJI0gkrGPqAkFFjRs8rp9Kdrke\nKKhKfp2KJ5YLzLxgfKLE9XcZCIFP1gaVYrsaIvspbK1lUhwLJY3sGg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVVlRRcFpIb0dJQTdhcGZs\nUTkySkVOakhXSCtuZC9QQzY3WjYwR21McEFBCnpVLy9zU3QrODdZdk5JVzFaNlZD\nR052TDBGdlRFdlhmUUZHalpnUEZONUUKLS0tIFhyTThtSnhkVXUwdlZCVjJFZC9h\nRkZNUG1idG9QVGxZOVJiMVdNQ2t2UmsKkvX85F+Bxno/qAh4Xkewl8a+3NXlLwk7\nXfc00i9ZCHql2+SMAAxItBeuJH4oSy4WjtNrWZue+cCTAnduMdHf8w==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkY2hjd1RGTGJDWmNaWmZH\ndnFIYWhSQmtHQk03U2JCR2kxakxXWVkwS1djCnpPWXQ3b3NYMnlUM1JaZitOS2ty\nLzM0WWdkOG1uYytXUkRwUDBkalJ2N1EKLS0tIElzZnRpR1NDdnJzMFVPZnF6QUdI\nWXJnMmtlUy9TM0dtZHppUHBFU1RxaTAKbHRBdwPd/955ddkpvLIpZHhDmOWeB0ad\nVIXD2hJh+vWciHwbwXjq5Mfgmw1Xb4ggGcKRp5HMeqO56cG4VhdQBA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:05Z",
+		"mac": "ENC[AES256_GCM,data:10rO5oL1zsQgxTZbPUC6cucFCISZTfMnPt5V+E4xaJIuxUUymBPIy9CaAdauspDKUdPtJZX2OZk0Bk9ygOAd5hWzu6vYYpLqIaAsme5C1h7+ZIUv2KIjKP6DLYckbD6O4ARpi68t0Yg/iDl3APHGOthlClkxr+U2E3n6eoo68dw=,iv:p3HbBwySvb3yGgVR1QdQiBT41/6sSNyvVoNFQfn5Cws=,tag:NYWLHkwQ1OWFgFKq0vRukA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/garbas-email-address.umbriel
+++ b/non-critical-infra/secrets/garbas-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:o0T4GFt8UPgUCr+BZg==,iv:ltwjum64fA8zmucLq/chybdhpj/cz1iN6fX7xiDowDQ=,tag:a+i3f5GaNzShnde2EVtuIg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyc01ZeTNMaHdYYTNWQ2FB\nSkx3QTFtK2N5WTV6cmwydEVXcGIzY1pYc25vCkhmQ1l2cXpYSXBnd2VqZ29lKzJD\nZ2ZpVjV2RzNNN1Q4cVNQbHBPSU13Z0EKLS0tIGdEN2VOeUxwWVNZcGIyQVRIcmF4\nUi9TTklGZG4zcDRJWWtXSjhRbk4yZ0EKnzZmGnSEJqcSqNylOy+SWbZt0ariASU+\ncTjZuQ9a+2/yUdhsiYu+B9eTNOCJOqTbalUZ8GDrdxE55Cd+Dd0kBg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTytmU29mY052QU5BODZp\nOFNTKy9ncGtDYzFEK0NpWUl6MExtcGM0ZWc4ClYwN1QvUStZQzlRcEd5UTNKN1ZY\nVHF4VTRISzROY3NLWk93VHlQTEp1dDQKLS0tIDZYM29Bc1pMYkRJUEtWclBuVzdD\nWUYvamRrTHJyelRVejY4M2JmVm9rY2sKP2Fn8ew9nb1MkxJjOhXcRxM71s3sU+N5\nktWmmPpxA3EyezBBw/Zg21kJpnBEy2+n2fBPMgvrQJBezWUMMoXXZQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvSHlBRkljd2FTV0tRQ0tX\nRlltT2xSL0lRUDZneVFkQ0FXUytzcTBEQjA0CmhHdHZEbWQ5WVdYalErTk9QelhS\nY0FoVEpSblR5TEZ4elpIakRwekhDTW8KLS0tIG8rS2Q0NURhOE1wTGtHYTdGUDBK\neTVsUnpxUFdPcXVPWmp4NWROZWM4K3MKkOmIWIzX8Fgz15Y3pFbIKmiVpgxwSFBZ\nsGwsVNx/mUrHxzK8DWoy84+k56P6yacCPupecNMgQzH2XCGGOvJoOQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:35Z",
+		"mac": "ENC[AES256_GCM,data:b2xymX4mwtBhq9Bm5gDL9T4STmi03gpkPmr5+wIHNgQWxNim6hI4C6PNhdeH++eBrf/EhinTbwrGUCMsZaQQsHqsELzYWym+d3jeZy5X90Q3cf9pzhAgEzLcOkmD6wttGUGuQlVXvHCYhkD8ZHfZXIRWcvO8TVGDP77CpRi9A7o=,iv:BEiB/lLuuwy3ADwK1OmZFnBoBYJzL6weZAkf1G+ctTo=,tag:tIBMhsHvESDYANiSvvNnCg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/gytis-ivaskevicius-email-address.umbriel
+++ b/non-critical-infra/secrets/gytis-ivaskevicius-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:KPLaBfNvjztzL5U=,iv:0cZyK7BFf+nqzoRQtXxc4ku7Iv26BJku3NOLJpZSzf8=,tag:uNJOGgGStxEuFH2RrEc7Kg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIUHFQNTI3NnExUmRydnNC\nNVNjMi9hczZ3U0RKa05ySGtTWDBoOU15blY0CkY2L1BJak5BZzBvNTJhbDVFTjRX\nb2NVY0YxVVhEbTBjSC9vQjIxWnlELzQKLS0tIFF2TlJKWXAvek41Nlo3RnAvWlNL\nanYxM0Fld1ZjYVhwU3VnUGZ3ZmNnSEUKOZHShXrCREAIb17qr+W/MAWAvuRmsEBR\n70hr+QKKMXZPGb6+565d3MulUvPRgaDOOZuO9rXGjVwT/Q1Y8g6ndQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBWVo0VlVsQzBTTENJUmZN\nMWszSHlrdWVGc2U5YTZzSnVROHp2UHBDMkF3CndKbUhWTnZ2RC9rZ3lydmFYVmM4\nQlQ3RFlrbDZ6czR2dHc5cERhVzZtejQKLS0tIG5VTkNGR0ZBYkhCUVcwUlRIaW1V\nSmx1aFI0TmY5MWorMGJUOE5lTHdpdzQKdUEcUdjpU8lWYFaFmQyGFzFct1/x3rki\nBh5MYqQVpmMDdLWq8V4eRQjnooDga7UbfwH3AxyiU3FYDCWXQvl4cw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtbW0xUVl5QXJ2bmdueTNN\ndHFZUGdjU1RPMkVBeVYyeWdrY3NHdVZwZ21zClNaaWRmYWkxcWllQXlnYlFlcndx\nQ2FGTzRBcG02KzVvbHlVZDYvN29mNm8KLS0tIHkrYkxOblFkQ2o5S1BwV1NxOFZ6\nR3dDNWVVREtZeG9KRm9VN0kzQlpmeDAKl4xEYJ7Bkt2fURIqle0KlOaRtGca8ViH\nAx0MUFgBlJswXjpaKg0+Y3xMOq2+uivDFGpj6ozK3es3rT8XIf4LLw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:31Z",
+		"mac": "ENC[AES256_GCM,data:AXzPMxNGZmFIf7nMaGQVjGsvO1HZkDvRmh8KTssz28vVxJ//K+wa7iK+dTREFANqKM6JBoakBk3HDdcNnzuMCeYx4SVcto1iVqYnuhWElOlIJC70cb0rrjR8RIY9xriHUuoqijPUyHCI21M+qo5+70jLXOgslG3bxqxMcg85dk4=,iv:wlwGI0afog+x0M8DlwrE3sfngOCKwQq0Qz0g7LOxR94=,tag:LwSJIBu6SW7pLWSSBRdGTw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/idabzo-email-address.umbriel
+++ b/non-critical-infra/secrets/idabzo-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:xfTE8CfwS0rZGBIlxcIONwPprL2h,iv:vtJ+uWpxDUMKw7wFK4h/zKEJNBVa2xgh8Qrq5zswrAA=,tag:xVnZhyEWGixss4FCJvSrRQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTaWxvNFFhSnN6MlBQUkJR\nTVlXRkthcCtaWUh3MU9ncVFydWJzMTlxOW53CjB6UmdsS1FUc2xDaDZwbUdSWjFr\nTFU0YUtEWG1mVVViem4vMHJiVVY1MzQKLS0tIGduOGlhbHFGL29McTdsSkp0bWox\nU1NvcVNkVlo5UWdGdm1UakFZZWFRSmMKwBJXmyrOaIC1dGHsR2swAJ6sDhHjh8Hx\n+hkJrHmTTekx/7agIzevNVVY+QES47dz5k3aE9y+sZM3zhnAEkm9mg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGTkVDNk9Ob3dPbG9kQ1Rn\nbVZZcmE5VXl1SVdOY2M2R3E1T0VoeDZRVFRnCjZMWjZGZVJ4MEhjUGhmSVhOOHpn\nbE92b3R3VllESVlLTm15Mktub29YTHMKLS0tIHE1MWs1SUhtSGxpcXRkYmgvS2Fp\nR1JBZCszcEptZTh2dEVTU01sTTloUVEKt5loGLT7+q473yYllnV+gBEFqXBdUkPG\ntlTjDCd9a40MbucGIwJ2ZxfoaYSURAcQcBSn0IM6BpLuQb2XrGpZzQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZlppVVliSXZVMXhqZ2xk\nQWRPcmk1K1J3cjR3RnYzaVhBRzNWSGJDajNFCi9sTnJ0VC8veTE3cTZ5QllaSWh1\na0IxejA1T1BxTkJDR2IxQUJXZ2YyOHMKLS0tIHJEQlAvaHJYQU5nSGE3cmxsTXZh\nT0xjWWc1OE5qM0wyUkwvbkxCQmdmREUKu8R3NB6Lyy74Rx3KNfYbHlR0rO4SR69K\ngmOId0yCornVzNH+wn81w5Vo+ENRFtL7k2kwzpSo27BmX80ZtQRPlA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:19Z",
+		"mac": "ENC[AES256_GCM,data:7rr2FFpYf5Um9gDAd1X+4S3EbL6Bl8vHPEsjbfyw3mp8KAt4bSi5DTGdZSri7HMcIsk6ZFbnWkRqMRFyMCzgxfwb/09JO44eOIYfgPPv1Br8srlXLzf30EzYucUEDch/0Iu2tbq3NZ4z5OfGiXphipOEhV8jjOxtKe8aSjylzP4=,iv:gi55gN0plG/1u04ukPqn+HR3zyvlF3nWzQoSaez7tq0=,tag:JJKjm1hbTE24hLWp98syrg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/imincik-email-address.umbriel
+++ b/non-critical-infra/secrets/imincik-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:EKQBvgYqD8hauv7Kb8Nq7HEume0p,iv:nM8yunkGwxoItpWp9WJp5hlYDvpk3GSCaIKdKtcbBNI=,tag:Caj0B318poMBlC4ZUDDjNg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTL0hCVkhteWVPTkR5enZq\ndXVEOW5vamNKUHc5Q1ZDUitKNlhRdWtVT25FCmpRcWtPTDdWblFvblhudG9JMTRB\nUjViSWdDMUE1MFdRWVhGRTlrZVZkWUkKLS0tIDBWSmJFZGJydmJDQzJFNG9PWmxu\nTk14SUN3ZGtudXVyRHV4cjdYVS84Qm8KPOtB2MC+FriDaZej+CBw8DdcqyvlGsbX\nPn46wTTtU8r4gJS5cdREH+NplmgfI3ehXPwBOzKG7VtWK5hf7oc5lg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIcWRPTll1U0NPd1YxQkRJ\nMGFWNkcza3dvUWJTNDVFVnFjaDlQeHJyZm5vCkFtTDhZc2xEelI3VmwrOHdITmtt\nREF6bFltSzlqZEplUDh2NXlEU3hVWFkKLS0tIEVESW1vLzB2SW01cWMvYm50Zmln\nMEhtTE40OTdlOUZJSk5VWmlHVTRhZEUKnQbAGy0X5e3DMlifdayyD+2mu26wzWW2\nCR7wR5OLTIf/92zLb5BVvBZXXwhOFziQkNAOtebonVYImJeNIkfO3w==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUjVYTFUxOUtmWGdhTXMy\nYkJvdEJTckI2aGxQMGhteWpPaHRtU0E5bTJ3CkVmNXZKbXhzQVZaL0tjQWFSOVZ0\nU1dvYzVaRThmdkJDVkpSRXpoSmZIcUUKLS0tIFNMeGpJb0NybVdlZ25IUWhuWVdr\nTXlTOHhzbUVhSTYwY0FMY2krN1F4M1UKMNM1ItQKHzF1zBeCwG2A0qGi3iJ9H+GW\nzYmizuUM4UKFarNxxJvpDPz/MQh18436y06XRnUpBKLEMZBqUaOSrQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:10Z",
+		"mac": "ENC[AES256_GCM,data:bjdSQBKpwUHWHT1N3vw24XnyUzByILnov88tly5NbatTnzObM/Dz8i90OUGfo7gZgzlUuilvn7VjKkXsvFIafitBScv7+cWYUHT130hfSUQGD8KEdv2OWbpaWBdUOa6i0HX9k2ovvPAJHMAbDRo7IJviq4Mc4AGxjJdLL8+vO+U=,iv:PXXnocj0/x7xfmCY8XgvcjrAaW+LGwOqeEr4Fm0NVnU=,tag:GUekRI6yio6eu+dKALPhXg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/infinisil-email-address.umbriel
+++ b/non-critical-infra/secrets/infinisil-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:g/NztGMiw6S5VlGl8R/v2puyS0WY,iv:RUcw9ErUfyg/IrfmFsCjRiqCqYIPhAPitzvzJ09MG+c=,tag:RNUJATI6hnkOHSyFNtFNSw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSckxRblVLVmc5OGx3ajFl\nZ3V2bjM5LzRhTDVDVEx1U0VyUnlzd2xyZEEwCjFTMDFtdzU1aittbkZyYnQwQ1FC\nWnpJL1N6NUN4UTlrMWZPQktDdFBJbUEKLS0tIENHa2E5NFZsdzlxU1hkT0dKUmI2\nRDAwVWp2Vlo4d2FUVjVWamtjV1c3QncK9zjkHKvFm9z+fxBrMa8H/L8pFoYoICgs\nTPRK3wxwZZEhINnbFYAffxcTSEuvKSy3yVnxa0Q/rOZJuJcpsuBa6A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGbTNUR1NrMDBPdCtLS3RQ\nb0VBajRBVzJWWWRYRGkxdzhWNDZrRXN0QlZNClBUczBZL1A0ZnR1RytnRWw0RUpQ\nS000RHhxQ29BUTFrczJkSHA1WnJwZGsKLS0tIFNBWVFHSGE0NEJTWXJOdUVtekhT\nb1p5UmVZbnFDeEZHRXA2MGsxc0xYUGsKvFOtn4zjnQwQnQU8xFVvuc0srnTHZ1zJ\nZClsCTZi6GB/KnSGDoH0uEG3GW6pN2XeTyVpkbWM7imcslR7HNi8nQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMXYzMXRsdVI5aktwdkNn\nL3NySHFiWkpSTmxCUDVYeXc2RzdCOG4rQ0NrCjFPSDFsWFBlcTlSM3ZIS3J5K1hF\nVm5yYjNyNW14R1JpNFUvd1RSZHVTM1kKLS0tIDU4MnpCcUFSbzlVb0owbWdURERR\naTFDaERxRDhQd2c0VDlsTWlrMkJSWTgKZbIRxrhupxHpremBum8hVr7nbP2vVGS9\nw92f+43HDANvrc+nN+WwRSVS6YXybPDrnWhfBeZhcofa5pyB29L0DA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:54Z",
+		"mac": "ENC[AES256_GCM,data:DDpX70GDNDHHYgRRP6GtKwvE+1TEA7sXuupQO+uHQ4DtWSI4yyeDCaRduXZUDX6W4OXkz45cfPkFJKw0plckEsqCHgaO3hX6ub13bfCFHVsxXXXhFKV+Hd++3JBqCbbwQL2S1VLhuZXAua47bPGIt3f5ov5gcxmCzYniEtXan9I=,iv:9jwrG92UNxNdhIkW9PfbLX4rnL/kd5R6MaE+l0Z8ago=,tag:ZO1pJKO6YaUzwE3cn4r5+w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/infinisil-nixcon-email-address.umbriel
+++ b/non-critical-infra/secrets/infinisil-nixcon-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:bwvfsHzw7jgReKI8uRvAdUusxIs=,iv:o9QOwug8Ewlv2K4uiO1NxzTWJUenlgaZD3TIe0rc6To=,tag:B4vRwFbEWZzTNHRT6L12dQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZUE4WURrL3NMdzBNNndM\ndVcyamEwblRuV1hXV3RGSlpxdWJFYlk4aEZZCjI1S3pOazVSeE91aTZwNGF5a1VQ\nVHp4YnVaOGFXTWpQNkFPMUVZdTBPSUEKLS0tIDFUenlNNDlQQXNiL2ZNVkR4VWxs\neUMrai90d3dLL1JjNXZtZ2Q3R1B5TzAKgtRotcPxCYnLchw9rD57droCcmP3mQDJ\nsVDaJ3gP54NgccmMjQ4ggFdd6BVvDq4PFNSNyGxo5E/mMUQKMDfWtA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzTTFIcUIyd3crbXkrOWF3\nMGpGbVpHcW5LMkhPbHhqdXBsRmk3VWNZZHpNCnl1SFZnV0xINmh5N29tdUFVTi94\nSmhGZjNIbCtsSjVhTjNyWGtseFo1VFEKLS0tIElnWGIvcGkwYzFwUkpQNVVvQlRJ\nQjhlRjNIMTBtblRRaWJuNU9kL1JtS1UKDHKn0DOUNGxeYWTWMko8vlbZ9Xf6ozJ7\nNt7fMt99FPDbqRV5OEESUIjD4/x0CV2sDG6vp5dOBAu59B6WMmE5RQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYaFAvUFErQzlZRHIxNlVR\nbW5JeHpaNkdlQVBoOXpYNWJqTW5TYzU1d1djCm1SYjZOVDJSZWVuWmNoQm5JOW9O\nT0dxdTE5d1ZYZ2d5QUxBYjErNEQ5VmcKLS0tIHMzbDdrQ2dRL21veFFTY3BWbE0z\nWWhMdnFMbEgvSitnVHNrb3k4U2JDNmcKXnNto4P0cZV8ovGP/QP24OSZkY7IL3/O\n9+U+zcIGs8e3kca0ELA7j1E5nCEGNUyTFKOB9B2zOu46HGkJ6YTR2Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:14Z",
+		"mac": "ENC[AES256_GCM,data:SRevXkFgRtpHtRmzqpT8+4a6WvbR4H6/gmImJ4LTmNi0Vm65Nb0Z8k2QAZpzyl2DWyhLDxZ4cDD6w+OMSdZ16ERweyIucP0Wm1U+GlwsEq5KdkR6UuQqqnX/lONUh7rUuJ++4k1EUTbTTQdkRg/npJPanRzS0Am/0Jd66B3WL4M=,iv:KD1QTsGZvSzoh+u+1tifLu34E2S8FQhno7C74p7cxtI=,tag:Lxid7jtazSTT8OFkNzcA9w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/john-rodewald-email-address.umbriel
+++ b/non-critical-infra/secrets/john-rodewald-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Vc7XQ+0U85wa6J10lcVDMbLabmmTiQ==,iv:fzXxoy/ZohNY5pR4Y2qYWa3WVLo18BNOLjE1w+dAAGI=,tag:DM3n88oe7QW0tZJXtEx4/A==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRRkRDc2c5Uzk2cytmVE1I\nd2FNU1M3QmR1VVlEa3FSWlMrd3I5dExsMzE0CldtWHkvNTNvL1NSeEhhWkVPakQz\nVUFjTllxUkhFVnpTejhGay9MWmcvcmMKLS0tIHlNbFJBTDNlblhBbCtncnJpVmVQ\nZzRqa2JyRHY0WVhVcTZIaE5QTU01VlUK6TL0Byz4UJeHEvoHXWb6U/y57J+o4p7C\nHPFxM/R6Ib1QUOPxukYojNcWOFV/BiMxLUp64CMibHkksHYg3bDGJg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOT1BXVE1nc3JZcld4NEo5\nRFJHQkhhVFRjVThMMFl2d29hMFlvT0xSQ2s0ClBEL1VsLzkxOENGRnIzZVRJYTFy\nWHhBOTNPMmJKNHYwMXdGV0NMZjN3WDQKLS0tIExDUElrYS9mK3o3Wmpicis2Zkdi\nQmcrbzdRQ1pBM1BmQXRycEdRWEVTNEkKX5u4At0LukCBUZQOxvBXiVMw4dn2whVc\ne0eFDkGvi8my4yUCyYoUFaAq2orygIhv++Ih+mYRorK5RyaCBpwEXg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2RVRRMWNWODJnakZSZVpS\naHBhczhkaEkzN01QSEIzOFVueEozak04N1FrCjhDTlBrbHNyQjhqRCtua05vRHRn\nMHY0SVFpMFQ0bTFKY0lqdzB3djdwWEEKLS0tIHZVUldueGdLUG80cWoyeHB6KzRZ\nMnpEYkFyUWxQNlNJWk00bGFKck53REUKUBVnYeidyG/0NLOS4XrSiSfFtz6UHvk9\nInBHRCjsWCuyPKSvURKj1+XS01F/+mAPId98GHb75RPkqXhcu9bAcQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:11Z",
+		"mac": "ENC[AES256_GCM,data:ABgTUQLGRyjG/lq88CJG/f1liPvL6cUqJNaYmqxTmv+EffJR/1EWl19O41ZyFCFW3/eSPckaB9MXn/oRqUfd6pY5GZ9tqCVDoK82YZ1cMqnHU5b+2n9lEH+Kn7uqvVh604j0Bx4lCpSUZX6/pC4NgpKbZB28EOVo8ptnMUSn6KQ=,iv:UHgEnD8VUyOW0vUuVTKR61wHvdXXdQHeChDgq/MZxmM=,tag:IuO4AUtGk4FiXEcnQJs+3g==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/jtojnar-email-address.umbriel
+++ b/non-critical-infra/secrets/jtojnar-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:cAqOtDZSzehegRTVGpB6uT0=,iv:tk35P3Wpw2ikNBrjCiz1GYtzY+M+te2dxWpGpnJJNuM=,tag:aG7J4/pt7YcvYWRoizfUqw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6WDZJbGdmYXZRcTR6S2dW\nZWdpNXF5VUJBZjRlZTVHZGpoQWZER1VObGlrCnBud3BrWUF0ZC9tV003L0NCZjNz\nYnJGMHlEbzZraVBtb3FNWkxZNktYaEEKLS0tIHhBVyt3K1ZoeGNySzYxN3NCRElq\nTmtyZGxOM3NCVmFJa0JYd1BsYmFTODgKl4x/bqTTMNQaT/GLp5gD7B0a/orkCBva\nocYoYtouwdlcdseu7jPaXgIb2ooomziPLMwqbORicVOAitFRnvNbTA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvZlVjek0wOGdFT0NuaWM2\nRWVXSlFRdkU5N0RNVWYvK2hsYVRrMWt5OGhJCnlyd1FLd0t5MzdjVTg3RG83Z0dQ\ncXBPR2szdkFPalBBTHFaN1FRU3BtN0EKLS0tIHFxZkZBNFpZMXdYVk5lZENRYlg2\nTEJqcHJNM2dDNGtMYVozd0F3MmFZSUUKGZY9yHf3aKBK/+/jEsofhKNN4ypIy0C8\nOAGUiEQ0Hk/yw2B8kuBAARHQSK6vNIMTqMqMtW3OMQzZ3hMrnGk3Rw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZHhTTlRXZ0JWTENoeVRV\nZGRGSzVBYTQ4am40NzZQakI3YlVWWXhiMGdJCnYvYUg0QlNka0lmaDZXc2VqTDNN\nRTB5dXV5Z21hdUdtY2JXalhwa0pYTmMKLS0tIGJBRmRNRnlLck42ZTNieHMxcjRq\nY29YbmZFZU5PUlJHc3lOYTdyVkVhYkkKTWI4dUPYbpmQY/PYPHVWIA1io6VPZObr\naN0hyzy+3STWnGkd7z9zLVvJ9uUBAyGxSUmDQ8qKyYo+J8Fi7BaEow==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:28Z",
+		"mac": "ENC[AES256_GCM,data:6Jh1Xo6KHU8JWDXU9lkJHmYOuJkndvJ7bL8YFZbBNmctv+O0nLTsaxl74FHhxVqdDDS/5ujtldUnWs1syl/TZO5dKCuNOvOfyOM9CeVpX1jKb1qNVRf8SRlZ0HYHngGMo5b1/BM92hy9Y8OkOB4Vas9NamKr0XYopGrnlt9jEpQ=,iv:FXrTqftMdKZFPfc2jDduEgWlFz5KbRUgDgIBuZlqghg=,tag:GL3hxPdu0JS2DbwmoVqq9w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/kate-email-address.umbriel
+++ b/non-critical-infra/secrets/kate-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:fmyrFIpAvRHBeAyQaewlt7331qUrqg==,iv:Dh0soNrOhU4ZP2lmNp2DJZl88yqvOK4Ivu/4dLjFYUg=,tag:KbVXL0E7wZ4Ezs+W2ObZYQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDeEZNSGlybjNtQ2hZajNy\ncURLQklBSlJoWWw1d3NDRmxFYjl0MUZvdlZBCnR3QnNmSG5qZEw1ak1ad0FUdEVS\nelE4NTBLV3JjS1pjWUhBVUEveC8rSE0KLS0tICt4MlpvQVlmMVM1bytNbkRRYmNV\ndjJhTC92ZHJmcG9ZdUxMNUlsMUtkaXMK1fzlUh1F23trAcSWIYop3k0jTS5zIXMn\nT+rlzjZeTvSCwR5whpGLkKcW9IxEvvk0YQ4WkF/rgRxgqdOVDGqcPA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYNmRFNE81aGFGSG1OTVFJ\nbEFBOUpYWCtLbmQvZDV3dEQ0YlRRdXNIclZvCnI3K3ZKOXd1K1JYcCtLT2x6cmNJ\nSEF5dmlhRHB4OXFWbjF5QVNyNWpNc0kKLS0tIFFYOEloV3g2ZFExOVo4MVF6cDQz\naDNRSHZrNXl6MVBmc0lOMmJnREd4azAKB5Cus+7lhFVRLUn3QXQNMBh2m2gnbqk0\nDtuQtNEv1BHxut2GQ/W7dmRYlCLFwF3RPfEdvNwHIsgVcDOx4TZZDA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QS90ZFNHUHZUeVZKdUV3\nZXNBTnAxWUY5RHFSUnlEQVBxSWRoc09VNUhjClZmTEFUV01iV0hFREZGUVc1eGw5\nbXNpREpGU2N3a2cxUUZGSlFNaGI0N1UKLS0tIHZNTXF6VTl0VTIxa2l3RFFudTBB\nMTB1d1ljQklGWXZTMWFXR0MvZVVTRncKmRI3OFYu/ALq57TacfVYls8LyscsdVLx\nROMkqvRNOhDWh776s+hp9uJQgNK7pXhBX5Ee2EAo7a6NZ1uLrh2O9Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:53Z",
+		"mac": "ENC[AES256_GCM,data:Hu54zQTTitSQr84kOAHQn7KeixF1lvtDHXKFqra9hFDEVTNSvf8zUfDa39WzeEB/aBCRjBND0RzCMEtFMpWVRIcxhYi/nW0L6Yfv9pjVgI0iYuo0W7qregRh9ipem1HH14JgLQxI19ZE4AFDNicMQWsAezNt17/JzVKrFFf/MMI=,iv:u1FhZiTxmMJXAxRyFdY3Wq0wzpyiq7RoUd2HtAab6pU=,tag:iRhYv+hggZd/4eQZIWu8bw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/lassulus-email-address.umbriel
+++ b/non-critical-infra/secrets/lassulus-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:nDMmn0o4dqZWIcSDhw==,iv:Fb1Sog/1Hzk7IpIYmq79a2Hi8xpgkX0ViU47aYLO/+c=,tag:TyHkRHWO/Ijtg1SdkWzKqg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVazl0NEFCZE5uTC9YS2lZ\nSjJSNzRUWG9heWNQTU96MTlSQ21zekI1T0cwClJ5VkFFb2tzUDJKVGozTnFUTGlS\nK0hKdmZkT3ZtVUorUXJ0L2MvYTMzVUUKLS0tIGd0WkZyUit0bWRzNDB5bWRUWE5E\ncmxYYW1OVHR4Y1QrOWpTSy9vc1pzcFkK5+qTmQSg0FO2WW/gP9EqAUQdZT9iFYEh\nX8IWMWnMlfE7eOI0PMax1AtBvISusyvbwTXfsmhRROcvyODKhQLvig==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYMGhHTWVwQ201OUpPVnVt\naVhVUmV5Q0FGNklLSGR5Sk5aL0JjYW9GMlZjClZ0cno3VlBIQnBkaWJTeGJMZVFP\nN3lTMUJGWnJwRlU0M3hrV1RwcUNaMlkKLS0tIGZPSlkwc0F6NEs5NXFvQUZGZHh2\naVBXK0F0YUprTHdhVDBNb05za0x1LzgKl/weC/O3ms3ccJH0aRwoxdmIRuTcmmki\nTr5/MLlRBegDwbU6jJVHUT+KEj9tBRpbduD7NjKGCYwdx3XHdHXDTg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhbE54Rk1mZTFBRFZxaFky\nNjZicnRCaVNSdjNKOFQzMENYRkJTdDNiTEhjCk9UVTNYZVh4aVdmNEtzMXZKcXY2\nbzhPak1FZWJ5NHlwUFpYSWNSZ085VmcKLS0tIFBUdlVzWllIQkl3Ukhpc0d5OEJ0\nMDRmRjNoK2FEZ2R2UHZMMERnSytWenMKyS+pjGWmtguHNDhMyTMVm/HIhw5aatIZ\nNX/csiQRAlO2UUsmimMiIfm932UStmbaePyF2X7uotNNUDUumhSEIA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:03Z",
+		"mac": "ENC[AES256_GCM,data:wYFTO9E99YKsZbAkSNIkvt7uNgPtUUuJGZBjvUOys6rQwk7hdn0YxaThkU+giGT9vJnwBQ2r8vHVOohORjP8/gA/osnImb8RZK8tjBWp0ydB3yltn3sU4U75luv8xWRF2AxMSsFCdZde0hzRsDmnbtNalRaP7TC6jmqhteA1cW0=,iv:nsWGyAxDWN1jmMdz/VdWGZbYGVIGMRudh2RhNr5Na24=,tag:1qcKYreDOeFw0lVEtdZN7w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/lassulus-nixcon-email-address.umbriel
+++ b/non-critical-infra/secrets/lassulus-nixcon-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:OecTZiJ863XBta1AVhrjBiW7,iv:B6jUYLlVLEpi5EHqr7cQHqiWK3hLvD3JmxQfh34EWBI=,tag:HrK4trEOhhtgPFpmDU9Rew==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWbXhCMi8weVdPYzR3T0VV\nUUhRQ1R4em56bmZRUFZ1NFRta3k4Z3pBS1hRClN3MThaeUFjaUJYSU9ISU5qcXBH\ndmx0Z3FJK0pTdXlhZ2ZObUdnbjMzcHcKLS0tIEdCSkRwb1ZySEo0dW0vWjFHY3BW\nUVFmejhSbjBSVWhLWk90TVllT0NZNjQKyBB0dqepE2s+v9Jg5epPYpAESV7Pa8St\nILY8LYa6mlvy5k8470iriR62u1WKwz4sID0IeMcWa1WDhNEOCTJGhw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXTUlOWDU0WXl4Skl5VW1Q\nS09JK1pqWEFmT1pEYXhicWlXTWRSL2VobUY4ClZqaUtlVWNkNWNTanlUVSszMWkx\nMHVyN2F2Yk5nN3lkdXcrTTlyWXVnaFEKLS0tIEhaM1hLYlJvS2ZHQUM0TEt5d2xT\nZ3ZVa0hiUnpyZ1lVc0oxOUVvdWNaUm8Kzn+ElRU/laE0YzvE2zc6pOAekZzTj9h/\n7OR15ozi0ulc1BM8VklWIG+xMgSXN9iWnPNVSL59d0g7bU/VSrffhA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTSXR2MkFaNDNnM1JrN2xL\ndGF4SnY0YXgvSHZnUjN0cWF6ZEhSVmV4L2tBCnlhUVFRcnlSdVNKTS9oRVRBUTVC\nY0pWN21sdzBoVE5weGJuZWlnL1JkZ2MKLS0tIFZJTmk4QnN3aDA5eHNrN0ZPNk1m\nenZrWGNMRnZvTjFPOUZaTi9yT2crNUkK4+Nw/Juomv9D0imAXFMuD+7M7lZ/w+J9\nYCcvdTdrdWQ4DF5DBRGaHmJ90h8gG+WQgn7lmYwFAYnn/oJXE0Ss7g==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:17Z",
+		"mac": "ENC[AES256_GCM,data:00WmF64EulPqhVxJ8gJrSc19Wgu1L+9KcRwxLWq8mR+hIYddABuPWCGRVr8eo57bT3rD6s2onEI6I9ttsGHVuG6fmFPKYrhGxG5VHSgP8VQcQjXIU14qUgpD+nhI+IJDUe196NK6WDCe0y79Fve4gyjf/YxluC21eeKC22pt/7I=,iv:dWvHXS6XwGf0vcW6tbI9gdDVUfORqCR3HXFI2GzXVFw=,tag:H5rWsVf+utGEjTbKMJtBrw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/mweinelt-email-address.umbriel
+++ b/non-critical-infra/secrets/mweinelt-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:h9DkkRIR3GNh5ZKMGC28SjWod0m1,iv:1tSssLzQ88q9FYg1HM+y4iv9kEldZBvqNBfM2YSpG/E=,tag:bpWxmLj0kX+jW4sq/X6YXw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqVjUya24rSStHdCtMbVkw\nSGdxVVRTWnMvd2VyTU04WGkvNEpaaUhYblg0Cnd1MWRINC80bEhiaEVreTRLdDNB\nMkpOYWMzS0ZoWEU4TTdITm05RXFVcGMKLS0tIEowblp6eVdHeFNPaFhDTnVJUXpw\nQlR5NERWTnk3eDVXZmVaR1pKTThLSE0Kbf5RBNWt5M9PYlqojAJN1I4s/msoK6EM\negGyoxdPheoKrCVqfOiAPjRCPfXVSNrWjT8SGVxjqMy7C67ZpaS/Og==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpRkp3TkZZdFpQZ3d4NHNB\nbXBKR0Q5ck5jdVJLazhSV09ReEZKYlRpVXdzCmNkNkNLSWhNWWRHdHdrdzdMV2cz\nTUU4RklKUGY4bDZKZENDdHhpbldIMWMKLS0tIEVjYWQzclNJZWJsTnBYUVU3SXRi\nR2k3bjZ1LzV2V0Y5cS9MOXhWYmpENDQK6VSazO993LrsQ1pRyyqM8tLL9sx6BiXa\nd+8JirT3MNYn+tFkcwtA3hR3h9KiOqy43MQIIhqCstI74EXvFoDjHw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxN0szaE9tL3d6dzdjV2Fv\nd25sS2E5QzVwUDRYMEZyL1BsSVdXTmY4bW1JCm1XQjU5WUs2ajNoeEIwdlZxcHhx\nNVNDYlNJbXQxdzRvRXRKbGh5YW1FWU0KLS0tIFUxYXc2TGlQaFh5TnNnN2JvSnQ2\nMXFINUd6cGhqSDBsVFlaQ2JvNVpFYlEKtEBikxgWvbxFw0z5DWgvQIEbWLEuPSoZ\nfylD+F7SIFFygyTWkj71gIuolu0/3F6HeU8WBe8a4av7vsIJkw91Gg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:22Z",
+		"mac": "ENC[AES256_GCM,data:pgrUk1zEKDapi19EESjQWx/JMkcWydh4stNhf6ALk60QxhwsyNPHWhrtJHl/VsP2q0KX5oRVuh5EjIRKOjrK3WeZlpRj4xCxw5sDNcsmxYQZkl215FLqmR2xBOt7dT+0qjbducmMJk0ba8L8a/SFGzn/WWTpT8fNGmh6gKVKq8E=,iv:10TOxOAGbCOtYVRilm6Scut/R9gHG5gMqnaSc1h5B/I=,tag:CE5OGlEHBO88fZJCzqTArA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/ners-email-address.umbriel
+++ b/non-critical-infra/secrets/ners-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:MaAii21TW3gwSdI=,iv:SpXn8gy12CQsC5ymt1N+uCcnDoG/kEcoP4S9rMkh+9k=,tag:Y/M0+LAEcRYMlOZ35sgdVw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPVWdBSkpuVGZ1dk43SGdP\nekcyOHFXMEIrMEx3L1N0RVNhRWVwZ1pYeFRzCk9qNFduV1FKK0ZEc0xVdENsRFli\nWGlSYnNCTHM2QVRMd2xNTnliZ1kyUGsKLS0tIEk0VlZqZjd2YXkydEVZaHl2bG5m\nOUZ4WFYyOW1uaDRrRmE0anQvN2dRaEkKmcflbtYPx2vdsR6OnF9g9xYsIyhSm59z\nVgk7C62THzU3YJmklPxOgLeUYZWuGAkPZ4WNzbT6V4dOz3wwXQqZLQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMQzFiK2RSVFVKMFFjaFor\nZUZOL3U3VTBrdzVoV1JMVlU0d2xKSEVjS0VBCnJjcSt5SmRULzVvR09pVnVra0JT\nRzNaaGFaRmVtMmJEc1hNVVY5NThaSkkKLS0tIGZ3bFoya1lvdXhDUXJWTDdZR0tB\nSklXZ1JnR2V2dmhrZW0xWWEwN2Y1dWMKc2RP1og2xEhI4j7qjHmNyzPXx3qHF/G+\nTix/T26LKy75hgEl4jez++pX3b7yHX1+fbohTXWAqYpNlNCv9BM/JA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZDE5WlR2UUdROGdWTEZD\nTXZsN3lrc3g1RVVxTGFjY1RkRysrZzNQV0hvCnZiai82Nk12MjRTTmtBYkU4TjVq\nOUYrV3gxTjlGcHFzdVdSbXR5aVNPSFUKLS0tIFZ6NjlHNE5NQUlhWExqREFEQ3BQ\nRDROcTZCbFlRMWJNWFZUWGdReEdoNWMKV8c9PTqc4wQWNLrO87Gknh0xT4EnyJU/\nPzfnhtcD2svCxGsS23fYKqktthlgSubIMTLyAVjxa+Bhwo7XFGD8jw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:11Z",
+		"mac": "ENC[AES256_GCM,data:guJ+30EF8fCCdZAE1q//fhs8stSWHuwKIXITiCa7vahZ3w628M4pbYMEhftxjXobo6m8LZEQU7eBo7DnP7vBz9yx50XJLoRuRqtGRRRxrZqIphIOId7Emrip4gfu6/wK/fPfD7abcJXnmrn43unYB6kLqOhdcsKsPZRQxwEjKxU=,iv:cTQ7JpgN9TPyRM0sOJJMNcS+C/BkJO7dyHthrcRR43s=,tag:s9TIIBaw4GFNGX2d5Vt/vQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/picnoir-email-address.umbriel
+++ b/non-critical-infra/secrets/picnoir-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:nyb8CLW2mX2wsKPFOx5TgNOD9Jnu7K+x8g==,iv:G6hcbILjJzQVgVfy7vxU806M/dTJg4AwKLxlBUAlJh8=,tag:zjQXyfH7+aoT/qy+IaeCLA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNVm1kSzhaMFdERjhFY25q\nL00rbHB6Qm1IdzJRK3Z0ZU9JNm94bFJ5SHdRCnFTTkdURGlkU0M3WWFWR2hpanRO\nbUdKdkoranhrL1B4dHhNUURDTWY1WG8KLS0tIE1pbllTejdRKzY4Vk1WQWp2RFZE\nWWVXZHpCOGp4TUEyaVpheEJTWWhqcjgKpYHtYq5RmJ1Fl5bQb6dQSPWBUj2eiPUH\n+w50zvGKefeUuFo2wjfnxgxfr7WmfHCQAVZ/a2JrqgY9mYkJJpCyHA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQVorMlkySE41clJwQU82\nb3hjbmxETDNaaWhhcUV4OTNIUU0rR1JpQ2hnCitsVy9oSWdnUVBzekdUU2xlaGJF\nTzJnR3g4SmtaTjI3TWd6dE5uVktYWjgKLS0tIDdOMXo4K05kUnhxSHYyT0hRTkVZ\nUVF0T2dLZThVb2ptT3Bkeko3Q2djbkUKI70oETq5q2pl1+fjiR/GjHcSfLi0F6KP\nZvug8/S/NifH/BbO+6EuUqLrFEGBxv0RTC+vnQ1y0MpvKXlXG0K4ow==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyLzgvQU1udzhDcys3UWZI\nelFWbjFOR29wM0x1VzA1Wm9BTDNoM2V4ampNCmFwM09URHVFSVE5c2h1UmxtT1hE\nM1Mwd1JqMHkrcEc4WjhFYms3WVFKeDAKLS0tIEV5cDFIZGZnTWM2QlhXUmJFdk5P\nYkI1cXNxdi9ORGhmWjlpS1Z5VWFFWncKi8KkI51plxvpeeTOHZ9kC0Xcd/vE31+v\np2XBcU3NrKhs8bAZN9xYKVag4lM23G1myfnrwB4RCXHKGnF1VJyAtw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:20Z",
+		"mac": "ENC[AES256_GCM,data:A5YAwuWo8pm/Hw3NxX3StvW8kT9wk2dUXLVQwJZ/inV0YpsbejhOlHIfca8iqMAb9Lu5o4V0bbdgAw9S5ThHKyatzQZtnIT2uRZM0Ietqes4yXjoL5mEjbEEgCVpbcdRd93fTNt/G4BLWEcpMU7xMNIxiT+KVk+eN0UO6tw38d0=,iv:2a4YRCi2If9VMSqRHciargwDJ9AHCbGBrRKsQxsFDTk=,tag:ejM7sV9JrR2A1EPdnz9OmQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/pinpox-email-address.umbriel
+++ b/non-critical-infra/secrets/pinpox-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Rcd6Zy2uzZuRmf29/nPlQAMk,iv:jK7RSiT69J83Qw2VyeCx3MSkferA733fcHjajTIZ/p8=,tag:224Jyu9/CX0yw25jOPYRKg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySGd1Rk1RMXptVnhmRHBz\naTA3WEJDQnBoVEhwV3ZXalpqbDhIWDdOdTJFCnJhUWljYllaR0xrMkVCbzVYN3Uy\nWVZlMFRpcXZPRmFxNm9WdXZIYWJxKzAKLS0tIEFEVDVSRmpscytRZDlxcmRIZ2ZD\nSnc3Y3N4Vzl6OXN6RW9rN3B2STdVZEkKKHODL0FubIpac4aTGI1oC1OEuUsY42fY\n4WJumZ296/fqSLNKKWZ5vIgZPUZ1dGGY+8mNhXQc+f3hrxCJ9m+Zwg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2L3J2TEpQZVpOVVArbWMy\nNEYyQTk4eUxRd2w0aUQyaFljb1pxeUUrRXdvClE5MjJvM241ajFjRzhablFaQkxK\nZ0Y5MzEycXgrTVh2WVl4UmZKNWNCbVUKLS0tIFgveUhFdUVtSlI5RWd5NU04aTR5\nb2Vja2pId1RVaWZraUtNbmRweTVWT2cKVdcZy4byb+xGHNlb/TA0qML8cFywkojd\nyCGxIIjFc2Xkp4OOOzLG424H02xREIYb+zsmILzyl+mJjuf+d64wAA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGM0ZWa0c1ZU9EaXhPakpa\nZjFaQzcrenFna1dYMGluM3ZYK09JRXhCelRrClRFMXFDTzB3TzNpOWg5MU5jNUlQ\nMmJJOTVlK1ppVkxrNFFzMTBpaG5CaVEKLS0tIEFMRk9rSkZKdGNYVDd3bkxKSlJE\nNHh2UkRhdWsreUphekFBZGRlVzBmMFEKklK7LWkIdSjNDqlwsnCnx9gOBOnzSk+K\nYnKcTpPI9LM4Qee6m6HzJV9AjWDmdEWKmCEr62yZNeW9qgYjzLT4uA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:18Z",
+		"mac": "ENC[AES256_GCM,data:/RWlPIuBgrS4+doX+2EinwOqwTSwXI3NzKS3nDAP5yK9bcm9rU3pwJ9R6nEf00TkLRUymyeudd13d1euDPft4Eu07Ux/UTiw2+EfLR4S7vCDAAytvL7/iTcFylkc8zpTIgb9xKF00mktJ9lIjP25XxvviiqTbHi0SLy/0AXE8P8=,iv:kXqsOtmf5xkP6HLTvYicWVnJN1He4Cl6F6nRg4TlTWg=,tag:mExl0GZtCK0lZy1WxEYEyA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/ra33it0-email-address.umbriel
+++ b/non-critical-infra/secrets/ra33it0-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:opUFn6E5u6E7tqqsHp5tb6s=,iv:KtLuT2eClZRii+RDWGU/LyanhsQp4HALs7MamLUbkao=,tag:RKzUm7KfH5ddVBiCOB0AbQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3bDlKbWx3MFBBYkM4OGhR\ndDM4RDIraDNxZVdHRnU1ek5POTUybGRIREJVClJCMUR3NDN4bWVLSXRyR0VIVEFN\nOGlWTHcvOTkxNVJ3a1Y1V3pNTkxPT3cKLS0tIDc0Zm9QZ1E0dXRQNHAzVnRXU0Vo\nUkd6N3lvQU53KzRwUmJPd2M0RldIR2cKggpci+A1nPPLOYH7Pagx9/eWNvv7KPYJ\nDA2YO5yeFOnhl0F9FV5ERt+P6oyl+UUQ07LJW2Xacf/nqokVogKuZQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwdDc5OFZWOHd4Z29EL0tP\nTlhCR0w0bG41WXNKSlU2Ni9TUXYzaTFQSlhBCmRRaWZLQTY4WC9vNVlFWWg3bHBs\nT2FiWGxCZ0FVN25VSmMwcS82cGZ6dEkKLS0tIEJqQWhza0FSY2hYSmJzclkvNkF5\nRDBWdjA3K2lPY0R6WTg1SWEwQWY1VWsKF1lFM9OxyJ1Vy/9eoEm1eDepnkaxo4Dx\nfVhSNJjsNsoZ2PX5hIGPHupz+6gEOWYPjQWhTIr6spS7JPM2rzOxVQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkU0FpMmlpbHcyVHRrRzIy\nKzZSWUxEcm1jWnl1a2FXS1NqK1pjK1lpaTBvCnRsTit2aXNzSm1xK0pjNlZxS2px\ndTh0Sk1pb0RzUDhlT3pWZmMxeHU5UXcKLS0tIFJpTlZWZUtUOGNNL0hhckR5bmwx\naEFIYnVlaisxNXA1Mmg1eDN1OE1DSmMKR+aO5zRqL22lEe+DexKjwajaYL0ftaMx\nIOufdQ4vUvx2cetD9wn7cSwNM+uwfGrr3v5rADhfAmZkfnrwxNNIYw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:13Z",
+		"mac": "ENC[AES256_GCM,data:AVc8Y8l3hYaCUfgm444IV7MJD9BK9NMA0jLtmckMwe1L2yMl6ECc/Hrw7fxj6GvVCmdwzczaFEE5gw07/29zUPqv+uIvxKvIlINI8M09pTS7wjU+1B2mvTvjuI/+7rP83rzpA+su3SzgqUXcnxHmlNtwJlX6AfCF7VYnPu2BDUg=,iv:8AUBBJslDzt/bhORPFgDJPQl7rhSA6m2gSqapyclUG8=,tag:TmBmi0HE/YXYgkm71y5LSA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/rbvermaa-email-address.umbriel
+++ b/non-critical-infra/secrets/rbvermaa-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:n4ESZDFSyxX6BcGZgxqe5FMyBTc8GAk8lef1,iv:+YIWHaElfL1LzEbIW41VPHm5ezI0CtkrpguKEN9r95o=,tag:I3XzG/R4aF99468AXSDwVA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0cHBZblZoQXFwYXV2eVN4\nMHZEemd4NUxFRVJlOGwraFd2RmlXMG1wbFJ3Ck1yZ3hMd0N1UG1vQVRLOENJTVZ1\nVElqUi8zS2U4UFhNODk1bjduMGFpZ1kKLS0tIExCS1U5blhNZ2N2NTNMSHdKNUdo\nR2NQTDZsY1ZSOERtOFN0VTFHWk9ybEkKZSjnPzcU+AT/ok5CPlAt2i633ditZivw\nMFaMmX7MnKbxQ8cc9n+PzykhRi1rkK13MSE+7EHURHGiKF7Mhi+FuA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWeUhPTTZKVVQ0aWxmUUF6\nZFRzMGFpUWx1UzZZNllyeHFsdkhtVEd3SERVCnBCd0tWbzI1MkdmZjcxaFhEZXAw\nVWlHL3Bza2NyZjdad2dmTldYdVNNMWsKLS0tIFAxMVl2a0N2RTJmbS9DV01DckVK\nSldCT1dHMEtBMDRWNW5KaFBaaWZnWW8KyhH9q+BYjeXB92PTNF7Z9XnVzfZeZj08\n3UlUKDaJqNF8HDV1h1BidSwkff/CQZak3/TChRyGnMchC+reejT6fg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKUFdudEhYTVEvd1lHVTht\nMWtCbGFCZGtBaVhyRG1pMTRIN1NMUEVoeFVVCnFEU2xrdkNzRkJRWGduV29XUW5i\nWHN3VzFHbHdNSTRMc3dLL3Y1VTlQVjgKLS0tIE1xYStVdHZXbGZWMWU2Y3Y2QWFo\nc0lOSlNmVi9qKzIzZUFFVnA4TXVHNlkKCcrrJRcQ3DN2uNe3eonpJDAcO/lT86yk\ncffD/NPtB6HdyIFNV8a4kSHpuVx8ew9/Bssh2GDT5QBdIqs2y+hpmg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:21Z",
+		"mac": "ENC[AES256_GCM,data:l/1zLRWOiD6hirIJ3etFBgXSTTxvMz5I8RE9TEp18/lLskzpAOXf1azYftXFCvCoz6u/6WSqUIinvGmIFcGGYv3x8ZLnJ7ABDtNGPcTIvr362H+Wq5vd+sr/6OKqNCD5CsYEXx4m2KVUl5qDwSImVZB93Nw64RBukRBgCumWWm8=,iv:II4peq9wUeA7aX71KL7KHVlwsw4OhDdUN39uK9QKWpA=,tag:Q9L1VNwf5yYsfQHonK9tSg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/refroni-email-address.umbriel
+++ b/non-critical-infra/secrets/refroni-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:3G/sSkcB8glDRc+ZyXOC,iv:aRKD0w7CIs7JfdjPQ8vLKSgmFmwUNWjwBvSYSbZsnhI=,tag:QLiHiRukS7Y5VdCNwmB3gQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNcFlHYU9nU3RkNSt3ckhU\na0NGT2E3QnV2L3FaeEIySXNzajdyY2M5UXhFCmJheGZUbENPV3F5Q2lrOHVYbFRD\nTVphTmlsa2NBekZGUUZQNXhwOWxNOUUKLS0tIEVyTmd1amlOM1hrNDFLc1RHKzVH\nS25PVG94S0oxOUkzQmlrVk9EcmF3NmsKWnp3FVHN/xV9zs4Ip/k7ZJFsitC9W3vL\nVi8QUcdSkAWeezZvdUYVg/U858KuLSUOq/tVw2l4f4kb9Z8KhFPVcQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxTkdPTURGR0dQU1RraVRR\naU16NHdvbnk3STMvNHBGRXBsVUluRDhsVTF3CjdDS041SmpoeGlKT3loVkN3aTk3\nRTNjcEhqeTM4Zm01OCthelFRUU5DNmMKLS0tIDAyYk1PbXQwZUpWQXpwWlJmZG5P\ncU9seEQ4T2g3VTRhalFKcFJlTTNLOU0KZp3aRIiFi8E48fyRecX0kpng/Ct2oQoU\noqnCHIG9Ad3UMSfcSvh/vy84I3+Ru8fTcKXSOpOLe2qSwjqA7VQweA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnNmpQSkh2OVo5QXR2Mkow\nVjNVeHhoTHNQVHRObGtmU3JXdEtJNVRPUlMwCmZSS0ZpVUpFamhnN0ZJTHdqYUgz\nYUdIZnV3N2ZWUUtKb3I2YVBDQjVpVlkKLS0tIGxDL1B4RVpBMlhqQUZNSWVVQlNB\nUnExYmpFTmR4T21MWEhjVDA0dkpHSEUKnMGqCRyghepYNGIz0ChFgp9ctkvTmBFX\nrolI+X12gguePHA4smuhXXn4qa0KuVkEEP0Uu9DdCAzJJ8CWgi2g0A==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:21Z",
+		"mac": "ENC[AES256_GCM,data:C1NGCV2Le1GkvnKNmM/6t5yDmMLyPa2nnoNhtScwb9rlzaQxjtWPSsJRRTMLgGgh/XTIhKjNO8+5PefLzQWfEqBZA0s1Y8n/0Qm1D4n18OXEajgYxPWOWpCTjR8aZfLTn6hXA+gx6IirCyYrfj05UspXcoo2mk06U4XTss669+0=,iv:kKhjEXpgdvTjSM8pfYkGhkWm3JtJOokMUvORqGLTb/o=,tag:SxuoieruxNkpqvcebrW9vw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/refroni-nixcon-email-address.umbriel
+++ b/non-critical-infra/secrets/refroni-nixcon-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:jFJNBd+T4CFxN6N4,iv:jzoyiMOmkN50O0Pj+J5U50nCY9zO72/AyZCAiA/vnKM=,tag:UVSK+zWYIgkVxpIxIQTP0Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJMHVNNWwyZGx5aUQwNzhH\nWG15TlBLelFBcGlEWmF2ay9IaHFWNDRLL1VrCmRxbkNNSkxMN1M0MVNwaTRzc1ND\naVg5czJQakJmU2NXd0o1a2RId1pLRFkKLS0tIGxaWUJ3RXJjSzJKcHk1bzN2UnZq\nT3RZckF4ZHB0UFNCUWxvdi9DMVU3VjAKePztDIswMCRgwWDVlNVlBXf1QnZtUmVo\nOQP6TQ2b71vshmupe991xoiVYh0p3XxlcVrSzlHL1cxpzOCVVrZbtw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWaDdyVGJrcnJjY0cxbHEv\ndVVOWll3WitNTVYzcWVURitiY3hrYS9oekZBClNDdlpyUG0xR1Z2aUViaCtQS0Ns\nbmRYTEc3ZjVadWVKdGpxVllXdjNNOEkKLS0tIFVodkpVQlRvWEI2dHYzYThFSGhH\nU0JNRm12VHZidTRQZFd5ZitVaXZBdDAKaF7XODevO7DPL9gWb0dTwEvLbe2Cr22r\nmfnjQAPKh8WX6fX6W1i2KksF2iU9Ny5Z1i6K7bTkIPWRBRMBjYTxEw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIcVQzWk5ucms1Q21WREJP\ncjBPcHdSVXlUMnErWHpNS2tMZWlmSDJtRXdjCnFFUkxtTTErb3RvcGtCTEtxQmZj\nVk4vS2J2M2dBYVpPMnZUMnMxOTI0NFUKLS0tIE1LSlNLeUdCRjRuUGVFSXUyQmZK\nWkJoOHo5bDg4cXJnTldZa0pVdkwzOGcKudKXzT6UD5/5eILbV3XBXgiTL4giNQJg\nKiFbcyW42IjXgGpIHYW2TGmM6kBa3aIYp+9FsavJvQoGxshxpy65Dg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:13Z",
+		"mac": "ENC[AES256_GCM,data:7Ul5t22GJMfOpZ/94QfLK+Kl/qd1EyDUDXUi2IsGpvGUTxfTP/It8lzTKF0STfzVT8JmGcm8WCy2a8i5kB+E1+gFWk6RShe3Q+IIW62UN5PxVcKQZEMThydbQG+R2JJmuQGmwZw93dFz1WWgUTY47EpXw4imIwNgk20B2S3pd3I=,iv:AMvByk17M5eGqVlS15GsmpIW/5Cx4s3Q3F7NEKsItys=,tag:PHHn6RcDD98tx0sOVK4JDw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/risicle-email-address.umbriel
+++ b/non-critical-infra/secrets/risicle-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:7fe9HOXmQMbKZvq0OuNEDiwX+YHgpw==,iv:S7dcT4b9ffl7wVZ+P8Pi7E2XX1gLqo8//DhiNweUFCY=,tag:kIK6xbo2uiGcLPedC5S/2g==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4YXhFWFo2cndkQXVsa083\nNlg3aEhOWXdERlVHdElRTUpGck5QVDNPUlU4CnF5SDFaZFhPa0o1ektkb0lVT3o3\nWFlleGY4WmZXZlpWWjcwdUhsQjh4OVUKLS0tIDZCekhOOGU5VGdDdzA0S3lhbzJN\nZ2tPWUJOV1dYK2VxQjdTQW5nM1NkR0UKWA3fPHXjPG0hc/ZQnhX9HZLEF1iP3xJ9\n+7uISRPlwy65nSch4hngfu41xdTAPLhkjJJUlcS5AE4Rp/dDc9eNkQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiREpoSHJyVE8ySjdIZlU4\nRjZWcTRFbnltaXpZU0V5N3VTSGlVYXdNc1J3CngwTlRZM1pUWExITnJ3NFZoeHBM\nUzVQSDNRakhicVJLUmcvNG93WW9DeDQKLS0tIDVNbTMxM0JYeGxkbjZjUTh4QkRo\ndWIwV3ozNmZGRVRMSTlzYVYrNmFCd2sKCWNELX+V6rhLKI5QRo713bq0QQBKtEwK\nl1Yr/N8tsT8LFyR38dXAee3Bi2WVFNGVOxtQvUeQwqQRlnPuCL/oUA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNamJHRGF2VlplcXk0M0Nv\nbiszVUJtcE5iazZpNklubUF0TGxCNDJ3WkJJCm41OEVyOFMvK0JGbW4vVUpOZDU2\nYnN1UHVDMWlQRUsvMjZFSDdRQkZBazQKLS0tIEpKb2R6TnpNSExLQjJCQzY1Yjds\nK3A4TU9GZXJsRVhKYllHMGQ4OU1VOW8KasD+UNmcjx4ZrPzYpVbetlwTaIbJGni4\n0Fr12kJbt6ZjcHV13UMIr9F9wZaV8aIlTZHfszEVbk02k9sFr5WnvQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:23Z",
+		"mac": "ENC[AES256_GCM,data:VYTsg8ys36szFJGXSM6S7bdbKXPq3bxE0SPBgfXzoQmZN1IJD5Z0foHXqRHfG9A8YvyAMvUVlnFNAtQaUGGNUibY0MFNKFmb8YsI6hXrlQSZFB2JsHqxDD4OyoJUHG0iBTucxJhHfv0HefnvpqttCW5s2VuEMFCLDkqcT00aHJc=,iv:tQSJLFOnWvzXYpxRURYArC2B81FUiX9tJu3GW7DR+FU=,tag:kW9cE8wNiCkGXfCPM+U8Jw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/roberth-email-address.umbriel
+++ b/non-critical-infra/secrets/roberth-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:BKx7sPjvcVJ6yxQCZs4dkSfM9pIxOX4=,iv:M7ImDURQWnmAIUWgc2TWU77R07i6T9ySyhKf4xmrIv8=,tag:6Ev8KHJ/i61YAZ4egUypUw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhc2JJa1ZmNEhubG5qRDhI\nNWFPd0Ura2xrbDRpSnlOVExQTDduU21kVTJjCmtGeWtER2Y0Z2NlMDZKOXlxRTFD\ndm92cDg3d09ZKzhsREJoblN0Y012TjAKLS0tIDh2amdFS3Y3WE0rNVhIVGUxOG1L\nN1FyQit6RzhUZk0vYkRLamUyNThxZlkKEJdDAjdh627PTMTjBY1qd0xdZRIuS3Fj\nZSj3uhKkGeQmTk4srYjTEd0IjsqdW8YhimGVX71WR7Yq9mQPTK3DWg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQY0o2V0FQbUgzaXV2M3V0\nTTlhNHA0LzE2TWRJUE1EZTEyR3NoTjVuNmdZClBCUk1zNUdnUEJmZGN5L2RPYXRG\nN2dBRE9UcW1mQmtRc2xuWnhPN0xpOEkKLS0tIEhNSHRpZG1VandmOG11VW8rcVI0\ndG9KNzg3NlJmWGhrYTA0ME4vazBxak0KnRGxMy9fLba0qamlS3dFObUkFmZx0eLp\nM9o8aVkBBpcqELG6X/Fy7WFLPc0ZV4jJ80wBZmiCcWLhhqjs+/ZqRQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3a2R0NVlIYmJ5QnlON0hB\nMXlibG1XWnRKRmRTNG12SDAxR3VQRy9UTG5JCjZ2NWhZNGFjRC9rNi9lNkYxcFJt\nNEg1NlNBemN0eWd5REpCMVE5MjB6eWMKLS0tIEtOQzlPWjZDL2dVU3htTzRJNkU0\nT0NCR1FlZ04yYW50NGNyUkdRTjFpTncKTjhufMAUSSXre7/6fBRmLR5VE67iDazd\nG/tTgikrm8XT6cpp6ujsv7Odm/sxMOUM9ceaYaNarJyYG7qfa21dlA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:26Z",
+		"mac": "ENC[AES256_GCM,data:ZulvYVb+MDCHnV65GS/cO+3hh65I05DFJpctsiVw1+oNk6sdK5zJ7N0vN4h2zcJXsWq2DDC+YItxiMuXKwZBCasbbs+KbRmO1fwyfXOjbTPbJzP2FlvZzYfA3MeS7DTJH+egVCH3OL0Kuui40jxlSY1BAvqi5YNMtE2VOmNQsaI=,iv:0gIl0i0zY1lrIFvHsQ/P6HdkHWnbUQETiNcX8x7ASDo=,tag:706cPF842rHxBg8m8f+hOA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/ryantrinkle-email-address.umbriel
+++ b/non-critical-infra/secrets/ryantrinkle-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:x+ehpNkvYQVqI37+Kvgi1Q==,iv:gDPZfbMVURPWcC8UUNpvS6YwyMOd8Ciu6Rdru6ujjmM=,tag://M4zFffC1/ZxunhwCTwYQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXMWxvaS9uLzdaTVBOMWdD\nSG1Da3hHQ1RpaXAyRmVnNlA4SDQ0ZW8yc0E0CmVOUXV4dDZwS0dFL09GSTFjck1i\nS2R3ajRiZ253MDVpcU9DWW5jRkd5SWcKLS0tIGtqelczVW42NllacTNDV2llSHFE\nbE5wdnlPMS9ZSGFWT0xDWWR2bHVib1UKFu4XaDDdOGCH6ZgBbl2J1BKywynNUt8+\nqfLi1nLr6HrO3/tPD5CCKS79/Y11k+wDMK4B0kNjZSs/MsIZvs/P4A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBldzhKakVnZW8zNTI0c1BM\nd0d6cHVkb1o2UDlWb25lWUZYUXoweWQ3ZEM0ClFtZHpyUFBBN3ZZMFpMMDk1c3dB\nRXREWkNIdVZiOFV1bWZYejhaSmJQVGcKLS0tIDBmQzBnT3dyY0hGa2NaTkQ2R3RK\nWllTSkplc3NlRmdTZ20vTTA0ZzdHZGcKUZy1hWgN7YL++gBMnhd505Vf+o6rwfm7\nouHyo4uTk4yqCjIWQMCv7UIhjoDu9IYQAzIl1oULpGEQUCwX3jyeTw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBINDB5d0E2N1dXcjB4UElS\nVENoL0FyS0VQWWltRWJ6bksxeG1jb0VEVVRFCkd5Tm9uc0hWVDA0bHhXU3dwZUE0\nbVpCWGhwMVFrS3lvSWdlb0dERVltVWsKLS0tIFowVGFqa25reVU4MWJtMmxSb3R2\nV1BrR3JTQTlPVXFVdHJpK1M0Z2gvb0EKLpyHwNjhrocU3Gy8KRpM72uxiM81S+AI\n1YS8wJZqLjyyVj1UugHUbJ5UXHbky9Dmf50FC0OJS4sW+N8DAbTV4w==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:56Z",
+		"mac": "ENC[AES256_GCM,data:Tp/Z2uRhfNpHoWDdZrnlq6JGSmpZV10oDiIJtYS8hG+nC6TEeqbIrrHnusVZvmn+U/QhK99gdmlUgFOnQHm/uKuYR/h50QdfP4uQdTL9ikJoGyXCUfBwZzm70enBvyw01zpMc8QlNDXJIHAZ88BZiuDE/wP2V6J50b3Dpw4aADY=,iv:MFv9iybEFuO9UXif/CvdiEbixRP85jK1+V1opleDW9w=,tag:64zemtTMSc8GKRuaxaAKOg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/therealpxc-email-address.umbriel
+++ b/non-critical-infra/secrets/therealpxc-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:g5501h94jFz34M1mx3QxZ2CXCRrPRg==,iv:cq7/f+RIDwwtWpKWBNBLGR0kWPpl6yRMo7Uq/wOMy2w=,tag:k9U+P6JLijjrBIXDB81rtw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoUUluT3JIRGRmQ1NhZW40\nOW54Z2E5MWhLeWVFeXkrTVRJMjRJWE45cTBNCmZQMUpQZkF5MDEvY243OUlITFcy\nU1NaZmdxRUk0c0xGUTV1UXlmMTZ6UkUKLS0tIE5LNGxHeTczb2Q4cXdiR28wbnIr\nTkZuWElyZkFsUFkwd0ExNGc0QTF6Q0UKItz54baQWvLEl2TWmAoiKInbQvW1VRjT\nNZfuFHF+GvfsM7SikMK/RW/gl8s1CDvW8XUh9/dDPnTiNW7cQ2WVAw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDK1ZQcjFJUGIzM0dpSE9M\naU5QR0FnQXVJMU1sa0dpZlRqc3c3VEhISlgwCnBYeE04ZUVSQ1hTdVFOSzBvaE8r\nNXd3eUlQUnZzLzFxalZPNjdSWWhkWjAKLS0tIEFmTS9vMW45THFMelJBQm91eUNR\nWkJwdDZ0Mk8zay9Ib3RVV0lHMmNneWsKCnsQZ83M/7Neu/LfXxX9wftpL18gbM26\nzBqMBlzCNtjseTVxPFJfFPEhlN+8yi7xyJHyo4sZYfcbDdtLliAtvQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqVDBmTmRqaHlaNHRRZUpX\nakp0M3E3YWh1ZE9iQ2R6OVdVTTdFN0Y2RVRJCk8wQnBTL3IvS3QvbkxuODc5R3VJ\nOEJUQlI4UkNuWjlBNXNkYTRlVE9TcW8KLS0tIElZZ0lzd2IxOCtuM2Nla2MxeitT\ncEllUmsvM3JyWnFIVzJoZHY0dHVTRm8Kw2RSXeiU7qVS3cAeuC7GHhXG2REbCdgn\nrKfVGY8z5/yCNE0bLmErRRNIy1SU0ozTNriatLUOWZwD7KcK3TnZ7Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:01Z",
+		"mac": "ENC[AES256_GCM,data:Wqg3N9V/YDERV4zNWoSqBTLC8Ice/W2UARHx+dOxVWGhBRUMdKNNatdsHVaBOYonJX/+Vnj7uNW3LbKMwzCDZdDyJuOXe+xNJ4Icqc9M4JCaVS9l47JSxiXhahQymZg3Xxq0Gbb1sd49I27Y84QgtWIzwnkWT6COF9NmJSL9kqo=,iv:AAmTF/0+wws3mimFwi7ZOqZd5fBxg585/hCkVnvQRUo=,tag:/Si62TyNF3pttks2sWPtQw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/tomberek-email-address.umbriel
+++ b/non-critical-infra/secrets/tomberek-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:mFYiVP1zOpwrmVB6jpahJszs,iv:EjgsCBuO67MOjF5DuoqO85n9nC6Su3yj3T264eMpPBc=,tag:1uxwCx0Y8BwrlZU+paxAmg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0MTR1Um5jTzdWWDF3RS9n\nWUc1YzBSKzRFVFNCOXRpL25PR096L2FjVUNzCmo0dFVKbmRIT0ZER2R4TGRKWXRL\ndTRPaWRvbk5TTHRONTFNZXZTWFo3UDgKLS0tIGFBNVNtUUppVVJWN21QbUo5VzVn\nb3RjTFZkM3FZYXRWRTBPVUZ6aVNFWk0K5ypbBy0SdPeRxYDtfrgFfGFUp03et7kr\nxZxLvtaqjJqbNHKS2e81ztRaITLORo/WJ2XswK8wb95EbhO/1wRVRA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsNnNncUhneDc4MlRpRnBt\nUGQ0eEt4cGdYM3BhcFFvd1ptNUZ5V1BwWUhNCmZNOWZZUWVyeDJlcmVDUTlOY0I2\nWHFrU1FwODdSRVZIbzUxaHk5WGRuelUKLS0tIC9MaEpyeG9hTGRCR1ZyN1VDUlh2\nS1pUMVRCSEkrUk1GRkRYaHlkSnRRMUUKuOhXQwxO2kJSmT9RL6QeY+zwpsppgNkz\nF1nyO1t7/mz3eXg8ZSLAUqBonGwQhfzttiMZcQg3hpnMXL9ZHhnGhg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArN1BsY05LZCtCc1VrQlpH\nbHBiTExHTEU1SlYxTlQ3VHdWaTN3NXQ2OUFZCm10bVBUejlvMWFoWTZrREJyMzVT\nV3lYVWxsQVFqdmpxTHRtcDJrYzJHU0UKLS0tIDkrcVhyZUhFbDEzT09uWmxWV3l1\nbG1uUDhGOWVOeXVZVGNObDB3VkdSazQKwMv653rlOTE/kXayVKTc388mTdZXyscU\nXdI2fVCAldknvMErvCFFDp+8BTxvvqihKrHLkrvK6SYzbIyM2fuM6w==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:30Z",
+		"mac": "ENC[AES256_GCM,data:92X7qT7ya4E24T22eETGZ8++S6f0bEJ14oyTHb1Q0ukaNLu0a0HCPrfQBw3KQFT+Y1SvrFDOot8PQIEpeijKMsDvzh1OqqhVVqSUHh98osLJwW0yMA7E3k/Wa9LKtup5/ZNIrstd0fKYhS/QVZXVxzkjddRYk8dhy7UdjVwZns8=,iv:D+/vMYfvCYIP5mcu6VLtTMm7bwZ+1lyQ8G8OC+Vo1xo=,tag:C2cassN2PStNeXf0xNxVUQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/uep-email-address.umbriel
+++ b/non-critical-infra/secrets/uep-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:iQM6Fk2XZdQww6MLaMzd1+NlzXerV8Qv1w==,iv:HqTeo3Ad5eW62H3j5Ej9v1WzB5dMiC9OOGEQATO7OGc=,tag:1hzAv7jQ+crr2swvSbfXtg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzQjhBd0dibGNhbG9hQnFB\neFBwUUhoNUhEV2hGQ2s5aXRoTUNyczEwZlFzCld1L2lkM3k1bWVGOUZGekt1WDZB\nYk1FbFF2aDA2NjA5Sk9tOFFOS2VZNmMKLS0tIFFGUWJXakx2bitKWUU4QXRPNEJ4\nMUN3ZXl3WTEyMTRGZE9VN1dqeWF5N0EK1OVsikT8NJkEgzivoNZVeSehYgg7LxH0\nBR+qt5HztP8wh7181BQniHHsYrmW/NG9hAE/lWaWVMdEXJp7Af/otA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMTdOaHVvVENpNUJQOHNh\naUwva04zaE1HSUZDWXZyWDU2R1c5d3U4TzFJCkMybVkyd1hsc0tKQjFCZnBaS2Zv\ncUNtN1ludkhBSzFLbVl5N2FBdXkvMmMKLS0tIEtJZzFKb3l1enZkOTIvbUJ2ZVps\nZmtuV1JXaUhJL3dGWjBIYnprY2JZT1EKmr6klqS9VHCQ176Fu8+W+13eWEhi/fJy\n3GV3Ayj7na4LLrKVVbzC6zzVzKhBu3KAs+yb38VHybJm/dXByPcE9Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5dVhrQTJ1ampCVHU0dUU4\nSnozSitZSFVTYmxvMzJDWWZtakdWQVdoOW44CmFncmxONHdvb25XNitWZDFKa3RI\ndEJIeUpsT1FGTnJZRGQ4NTV5TVJ0OG8KLS0tIGg0cHM5cUtSRUlQbFVnZjNlUFho\nTk5pYUdwSUsvb3h5MnNyVDRqU2xvbVkKsIgJCvvqZMRjZw0Z+CERcuGfpib2IKOM\nba9//ju0Lxdc3diVBakFzXWaZVDP6ww11P7Z18Ciol5gHh+J8EnhlQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:04Z",
+		"mac": "ENC[AES256_GCM,data:hKITtyGY+mQS5Qr3D5x77GOew9OXw4C+ha5EIjJJZqq+v/oUdp0ao4KxgRevbqqXqjSovKLt3qF+KFrB1+HmP/WN8FBJzN6L+K8LP+DVmyjB+9tkQib4jXwp0sYDhH7eOTmgnRyzWcBSBOwApmscuvt9lvQlD4oUK9BNMQArB2E=,iv:wT9DNjqySCKuXfDPNu8c8i7Q88XGr0t0njDQPQunKE4=,tag:Rpb7zDHM06FXFJasexzLVg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/vcunat-email-address.umbriel
+++ b/non-critical-infra/secrets/vcunat-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:+aa6Bj/eDk/Zx6FTU2Rh3w==,iv:fWUXCuTb52bfW45l9pZRIkpg1K4yUYjYmk3ezhbVcTs=,tag:PDR3bkCZNgLwrbibj6iVmA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPV0dqUS9NQmFYWmFZYjFL\ncEc5b2ZROEswbzVkdXVEOWJ3V1Avb3FzN3dZCkNiUDlia1B4NE1EV052QjM1MGQy\nUFhsSUFaYjV0NlBCc1BycUt1TDhHZE0KLS0tIDNNSEVybW5vQllTSDgvaHJiSjAx\nK0NCa0hHSFJXd25wREgxejVEakt2aFEKhagkza49dDn1LXlg4fUfmdPGOVO1wB2v\n9wV+OHFQOdbWl1QKPhE2TLRZt84Hbv4uuQaXl/aJ4sU7eFOhNlcJDA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqU0VIakZjSmkzUHV6MS9B\nK25RMUdqZkREb2MreUFZSTUwdFhiRjB1NVFzCk54NGY2VHZJM1gwSEpUM2l6QjNZ\nRkwxYWRWTnR1ejlkcTZOUUQ5bWZlZmsKLS0tIGFJck1ZczFrSUJ2aFZIR0dSems5\nY21UdTl5bXJSSEU1MzJOai9icXd5cU0KNaPF4uhJfLBQMyxaC6/VVXZuzj7ySTr2\nkxXkT2rQcQIXkd4KyBPwCPieY52n4lmNQYwKiO9ycf5vq70nZOHGVw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKc2VBQllmZzdCTE12VE5s\nNks5cFpxSm14R2Y1Vzc2SUR2RGJpWjRsWW1NCitpUjFXUm11RFlNdDB3dmhHN05H\nNUJia3NXM291ZHAweGNPM2pydk41a0UKLS0tIHZKTUF3ckpuSktaSUxqWGdsWi9k\nWlpNSlEzbHJUUkV1YmJFUGFhcCtYTG8KFkJKmF8R40yfLuBwgWLXVRY9lVBVYU9I\nR+nj+9xNLb4I8PYqE+qeQ/Rqm8p5UQuEaeXC7VoPHFZwJ5G6KWyhAg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:58Z",
+		"mac": "ENC[AES256_GCM,data:ycBM+SZZmzjmVxY9ODYApiVz/7TvDvf+8KioA6TbfIhdsjfupG7w70W7NrBaqIhBKtL2F44fwHQa6hQ0umwqF6H9ALHZetXQp3WFFTcN7IIp2tUEOoNe6DQ6wWFT/wqPoPB1pNBcPZjiWeAn3+yGzOXVg8RXbpCXugCxEm/WCxM=,iv:cKm4T3Syse1SUGu+IpmcepxMC8ETxWZZKdDYYorsPio=,tag:pBjx5C4AKqzT9IWQpeO/7A==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/wamirez-email-address.umbriel
+++ b/non-critical-infra/secrets/wamirez-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:iN953pWtKRG4z4UJDnv0tCHmT6aMpQKH7jiqlSk=,iv:M4S0H52IdLwrGLdgfsJbVX9VwZKf3LmPv9thTWGBngE=,tag:DxbjclFn90mNyLPFrY2cgg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtUDNUZWM2Uk8wUnE5OVhR\nc0NoNEdoY21EYWN5aUZSQ1YxM0RXRHpWWmdFCk15emhqcmhNNVMwRTZqRjF5dVZq\nU29Zbk8xV3NEaXY4WUJ1R0xjOXYzSE0KLS0tIGJ4ZnQ5aFlZN3ZaUnF6blFDR1d0\nb3pIQ3VZK1Z5WmFNN0hIQ0YzMG9US3MKEc0mLJ88zWIbSbYPwKSgBrxRjbIXqRSt\nLtyOx6K+9hDAASZiF4gxcUzuypCIUXdGrcGds8EHbzu1Y18KBacZ7A==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3K1Q4clh6ODQ0dHh5S0Fx\ndzg0TDFRa254Z09SaWhydmNmRmtYd1JEMGdvCnF1Zy8zWlBjLy9GbkxWKytFek8w\nZ2Fqck9YSVlSYXNwUUV1dWhkdUNlcGMKLS0tIEcwcUNQQysrUjVYYldha08rb0ZY\nMGcydjI5YXVncitvNThjTUtzTVp3ejQKjnw5kSgSgykY/z2iBoRQB/2dWcs5V+Nh\nvEHMaKKH7fKI1ULhPrzEyrnlsX0ct3F2lmcHQWN6qgRF+lFtQNDhAg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxZ1FCL1BsVUpRS2JsRkMz\nYzRnbWFKM1hDWjBHaVFBMWo2eWxQUDB2L3pVCkl0eGJybUUyaEV1S2ZUS2V0cmtM\nK0VRRUdBUjduUnN4cXY0MncrTldEdkkKLS0tIElkVEVPOFBDTWNZazJsM3pFcmpZ\nZ2w4OEVBTE9YLzVJR1pYVkxndUMwdW8KW62Hj9diIpnu2wNzA9+n6gPtTI7PKuA/\nfgOk6xL6nF+XMrslElyOdBf0datceHP0/MNlrj0xGPmyfz5ACK8WTQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:05Z",
+		"mac": "ENC[AES256_GCM,data:+HUIijGLLwvPJOh6CkDcnBUBcgizLp1gNVtp7LHYOtFVxqTSNf2EdEdBLSq2KTn79TAEioIQzyVD4lyJ3fhHF9dnuI0XVQ3O30+Jzdl83xsGiDzgs/PpU2/o6js66bKkiXClTlypDbkmNgY+G2Xf4KV6sBw3MVRKq7Fvm2uEl74=,iv:GugXBhIaYx4mo/Gr3iMHaMwBK7EdBVRygNw7nJEMUbg=,tag:ZbDR7Kz7xCeTVPws7SS1Fw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/wegank-email-address.umbriel
+++ b/non-critical-infra/secrets/wegank-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:bZupeSe/nYVGTPsv+oCFUym/pRc1QSXt,iv:e3FeNqdM30CrH61gGs4vhGmvHFYG3C22WMAtKH9jyvM=,tag:pFP9ZSKyt7+dU63GC/4wGw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFbWs5YTd1enNMd3lDSnZS\nUVZwb3pRem5ZL3JZUUVWZUdXS3JGc1ptcFE4Cml2QXE0azV5dzR5MkJZVkpOK0pF\nV0JsU0lYT2k5R2N6MTFnaHc5dEtCRGMKLS0tIDZCd0xaR243SUJ4eWtUSzBjYm5r\nbEFySnlCUGVUTXhjOFhKTWpkdDloTkEKkdXI6jiEHkKZ2/4sWQUuxZ+rUBeoy5ND\nfhUT7Qjo39JiRO9rmXlBy3hCOs7lZZgaWkdea4z+a0f8I5JUKR65Qg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2ZVVXZmp4Vi9MMjd5N0lI\nRTJOQTNtVU1FRG5lNGhuc0toYVFTUWJ1Ym5FCjJjQU9OcEh6dXNTcUIvdkZIbkFn\nNTl4R2UxTllQOXJVK3R4WTUvajdldlkKLS0tIGJ3MTZiZy8rbWtOODlLQ1VJZ2Z1\nbnMyRFhGRXlsZXZ2QkRJMzNTOXZRbzQKGeEzUISDmFpminNB5u/7YFLZO/b9qHf2\nPu3uYCBegQhZoBFHjFnFQVtqGgWY6l79cQhd3iVenefJIeQvdEZ+fQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyY0hRTHZhSnVWcGpuUjdl\nV3NENjRPcklLcEtGdnJ5eXpnY09hWW1QNUVnCnEwTFlNdHFyVlJKRmVDSWgwV1Jr\nNHBnYmVMZjRNdis0UFlremVGSGdpdkEKLS0tIEVXRDZUK1RIR0VsemprL2NIY3Vu\nck5yaW4rS2RWWTJLUFhIVDAvS0s3TjAKjchVNXB5AcefJY/EBQ40ilWs/SHtGijs\neICATW0dPp7s12YZ3hLIOHbiu6bWGjOXwxnjYt2XExfF9eFVDegWKQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:09Z",
+		"mac": "ENC[AES256_GCM,data:3/mnul+Wz/t6q/UOltWGJ5d2ruMEwQfKBONDhEG5wrp+qk0D6h27Yt+SnnfpNE8xu8ahU4/cfvH4ubWBemRNoDybhWqwUF+sD9Rlr/U6TGWcr5pWEVeZkfkN8yyeFJYJVeBJLo4xyBJHX1TP4xOlUEwXboyjSJH9xrFguIPVrO4=,iv:oRKsXgoBtZ/osSLARCNg9MXnt5/Ehukm5v1tjJJYzHo=,tag:ETvMY51ZoOHp5sblpXguLg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/winterqt-email-address.umbriel
+++ b/non-critical-infra/secrets/winterqt-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:GaqqJ535lfLVj+gQth9zpo0=,iv:QNau6T2abPBkd02Q+xg0HMP8HF1hA1HI6I3HuSJ5GHk=,tag:0W/RMZmkn7uMiJZCmJ+mQg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5N2hZb2dXbk1zTEYrOUda\nSXZzMkxqaC9wRFNGZzBzbnk3M3J1TVhNV3hNClpPalduWldsSlNoa2xxUGk3RVUz\nVEZxUkV1NFQ1eU1wd1lLM0hQc0dubVEKLS0tIGxBdHF0TGxxVFExUmw1dXIyN2ZM\nQVFkeE5LTEtoMmx3SFkwSU10bi9YRTgKtBAtzERSghfG081LWDen3g2asRCOqki9\na9pIdnn7nPUCA1d0JYd/+ydKENZqi7MmRrqRVe7ahKP7gTEJYPBVmw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqaSs0aWcvTW1oTWh5Misz\nUzR0bWdCV0RLMGZobnlDY3JmZS81OWpscXdRCjcyaU1lUmdQeHVjL3JsdDcvd3Yx\ncGs1RVBvTDF4K3JSWWhMSUNEZzh0ZGMKLS0tIHVMclkvUkR2L3lpQm10MkZkNUJy\nVXV2TzRMZ280ZUtPNlRjVTdRc0ZJKzQK6DCNcmVHESA8C55fSuv4LzfSBOILbyqH\noIIoGO+J86K9/jZxS1rAQUcm9vabnIdQPMVip/5uFG7NPiykN/6QVA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhRzBMUzc4d244aHRhaGQy\nbEVwcU5QLzNIMlgvd2JGUjVsRklDY2dmdWgwCjlzeE4wbEo5Q1BjYWwvR3ZYVFlY\naDZVd290bDRFZUlXTDRNY2FqTzFNamsKLS0tIFM3Zzh1SVExSW9TZ2d6dUNlWm5a\nVW1VaGU1Y29iWmFoSUVZbldtOU1uRG8KVPqRlzOCYGhiNqJG098shKR5Vfz5PxXL\nKSe/DteGWCtKTTaDf+vQxnMZYn27ZQ1thnYBdCVkDTZHcZJh8XiATQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:27Z",
+		"mac": "ENC[AES256_GCM,data:p8KIUyM7slHxJI5b/78KrGymcTkuV4puIYvTTllK5F1A+DiyU3D88NHEUAmMxuRovNgBtyuDFnTa03ozHD93s6PVP12FT5nUNI53UysQptcx6Pz/5UCKXx0Shzok2RGr8IfvxuV+Z03YUCoHEc6+rROzQmYamZDBRCi0ipLpNzg=,iv:+79HhdlGWJaERzk58+JI1YEezUNrVI1Hv+OT6yfpPCM=,tag:sbyc7SDrVZLb6qUL6A9vaw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/ysndr-email-address.umbriel
+++ b/non-critical-infra/secrets/ysndr-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Y4YOmEBOaGquqDY=,iv:A8TPjKU97NEW4q2bGWMZcXZTkrm0eQCdwUgtxOMTyVo=,tag:Q/u0rcCpxEX4w/qwPjCWCA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5cjJjWmpkT3NGdURUL3c2\nOU10VFJVckVLNGNYdGNaaVZxUFRtUVJkQ1FJCnBOMHhjL24wUER3bk1heitXQ29O\nTGRURXBlYkFiWEtXM1FoYTQwQ1RtOUkKLS0tIFRWcEs0cmJ5OGlxZDhGaSt4akNh\nSEpSSTV4Ui95d1pJUHZVUDhWYmxxdUkKr+pfm60iiA/KPvGC+8/FG+k66VrWUe55\n5wJWY9kaAiryufCOJ6MxusmA7wukEyG11fL2/pbVnyuTjyVQQJBncg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJM1NRVlZPbWZpYmdoaUc3\nM1lxN1NvamJNci8wWWs2TlpTTWx6N1UzQmpjCkJaYXVRdWpFYks3RWNhcjE4WGxl\nV0g0TnpPTllnR3FsandBMkIzT2c1cDQKLS0tIDc5VktJaVdoSWNGRmwyZCsrWnBw\nUG04MEpWNXQ4YUMveHdybjZoZ0VoYkEKRyHiuLYrnkDhyBvatsGhojZJY5Zw93Ul\nUZUnSP9VHEKUUeRden8t0GbDB5yaE07Ct38dutZBiKdwq5Ndd+Dstw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3SFRpdWxFV2s2M0xxNUNT\nczlLRUtmOEE4cUpDSjcyNjQrbzlFeDJxRHg4CkZiWTlReUF2clRWbFhNcExkdjRz\nQzYxcEZ3Tk1KYzdJK3Qza1lqZXlFelkKLS0tIGpRb1Fnc1NzaE9sMlN5Mk5ic05P\nUlJxVGpybDVqNzJHOXhrdE1McWo3ZnMKI6TIXqZmjgTP6n6aIYqVsNRpDWveivk9\nC1QHKDfSBzVd/T2GABTV6Z9eMsudYFyBte6cZOCRl2BKRLDKJii3cA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:32Z",
+		"mac": "ENC[AES256_GCM,data:srReKGtO+y3gEbo8QV7Mn+rlELqjGO5FBSCicBOdvZqhNMrhi2pjA7lcf2AOA/QADczF3wDIHb/sLfSK0jorHV6UxnnLsz9xiIja/I3PFykKa1UBVtT9rEoLB3B1J7tTdXmZbr13TC/FnoaDs5XqQ+HESp08GYCB1KPUUpJqhks=,iv:7QvEVhTXwy3cPBu1zTVYqHThxmP0Rq9Gfz4M4arbjQo=,tag:BN512LFyrlYGuW2ZNoVD8Q==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/zimbatm-admin-email-address.umbriel
+++ b/non-critical-infra/secrets/zimbatm-admin-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:/B9q0aK0T58QAWuDM432j67GOn97P9Q0cQ==,iv:CmoZAWxAwhVICYChnnv+KJKbBVNBDsIsd46O7xbW09M=,tag:9M91PSeVYqjFLBwU29B1Lw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvNS84ZGhEejJCT096OG9o\nbmt0V204aS9ndHNoYUJQWFRXd3B2RXlWQUZzCk0yai92c09icUJrU0pZNlpXTzho\nY3Q4QkRqTVdVdlkxOVJMVHpyNERYSTgKLS0tIFVoZDd2VWwremR0NzVvNmRxWkg0\ndHk3ZjZWVlpMZWs2ZG82d3BsbFVuelEKzfSkYRqQfanMZNHQ6wjHr54a2VR3jRfF\n71VVbbLLDNoZ0kkwv/mjdH/Dn0iQyVDUMRn9uQqmlirT3DH74Jsh1w==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0TENhT2QvWit4UjBkcy85\nRVlxL3ozRnBUNlVZVW1UcWVFams5dmhiVm1nCm05ZlVrT0hVSmlKQmozNUU5MHFU\nb1VUV25mK2hocXhnNGJOVWxuMVJ5UVEKLS0tIHBRZEluTnVHMFo3VGVIN2VkNDc3\ncUZOTExwMTMxNW96S1h5SlhHNXVqWjQKdYoZxT9IDjtLcmUHClyuTqnpWHa3zX9e\n/afTEsArLfJ00n2O1hThP3puJmSEe1mDvz7CF57Cwf7iu51nLhitpg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTzBFdnNGV0FaYVd0aUp0\nczJoNmQ0Y0p2a3VxSTBrT0V2QjNWdTlaZVM0CjQvSENGMmlrWWIzVEhEL1h4QnBx\nR1RISHQzK21Rb2hpS2hzK0czWmZFbVkKLS0tIG85b1VXVVlpRXRENU1ScEUrd1BL\nQlpDWXVKeHpsbktQT2dnNDR1RGY2cncKB5611errmeH6HkZ563J0tweRl2kY3/85\neIqp8yuADpdxOW8EpTtGBFLXc3XpWErK4KLz1i9XiPUl3NEF7r9nIg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:33Z",
+		"mac": "ENC[AES256_GCM,data:y9bVOXG1I8zmQWo/MX1QTcCsoSkJXMCERUaeRKiAbOlDUOsjmrUhmGyz51XRNXmYNELLF7uYjTV6xy3ZKc64fxaxt90R8YAftElFAYk9wZIBGrA27pkXD91+pTk9Y9gFqQ3CXHVp7VNrabuGDQsNfG9AVIiUZKzp5qUOMBfH6vw=,iv:RAg3UaPFKb3a9SYWLkwZtolwqMQhhfYWaStlTMj61RY=,tag:DbOWDc7M3hRCeSN7VlnBVw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/zimbatm-email-address.umbriel
+++ b/non-critical-infra/secrets/zimbatm-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:hWrx45+MS4e2v2YPpWbpZ6nKpw==,iv:YSbUsRMeyCKs1gt5ScnE/seG3LC7YcylLE8tegRo208=,tag:CjcOuODmVt5HPsD6Dl3/OA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWN1Q4bFY4aHRQdlNZa2RJ\nRmJDdWdyMGZnUTBQcHlacVdkK2h1eWgwWnhVCkk1OGRlSCtpZWR1dEg4OTVocEor\nT1UzRm9BZmFEbXZyaXdTb3ZmR082cTQKLS0tIDRYRUhMY1hIYSswcENkenZJNUh3\nQ2VtVlFsdmxRcDBYTll6ZVJCN2NRWDQKT0/VwpK38hNStcRcnQE6L34tcTS+0JEK\nGxlsdm9uQ5XLtmLF3UabrGkGee80mQ1XkhPYte9CPnNZRlIJoxHA1g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxcXZNd2ZIOXhDTnFzNFNN\nSWpSRHFyZHA4bUZRNzBhS1pkVWNlcGRWaUdjCjZVSFczUGdrK2swNy9sdzVhTk5j\nbjlDQko1bklXU0UwU2E4Y3IvTTZnd28KLS0tIFl0NVR4ZzZHZk9reEl4dDRMdDZi\nZG9pRVJYU3JWK016d1BWMzRueXZJL3MKCR3NxNuASwNrMwa8DmyV1T46kJWEc3ZF\nO/apjWFxxmLDui3AN5hLWVF70a9kEjk62g12XKvVTZ+cZT695si/Pw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvcCtZeVBaaVNiQ3RLN25k\nUVZuRUNrS1psZ2oydFdzYldORWxrWXF3Y2pjCnVPaERFMjk5VUNlbGp0dmI2REpE\nOUdhV2dLV0N5bWxWRVhmRDRzbzFzdE0KLS0tIE9CZGJQSEFPeFdQL3dKbFlBU1dK\nUEhkdThKdkNsU2NEb0JRUUZLRVE2cVkKqIPmBE2+dpWLGwiOlVvWxleJUZ85gscR\nn8DeAxHkj91yYvKTVRFI7IHXodKm5Tv36Do20FEYActXU7O04x5gKA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:53:58Z",
+		"mac": "ENC[AES256_GCM,data:4ArDpnWg+fOyx3GXmKutr5/NT4PvoeUDT5W/r7D4vtbQG/dwlnBZ4PV7tZte03lnCWfRRxWsV9Uo3gkfcbs9PXU5jcWiUjsZF6fwHaOo7icD2szA/gyWka66SC1Bxx5Ob0DQBhe3FuzLTq7ZPYxp1vXRdqTT8CSxe+ImzPGHank=,iv:t7ogDMdhVG6BX7hxRH3G2ov2LPH5DBZ0j6enx5YmobQ=,tag:TVKzrERdsJo0ARzxk1TsWQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}

--- a/non-critical-infra/secrets/zmberber-email-address.umbriel
+++ b/non-critical-infra/secrets/zmberber-email-address.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:2k7CE3eP/tkjWrDsVD5VHj5MMw==,iv:W9ojzlwPejmI801En8WyXkJ2Mbon5VD8CdBevDdn8SQ=,tag:Qzlgqp3jRYiMjofENRok1A==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSNTI3bHYxNml0WVRZZkxn\nRG03eDJha0p0TmI3ZXZsRkpXSm9sMEpwT2tRCmszSWxicnZGa2EyL2RoUDF4ZWZN\nazIrMmJydkRvUlFTb0VNTVNuQTBwMUEKLS0tIElVSVN3T0hNdkdoTnJUUlFJenQ1\nMEd4ZW5aemtQcm15ZVozK3hOSW5YbG8KGOpwQmdk0CNUTI8CaUjXg4HqHuwn0Fcx\nNKJRYbRLsawTgWu7Cpg72uM0TaiYhU9+HOIP+XRgrXWDBrTos3qPjA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKTEpBMnVnNzVPcmdZd0F3\nR3R0aFpxUVdXNGpiQ3BRU1dNT202akFuMHcwCnJKUFZ6UnV3d2c4WDkrdFdpUFdJ\nSFF1UmczZHlYQ0NEaDRYWkhXTHF1TWsKLS0tIFB6SDQ3VFJPK3B3aFQrOVVYYnlv\nclQrT2Q0NklDS2Y1Mm9Kd3BBVmV0VHMK12RhOd3Y/+RqqzVLi7iSx1MJ0ZwgMRqB\nNa6hQ26E5VvrrpD2DWez3B4tFcvPnqs0E8H+XSmepAZDkKwaCEk9gg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQy9qZ1ZPTU0reXNxSHJ0\nVDRHeTZud0JibGF4SGlhMDBYYW42SVR6SGdnClk0VG81MFdXVDRBU0VkK3VKN2gw\ncXAwamlXanlUTDlGMU5kMDI2QVU2R2cKLS0tIG1tc3RtMW1ZMkhFekMvcHc4NUxS\nL1FIL1l2Rlo2NkdqZXVYV3hySDloYTAKHR3ylAvNTCgcqYBT5fqtAekzsFfhyAlG\nML9owA1as6L2gz0Q0mNs+hQ7bVTJcX79IvGJO3XGRzzKiV0mDg9+6w==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-22T15:54:16Z",
+		"mac": "ENC[AES256_GCM,data:pdfPTfLuchk8RPTYJn5+zF2SyJVVr85gSbwQVHZ8ntViyGLUpvnlhLDay33CYV/6bnwQZIF9S5xo13/eQeemTa+p++tZKz4A8g6vWh5NuHgN4PBz63W25tmfPQGLk/sy6wm9wMmatDncJ9RjGtRfkDxqhjpNXM8eW9rvUezFBOA=,iv:pw92c307xRw8iZABrzeKycsv54TJWlzJBgl+itBb5vU=,tag:0LglVHSUgHi+CgA6US9vWQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}


### PR DESCRIPTION
Note: there are 2 commits here: a refactor and then the import.
I suggest reading them independently.

This completes the aliases part of <https://github.com/NixOS/infra/issues/586>.

I wrote a script to parse a ImprovMX dump and generate this, but I don't want
to share it publicly because it has people's personal email addresses in
it. If you want to read the script, reach out to me on matrix, and I can
share it.