### PR TITLE
builders: adopt hopeful-rivest

### DIFF
--- a/build/hydra.nix
+++ b/build/hydra.nix
@@ -170,6 +170,8 @@ in
     # aarch64-linux at Hetzner
     "goofy-hopcroft.builder.nixos.org".publicKey =
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICTJEi+nQNd7hzNYN3cLBK/0JCkmwmyC1I+b5nMI7+dd";
+    "hopeful-rivest.builder.nixos.org".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBgjwpQaNAWdEdnk1YG7JWThM4xQdKNJ3h3arhF7+iFm";
 
     # M1 Macs in North America
     "*.foundation.detsys.dev" = {

--- a/build/pluto/prometheus/exporters/node.nix
+++ b/build/pluto/prometheus/exporters/node.nix
@@ -48,6 +48,7 @@
               "elated-minsky.builder.nixos.org:9100"
               "sleepy-brown.builder.nixos.org:9100"
               "goofy-hopcroft.builder.nixos.org:9100"
+              "hopeful-rivest.builder.nixos.org:9100"
             ];
           }
         ];

--- a/build/pluto/prometheus/exporters/rasdaemon.nix
+++ b/build/pluto/prometheus/exporters/rasdaemon.nix
@@ -17,6 +17,7 @@
               "elated-minsky.builder.nixos.org:10029"
               "sleepy-brown.builder.nixos.org:10029"
               "goofy-hopcroft.builder.nixos.org:10029"
+              "hopeful-rivest.builder.nixos.org:10029"
 
               # non-critical
               "caliban.nixos.org:10029"

--- a/builders/flake-module.nix
+++ b/builders/flake-module.nix
@@ -33,5 +33,8 @@
 
       # Ampere Q80-30 (80C), 256 GB DDR4 RAM, 2x3.84TB PCIe4 NVME
       goofy-hopcroft = mkNixOS "aarch64-linux" ./instances/goofy-hopcroft.nix;
+
+      # Ampere Q80-30 (80C), 128 GB DDR4 RAM, 2x960GB PCIe4 NVME
+      hopeful-rivest = mkNixOS "aarch64-linux" ./instances/hopeful-rivest.nix;
     };
 }

--- a/builders/instances/hopeful-rivest.nix
+++ b/builders/instances/hopeful-rivest.nix
@@ -1,0 +1,40 @@
+{
+  imports = [
+    ../profiles/hetzner-rx170.nix
+  ];
+
+  nix.settings = {
+    cores = 20;
+    max-jobs = 10;
+  };
+
+  networking = {
+    hostName = "hopeful-rivest";
+    domain = "builders.nixos.org";
+    useDHCP = false;
+  };
+
+  systemd.network = {
+    enable = true;
+    networks = {
+      "30-eno1" = {
+        matchConfig = {
+          MACAddress = "74:56:3c:4e:d9:af";
+          Type = "ether";
+        };
+        linkConfig.RequiredForOnline = true;
+        networkConfig.Description = "WAN";
+        address = [
+          "135.181.230.86/26"
+          "2a01:4f9:3080:388f::1/64"
+        ];
+        routes = [
+          { Gateway = "135.181.230.65"; }
+          { Gateway = "fe80::1"; }
+        ];
+      };
+    };
+  };
+
+  system.stateVersion = "24.11";
+}

--- a/builders/profiles/hetzner-rx170.nix
+++ b/builders/profiles/hetzner-rx170.nix
@@ -1,0 +1,14 @@
+{
+  imports = [
+    ../boot/efi-grub.nix
+  ];
+
+  disko.devices = import ../disk-layouts/efi-zfs-raid0.nix { };
+  boot.supportedFilesystems.zfs = true;
+  networking.hostId = "91312b0a";
+
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "usbhid"
+  ];
+}

--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -77,6 +77,9 @@ D("nixos.org",
 
 	A("growing-jennet.mac", "23.88.76.75"),
 
+	A("hopeful-rivest.builder", "135.181.230.86"),
+	AAAA("hopeful-rivest.builder", "2a01:4f9:3080:388f::1"),
+
 	A("intense-heron.mac", "23.88.75.215"),
 
 	AAAA("kind-lumiere.mac", "2a09:9340:808:60a::1"),


### PR DESCRIPTION
RX170 builder that up until now was running unmanaged.