### PR TITLE
dns: migrate nixcon.org and set up mailing

### DIFF
--- a/dns/dnsconfig.js
+++ b/dns/dnsconfig.js
@@ -5,7 +5,8 @@ DEFAULTS(
 var REG_NONE = NewRegistrar("none");
 var DSP_GANDI = NewDnsProvider("gandi");
 
-require("ofborg.org.js");
+require("nixcon.org.js");
 require("nix.dev.js");
 require("nixos.org.js");
+require("ofborg.org.js");
 

--- a/dns/nixcon.org.js
+++ b/dns/nixcon.org.js
@@ -1,0 +1,43 @@
+D("nixcon.org",
+	REG_NONE,
+	DnsProvider(DSP_GANDI),
+
+	MX("@", 10, "umbriel"),
+	SPF_BUILDER({
+		label: "@",
+		parts: [
+			"v=spf1",
+			"a:umbriel.nixos.org",
+			"-all"
+		]
+	}),
+	// Matching private key in `non-critical-infra/secrets/nixcon.org.mail.key.umbriel`
+	TXT("mail._domainkey", "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC1wQ2uPZfdlGmjDDxeNVet7IEFxS55TpWuqQWNKmd4fX8HcKKw7kVHXU5+gjT37wMUI27ZZnIobYhumnl+BLiXZqbuzAt7s3dbJU2de2ZWxOqcDRbK6m2A3AwIAiMzzRUjx14EWgnw55KRi2enpLyS0pKGdvSquHnxaySkAF8YIwIDAQAB"),
+	DMARC_BUILDER({
+		policy: "none",
+	}),
+
+	// Websites
+	TXT("_github-pages-challenge-nixcon", "6608e513e09036ab8cadb7ca4eb71b"),
+
+	ALIAS("@", "nixcon.github.io."),
+	CNAME("www", "nixcon.github.io."),
+
+	CNAME("2015", "nixcon.github.io."),
+	CNAME("2016", "nixcon.github.io."),
+	CNAME("2017", "nixcon.github.io."),
+	CNAME("2018", "nixcon.github.io."),
+	CNAME("2019", "nixcon.github.io."),
+	CNAME("2020", "nixcon.github.io."),
+	CNAME("2022", "nixcon.github.io."),
+	CNAME("2023", "nixcon.github.io."),
+	CNAME("2024-na", "nixcon.github.io."),
+	CNAME("2024", "nixcon.github.io."),
+
+	// Scheduling
+	CNAME("cfp", "pretalx.com."),
+	CNAME("talks", "pretalx.com."),
+
+	// Ticketing
+	CNAME("tickets", "nixcon.cname.pretix.eu.")
+);

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -12,7 +12,10 @@
 
     fqdn = config.networking.fqdn;
 
-    domains = [ "nixos.org" ];
+    domains = [
+      "nixcon.org"
+      "nixos.org"
+    ];
   };
 
   sops.secrets."nixos.org.mail.key" = {
@@ -39,6 +42,15 @@
     # Ensure the file gets symlinked to where Simple NixOS Mailserver expects
     # to find it.
     path = "${config.mailserver.dkimKeyDirectory}/nixos.org.mail.key";
+  };
+
+  sops.secrets."nixcon.org.mail.key" = {
+    format = "binary";
+    owner = "opendkim";
+    group = "opendkim";
+    mode = "0600";
+    sopsFile = ../../secrets/nixcon.org.mail.key.umbriel;
+    path = "${config.mailserver.dkimKeyDirectory}/nixcon.org.mail.key";
   };
 
   services.postfix.config.bounce_template_file = "${pkgs.writeText "bounce-template.cf" ''

