### PR TITLE
dns: drop final trailing comma in nixos.org zone

### DIFF
--- a/.github/workflows/dns-apply.yml
+++ b/.github/workflows/dns-apply.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'dns/**'
+      - "dns/**"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/dns-preview.yml
+++ b/.github/workflows/dns-preview.yml
@@ -4,7 +4,7 @@ name: Test/Preview DNS changes
 on:
   pull_request:
     paths:
-      - 'dns/**'
+      - "dns/**"
 
 permissions: {}
 

--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -181,5 +181,5 @@ D("nixos.org",
 	// netlify pages
 	CNAME("planet", "nixos-planet.netlify.app."),
 	CNAME("status", "nixos-status.netlify.app."),
-	CNAME("weekly", "nixos-weekly.netlify.com."),
+	CNAME("weekly", "nixos-weekly.netlify.com.")
 );


### PR DESCRIPTION
Was missed, because the CI didn't trigger.