### PR TITLE
mailserver: Enable DMARC reporting

### DIFF
--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -13,6 +13,13 @@
     fqdn = config.networking.fqdn;
 
     domains = [ "nixos.org" ];
+
+    dmarcReporting = {
+      enable = true;
+      domain = "nixos.org";
+      fromName = "NixOS.org DMARC Report";
+      organizationName = "NixOS";
+    };
   };
 
   sops.secrets."nixos.org.mail.key" = {


### PR DESCRIPTION
When someone sends us mail and their domain has rua= configured in their DMARC record we send back daily deliveriability summaries.