--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -8,6 +8,14 @@
   # an encrypted password. Run `nix run .#encrypt-email login -- --help` and
   # follow the instructions.
   mailing-lists = {
+    # nixcon.org
+    "orgateam@nixcon.org" = {
+      forwardTo = [
+        "nixcon@nixos.org"
+      ];
+    };
+
+    # nixos.org
     "abuse@nixos.org" = {
       forwardTo = [
         "infra@nixos.org"

--- a/non-critical-infra/secrets/nixcon.org.mail.key.umbriel
+++ b/non-critical-infra/secrets/nixcon.org.mail.key.umbriel
@@ -1,0 +1,28 @@
+{
+	"data": "ENC[AES256_GCM,data:KhPGql8CE3DDErIq575LdsThvTOo3XQWgenGXrD5Z5nZESpHLHa67itlrXDTIyWs01Qa8aDYlL7FHBaVJk3IhlTl8+uRuD1IQTvi8qerWCN7/4yr8QueGjZDMHoVzFcKoDeFO1azC1UDX9JX2Y9bl4B5RX8ye7G4WbUw4Vlp25gya/xwMxS2/CE5k/+Sx257XxVtAXQpWQh9t4QObf2C7u6uQm33M/eISdsSzcM9NA3BTSjmu3iRgv3UrnDwimPp41mBdCb/x0G4baHOSY9Oe/3iOhsoqM6r2acWOLKqJqEIRoNBUdzo2cLMYn78FzHGDJcrxWQOO3ffP1983IbeSIEZqNVHlqY+us2N0T+hzXxc+k3fnJQjBGNwFYTLCFoN8tazs8v2a2I7nbo+4SScmtRY/xG1Egni2ssBpntypLsEq8EiEr0bELWHEvYVk43sHSKAmA2F2gipX1/YIkPIJ3JGXDLt/abd3sD98gSQoc745itRLVVp5Z4QMqN7JZxuhiBCvrN8XbpqmjIduFqPwl4FXVojhYKsOBkAhrtdYHuThfP4vKiaPN5xLKgENBO20SzDSyYtO6Y/thZRfw1fvkFWldfvMlMmsTe5qnTTdCcMQfIDJ2CVjYE9TJirasu5uBFboBIQR6Sv1bwfxivtf6Pscpw95kX42EoXjDAJwwajItz7y0l2XGpfiGPJiMNEmSHx95HItDaBlhtkObt8t/2/ymp+8BRldj+5bf2LR+I+Tb66QoDQAeiIuO7LvZc8ucZ5JWZqyLP8BuUdsb8u4WP/cJJCopUxatN1GVH5blMFRNy4imVQ020tOpc7ICkbjaYiVawhzM5B/WfbrZMCsNfSs6XQN+aS+sf5F7g7WYoKwqZV+UJaK8ZJoH5RWDMfhosCu/Q/UHmlBT/2L2fQshUgqpow06lIvcedK2vbRZ2hbO2p5bz9PfBkl1p2XH1wO+gQgx4d2qF0jg6c5+sbBnivYkMXKkxMQ83Lt4k1wbrzzS++qSN42d2dWgntZIUusBI3jPuBsTtGO05RuJF/GCjPGCsEegqlKUNphLCv5DF1nkgCMUw+4kkrcfqed+cGdY10EU2HbgnY+y+f/7f8J+93YYWy50sMK+TYaBnlVLJ42csI/gUMnah9zGC9FyV4JnkEabT1OwMuuEokvHIFz2HSkaJWqqklNld/1ImGPzBn2Dx/cwstDGIsaItiwzwCRKLWQQ==,iv:DeGWzsY9gt6xjfRws5EborbBwWVFGGlKTsfLlUemYAU=,tag:UiyvsVd7Y3KVq2fMZhMs9Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLQ3VQS2ovUUxOR2RGVmI2\ncGhvR0lzVS8wQWdldU1hNkVrbFVabHE2V1YwCkt6MG92ZnMyN1Q1dldwMHZCN2x5\nVzV1ZTYvYUpkWUJPK2RhYTBNVVU0Yk0KLS0tIFg2K3dmYVQ3TmIrNFA1ZllPYURJ\nYVJKRjdPNHRkVkU4ZWtzSEI0bEZZMlUKTcwSbuX3BvSON7YtJwr8bD9626oDwyB6\nzI8rpuiVcr+r2Ppb93tqGJAUHKaOPyNIeRYMGXwiDDwBPeeMqAq81g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDYll3R2ZYRGdUT0EvZS8y\naDhKeENVR3JNRUFJWmoyM0M1QUFoUVNQMG1JCmlrWGxTYkJoZ2YzaFVZOXpERHRR\nd1ZzQ2drR2VTZW1uZ09ZUWZ5cmpOR0kKLS0tIHlnRElKYktYc2hwZSt3ek1QLzV2\ndzViNFhOTlNPVUhObXl4aUpkMGpZdDAKQSfKR5YlBwYKtgaOKZivzEYUyoeRur25\ngPNWPmGJWrmvORQtuglEdECbm4HOsEUT8UnNwU73/08qYhc8ACFgFw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4UzIvMXRMQ2I4QnEzRGd3\nVGtoL0lyUzAvOU5aNG50TFBsYWphelEyOEVnCkN3ZTV3aklXU1dEQklxd2dzSGNi\nRTRZWGlKS0pCd2hEU2FScEJCTkhFa0EKLS0tIGNUdUNsTGhuQ3JKSFBoalRmazUv\neGRTdVNpbmVKVGNlWEhUQnYxTEhHY2MKVFZODyZoZJ1ZiZUITIiUkjy6FDJQWbA7\nyeFlTCu62YNrd+ja1gOFC0Tz4RA1GQmjh1zWVnmQ+QMzeHHwT5c1Ww==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-04-17T00:38:26Z",
+		"mac": "ENC[AES256_GCM,data:r65s/Rw9Ip/bmCOmqd9NScRuD9pdFsgjCB9YP7jAM4Yyc9kTJfEo7bxOQAIAe4mzLRkRdURn3H6n152DYG8JVhGvEs0rgQKwGk4nO6WsGxeONPjBjwI3di2aZRUa5HNfPcUSU2d9xHXv10bMGWTUOjwTh0yR7wpkqu4Es84FkaY=,iv:mXBSvWPPncVvztSAQigND9wY6GuNXvLwOQgLgsa/ELU=,tag:dCd6cWZveFMjzknXRXM6SA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.4"
+	}
+}


### PR DESCRIPTION
Migrates the DNS for nixcon.org to Gandi and management via dnscontrol through this repo.

Sets up mailing through umbriel.nixos.org and migrates some aliases, that are up for debate.

- orgateam@: primary contact address, currently nixcon@nixos.org
- foundation@ : does it make sense to still have that when the same name @nixos.org exists?
- volunteers@: unclear
- 2024@, 2024cfp@: are they still required? @Lassulus
- 2023@ was in Darmstadt and I can guarantee we don't require them any more
- 2022@ is even older, so I'm dropping it as well

Additionally, they all point to the same Google Group that I'm not sure gets used any more.

cc @infinisil 