### PR TITLE
Revert "Switch our MX record(s) from ImprovMX to `umbriel.nixos.org`"

### DIFF
--- a/build/pluto/prometheus/exporters/blackbox.nix
+++ b/build/pluto/prometheus/exporters/blackbox.nix
@@ -117,6 +117,14 @@ in
           "https://tracker.security.nixos.org"
         ];
       })
+      # TODO: remove this static probe once `umbriel` is our MX record, and
+      # ImprovMX is out of the picture.
+      # https://github.com/NixOS/infra/issues/485
+      (mkStaticProbe {
+        module = "smtp_starttls";
+        job_suffix = "_umbriel";
+        targets = [ "umbriel.nixos.org:25" ];
+      })
       (mkDnsSdProbe "smtp_starttls" {
         names = [
           "nixos.org"

--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -7,11 +7,16 @@ D("nixos.org",
 	TXT("@", "google-site-verification=Pm5opvmNjJOwdb7JnuVJ_eFBPaZYWNcAavY-08AJoGc"),
 
 	// nixos.org mailing
-	MX("@", 10, "umbriel"),
+	MX("@", 10, "mx1.improvmx.com."),
+	MX("@", 10, "mx2.improvmx.com."),
+	// TODO: Replace with the following MX records once we migrate away from ImprovMX
+	//MX("@", "umbriel")
 	SPF_BUILDER({
 		label: "@",
 		parts: [
 			"v=spf1",
+			// TODO: Remove once we migrate away from ImprovMX
+			"include:spf.improvmx.com",
 			"a:umbriel.nixos.org",
 			"~all"
 		]
@@ -19,6 +24,9 @@ D("nixos.org",
 	DMARC_BUILDER({
 		policy: "none",
 	}),
+	// TODO: Remove once we migrate away from ImprovMX
+	CNAME("dkimprovmx1._domainkey", "dkimprovmx1.improvmx.com."),
+	CNAME("dkimprovmx2._domainkey", "dkimprovmx2.improvmx.com."),
 
 	// discourse
 	A("discourse", "195.62.126.31"),

--- a/non-critical-infra/modules/mailserver/README.md
+++ b/non-critical-infra/modules/mailserver/README.md
@@ -1,6 +1,8 @@
 # NixOS mailserver
 
-This module will provides mail services for `nixos.org`.
+This module will [eventually][issue 485] provide mail services for `nixos.org`.
+
+[issue 485]: https://github.com/NixOS/infra/issues/485
 
 ## Mailing lists
 


### PR DESCRIPTION
This reverts commit e47fbe09e3592bd56c040ee2da718e50547c2eea.

We received a report of delivery issues:
https://github.com/NixOS/infra/issues/485#issuecomment-2784985232.

I'm not sure how long it will take to root cause this issue and fix it. I propose that we roll back for now.