### PR TITLE
Revert "switch flake to channel"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -419,15 +419,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745418384,
-        "narHash": "sha256-or5DjwxuVXydG9DwTg0keqIASlR6wxsCDHXcqnCNeVM=",
+        "lastModified": 1745408698,
+        "narHash": "sha256-JT1wMjLIypWJA0N2V27WpUw8feDmTok4Dwkb0oYXDS4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
         "rev": "eea3403f7ca9f9942098f4f2756adab4ec924b2b",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/24.11-small/nixos-24.11.717246.eea3403f7ca9/nixexprs.tar.xz"
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://nixos.org/channels/nixos-24.11-small/nixexprs.tar.xz"
+        "owner": "NixOS",
+        "ref": "nixos-24.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-24_11": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     rfc39.url = "github:NixOS/rfc39";
     rfc39.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixpkgs.url = "https://nixos.org/channels/nixos-24.11-small/nixexprs.tar.xz";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11-small";
 
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 


### PR DESCRIPTION
This reverts commit 4df82d384e32afd94027c90d58fd2045de97d052.

I don' think renovate can handle this tarball channel yet.