### PR TITLE
prometheus: Scrape makemake.ngi.n.o node-exporter

### DIFF
--- a/build/pluto/prometheus/exporters/node.nix
+++ b/build/pluto/prometheus/exporters/node.nix
@@ -26,6 +26,7 @@
               "caliban.nixos.org:9100"
               "umbriel.nixos.org:9100"
               "tracker.security.nixos.org:9100"
+              "makemake.ngi.nixos.org:9100"
             ];
           }
           {


### PR DESCRIPTION
We don't currently have any metrics for makemake.ngi.nixos.org, so this PR fixes this. I've added it to the `services` list as makemake is currently also serving the `summer.nixos.org` subdomain and a cryptpad service as well.