### PR TITLE
fix(mailserver): enable Sender Rewriting Scheme (SRS) on umbriel

### DIFF
--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./mailing-lists.nix
+    ./postsrsd.nix
   ];
 
   mailserver = {

--- a/non-critical-infra/modules/mailserver/postsrsd.nix
+++ b/non-critical-infra/modules/mailserver/postsrsd.nix
@@ -1,0 +1,40 @@
+{ config, ... }:
+# We use `postsrsd` to enable Sender Rewriting Scheme (SRS) so mail we forward
+# to another domain does not fail SPF. See
+# https://github.com/NixOS/infra/issues/485#issuecomment-2787490679 for
+# details.
+{
+  services.postsrsd = {
+    enable = true;
+    domain = "nixos.org";
+    secretsFile = config.sops.secrets.postsrsd-secret.path;
+  };
+
+  # Configure postfix as per
+  # https://github.com/roehling/postsrsd?tab=readme-ov-file#postfix-setup
+  services.postfix.config = {
+    # TODO: switch to "socketmap:unix:/run/postsrsd/socket:forward" once
+    # postsrsd 2 is available: https://github.com/NixOS/nixpkgs/pull/397316
+    sender_canonical_maps = "tcp:127.0.0.1:${builtins.toString config.services.postsrsd.forwardPort}";
+    sender_canonical_classes = "envelope_sender";
+
+    # TODO: switch to "socketmap:unix:/run/postsrsd/socket:forward" once
+    # postsrsd 2 is available: https://github.com/NixOS/nixpkgs/pull/397316
+    recipient_canonical_maps = "tcp:127.0.0.1:${builtins.toString config.services.postsrsd.reversePort}";
+    recipient_canonical_classes = "envelope_recipient, header_recipient";
+  };
+
+  # ```
+  # How to generate:
+  #
+  # ```console
+  # cd non-critical-infra
+  # SECRET_PATH=secrets/postsrsd-secret.umbriel
+  # dd if=/dev/random bs=18 count=1 status=none | base64 > "$SECRET_PATH"
+  # sops encrypt --in-place "$SECRET_PATH"
+  # ```
+  sops.secrets.postsrsd-secret = {
+    format = "binary";
+    sopsFile = ../../secrets/postsrsd-secret.umbriel;
+  };
+}

--- a/non-critical-infra/secrets/postsrsd-secret.umbriel
+++ b/non-critical-infra/secrets/postsrsd-secret.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:Oy/Lqq1DTXVX0SK0pJOa6fJhf9H3Qi2G3w==,iv:JG2o4C9EjBbt4PqrE3kHPNabFbk2Ar3IHseQyrQxnP0=,tag:IRG+EYLebBDf99svFmcHWw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArTmVPZGo0aXlsbklBZlEy\naXZ3SmcxNlN1WkowQUFuSkdSVGo0Q3BneGhZClliMnIvbUVnb1FyMWJEcXFxOTh5\neDNHMFN3NUw5bGMxcm5EUWpncnkxNnMKLS0tIDNVaXFJOGxQa2FUVUhYbVkrQ0Rp\nS3RmbElCUlUxdkNXblY1S2VSQnkrc2sKusUip4Vnr56lfiEAHRPqQiZjb91rovLA\nQhPCz/LwTyxDDMTsq1dNbasniqeErmUfUfK792HqigBo2qXbsk4bjw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBY3gzUU1WSk92QTBFNlFU\nbVhLamEybkZUYWs4U3FPYWJFSTQybXlkK2pRCjhBdUlOVEVsMkhlbUJFbEVnbS9u\nN1VuV0xpTzdQVk1zMURyb0VQTHVMWVUKLS0tIFkzdmNtMmgxajVRQlNiTTFzTnY4\nMGdZcVpGRkRLQVVSMHJ1QlZjUm9halkKnTU4dXWpYOj4GLuyoNvz90uarPbn5CBR\nfiIXd7QPQl2+3SstC8KrxXSvRx2DmxR+imtPRvqGEf7EaspXpfy1UQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSRUY3M0haTkV1RTlUbnpi\nNk9WNU5OTkR6dVozUTJKbzhmVXJRSlJxMG1FCmUwWTJmbm12UDNmSG0rdThVekRw\nWk1sOUFLUFlzMW0vKy9IWW5HNmtDd2cKLS0tIFc3cjVLTEF3QVdaeG1Kck9KMm13\nS2pWZEpkUU5OaTJIYmNpZzIrRHdReGsKN15CghVCZmL5irAOuhewFIR1hL8YkT27\nwahQun20ahRiIkQRZxGWi1C9HJ/v4IVjwsTRYbM9BwIuopDQkofosw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-04-09T10:20:42Z",
+		"mac": "ENC[AES256_GCM,data:QhBJD/BaFKX16orijmxl/Oi/50d8iqBKR90QPOHgWSp+MYXfzArS/OLu8ZtZ/xwucW7pNh1oC+CGmMHTW1xrBpuMg6MQ5qyhedKjlINptYG/IIcqIkakulppOxw9LMuUWznXcDApd3w5SkMux63tO7vti0kWQ3Zv4A9XpmOXRCM=,iv:85o1/ucnYoKBc/2cCCr+TgrXCQinzX3vGYv5xzEaJmQ=,tag:dokOTNpd0aQMsvVX4MOxFg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}


### PR DESCRIPTION
We had deliverability issues when forwarding mail to other domains (if the domain of the email we were forwarding had a strict SPF policy, the receiving mailserver would drop it due to SPF fail). See https://github.com/NixOS/infra/issues/485#issuecomment-2787490679 for details.