### PR TITLE
nit: add missing `diskSelector` to `node_filesystem_files_free`

### DIFF
--- a/build/pluto/prometheus/exporters/node.nix
+++ b/build/pluto/prometheus/exporters/node.nix
@@ -68,7 +68,7 @@
                   {
                     alert = "PartitionLowInodes";
                     expr = ''
-                      node_filesystem_files_free / node_filesystem_files{${diskSelector}} * 100 < 10
+                      node_filesystem_files_free{${diskSelector}} / node_filesystem_files{${diskSelector}} * 100 < 10
                     '';
                     for = "30m";
                     labels.severity = "warning";


### PR DESCRIPTION
(continuation of https://github.com/NixOS/infra/pull/550)

IIUC, this doesn't change the behavior of this query at all (Prometheus will still only pick values for `node_filesystem_files_free` and `node_filesystem_files` where all the labels match), but perhaps makes it cleaner to read.

I'm extremely new to PromQL, and I'm mostly filing this as a learning opportunity. Are there best practices around this sort of thing? Do we like the way this was written, and should I change our other expressions ot match (some of the other expressions use `${diskSelector}` twice).