### PR TITLE
Add NGI smtp password and update help text on encrypt-mail.py

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -101,6 +101,7 @@
         ../../secrets/erethon-email-address.umbriel # https://github.com/erethon
         ../../secrets/imincik-email-address.umbriel # https://github.com/imincik
       ];
+      loginAccount.encryptedHashedPassword = ../../secrets/ngi-nixos-org-email-login.umbriel;
     };
 
     "nixcon@nixos.org" = {

--- a/non-critical-infra/packages/encrypt-email/encrypt-email.py
+++ b/non-critical-infra/packages/encrypt-email/encrypt-email.py
@@ -22,6 +22,12 @@ def find_relative_project_root() -> Path:
     return find_project_root(Path.cwd()).relative_to(Path.cwd(), walk_up=True)
 
 
+PROJECT_ROOT = find_relative_project_root()
+NON_CRITICAL_INFRA_DIR = PROJECT_ROOT / "non-critical-infra"
+MAILING_LISTS_NIX = NON_CRITICAL_INFRA_DIR / "modules/mailserver/mailing-lists.nix"
+assert MAILING_LISTS_NIX.exists()
+
+
 def encrypt_to_file(plaintext: str, secret_path: Path, force: bool) -> None:
     if secret_path.exists():
         if not force:
@@ -94,18 +100,18 @@ def address(address_id: str, email: str, force: bool) -> None:
         click.secho("Removed whitespace surrounding given email address", fg="yellow")
     email = clean_email
 
-    secret_path = non_critical_infra_dir / f"secrets/{address_id}-email-address.umbriel"
+    secret_path = NON_CRITICAL_INFRA_DIR / f"secrets/{address_id}-email-address.umbriel"
     encrypt_to_file(email, secret_path, force)
 
     click.secho()
     click.secho("Now add `", nl=False)
     click.secho(
-        secret_path.relative_to(mailing_lists_nix.parent, walk_up=True),
+        secret_path.relative_to(MAILING_LISTS_NIX.parent, walk_up=True),
         fg="blue",
         nl=False,
     )
     click.secho("` to the relevant mailing list in '", nl=False)
-    click.secho(mailing_lists_nix, fg="blue")
+    click.secho(MAILING_LISTS_NIX, fg="blue")
 
 
 @main.command()
@@ -130,7 +136,7 @@ def login(address_id: str, force: bool) -> None:
 
     hashed_password = hash_password(password)
 
-    secret_path = non_critical_infra_dir / f"secrets/{address_id}-email-login.umbriel"
+    secret_path = NON_CRITICAL_INFRA_DIR / f"secrets/{address_id}-email-login.umbriel"
     encrypt_to_file(hashed_password, secret_path, force)
 
     nix_code = dedent(
@@ -145,16 +151,11 @@ def login(address_id: str, force: bool) -> None:
     )
     click.secho()
     click.secho("Now add this login account to ", nl=False)
-    click.secho(mailing_lists_nix, fg="blue", nl=False)
+    click.secho(MAILING_LISTS_NIX, fg="blue", nl=False)
     click.secho("'. Add or edit an entry that looks like this:")
     click.secho()
     click.secho(indent(nix_code, prefix=" " * 4), fg="blue")
 
 
 if __name__ == "__main__":
-    project_root = find_relative_project_root()
-    non_critical_infra_dir = project_root / "non-critical-infra"
-    mailing_lists_nix = non_critical_infra_dir / "modules/mailserver/mailing-lists.nix"
-    assert mailing_lists_nix.exists()
-
     main()

--- a/non-critical-infra/secrets/ngi-nixos-org-email-login.umbriel
+++ b/non-critical-infra/secrets/ngi-nixos-org-email-login.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:UP0vY74lmT1mKadLp+Kiw/Q2ZCjc/Y7Cc/yQ17AumruBHXGqmDOm5H9JjlcdE8DU7k43kspBHqpnxBchUA==,iv:LMaEH59zz8jZ2GfkweAGM7/2LdgQ9HQDpkaUGTZ/SOU=,tag:tIu2rBrCsaFzQsRXJyRNSA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTNE9Bc0FxOFIzU01kekt4\ndlJZYnBGeFpBMTNvTDUybHNlRFFGd0xZQmdvCjhLR09xWnM1c3R3MEoxMmZKZTFT\nZ2V1ZHFQQ0dlUHpIZVNreExRdG5Ja0kKLS0tIFdrcmExODhTVzh1cXo3REcxZEVi\nNmw5Sm5jcU9BVm14ZVR2djdwejhUd2cKaq53IBfwqonP+nOYQImFSrxUQ9KaejL5\n4ee8QUn+4fcZLF/rOma6Ydx3LN2K0akk96T7XzF7JT/f1cZO8uU3+Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhTGdCWldkOGRYdk9TSDlu\nejMwaFpDb3BkcUNENVBkSmc1azlBNjZrbmlNCkNnZ295VDJPUmZSU0dpM2RYNjhH\nWmdZZ2pZWlJGcmtMN0tEK1RsbW01NjAKLS0tIEVlekdvT0xldFdiSEw3MjVjUWVP\nZFBUdmc0V0I3SjE5RExUQ2tLMjcvT2sKEMvMayOBvWl3w+ryflSgcNaS830PyqX1\nMol+pupToqIFxXWIz8CCc6q3Xx0iJTfHXMfRp1bjfK8igN+fgPtNng==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNQTVLSThGMHlMc1hBQVFB\nZXB4Y01rdFNscEJsSDVaOWpvVVFBVFVOUENRCkF4RmFSYXR4dTd4b1o0VGpjZXJS\neCtUcit3Z0I2dUZNWjRvb3RPc2d4bjQKLS0tICsxZ281NE5OVWg5dG9mYjFDOElI\nSWFsV3c0azhISyt0RDNZU1NlRGpmSlUKFe6LRnCY1j20PQGZwbFAjfMStGupbBUN\ntNzo1xi8EK6lyxjEgrzepdTP8nF6p8pHoQuU/V9QQ0Swa6anx73GiQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-03-28T22:18:06Z",
+		"mac": "ENC[AES256_GCM,data:DDt0A8oyegeK2LA8eVmvxpSTsii322vpwBqBwcivnLuu/12St1Rnw7lYtHsgNv24mp5L+GhS79USWR8H/tN7ArW198qpWZ1jAs2R9XkK8wSD0W3aZInwTgnwPFxjrpDzmWZ0WC9UXERgG367P/s5aFFN/LTl7zAyfTcLLu08Vbk=,iv:Eqo1xnW6Q5G/84cA04tK6HwOUA5Wh9VL3ZTtkkmovsQ=,tag:qcof1IsOYt7LxEWznmpxsw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}


### PR DESCRIPTION
This PR:
1) Updates the python encrypt-mail helper script to make instructions a bit more clear and fix some file paths.
2) Adds a login account for the ngi@nixos.org email address.