### PR TITLE
dns: Add cryptpad(-sandbox).ngi.nixos.org

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -127,6 +127,8 @@ D("nixos.org",
 	A("makemake.ngi", "116.202.113.248"),
 	AAAA("makemake.ngi", "2a01:4f8:231:4187::"),
 	CNAME("buildbot.ngi", "makemake.ngi.nixos.org."),
+	CNAME("cryptpad.ngi", "makemake.ngi.nixos.org."),
+	CNAME("cryptpad-sandbox.ngi", "makemake.ngi.nixos.org."),
 	CNAME("summer", "makemake.ngi.nixos.org."),
 
 	A("tracker.security", "188.245.41.195"),


### PR DESCRIPTION
The Nix@NGI team plans to survey authors of NGI funded projects. [CryptPad](https://github.com/cryptpad/cryptpad) was selected as the software to use for the survey, so this PR adds two CNAMEs pointing to `makemake.ngi.nixos.org` in order to setup a CryptPad instance there.