### PR TITLE
Add nixcon CFP email

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -124,6 +124,15 @@
       ];
     };
 
+    "cfp@nixcon.org" = {
+      forwardTo = [
+        ../../secrets/ners-email-address.umbriel
+        ../../secrets/ra33it0-email-address.umbriel
+        ../../secrets/lassulus-nixcon-email-address.umbriel
+        ../../secrets/a-kenji-email-address.umbriel
+      ];
+    };
+
     "partnerships@nixos.org" = {
       forwardTo = [
         ../../secrets/refroni-email-address.umbriel # https://github.com/refroni


### PR DESCRIPTION
Need an email for pretalx and we don't want to use the main one. Discussed in the NixCon org meeting from 2025-04-10

Ping @ra33it0, @ners, @Lassulus, @a-kenji