### PR TITLE
Move away from deprecated in-line `lifecycle_rule` and `cors_rule`

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -5,15 +5,26 @@ locals {
 resource "aws_s3_bucket" "cache" {
   provider = aws.us
   bucket   = "nix-cache"
+}
 
-  lifecycle_rule {
-    enabled = true
+resource "aws_s3_bucket_lifecycle_configuration" "cache" {
+  provider = aws.us
+  bucket   = aws_s3_bucket.cache.id
+
+  rule {
+    id     = "transition-to-standard-ia"
+    status = "Enabled"
 
     transition {
       days          = 365
       storage_class = "STANDARD_IA"
     }
   }
+}
+
+resource "aws_s3_bucket_cors_configuration" "cache" {
+  provider = aws.us
+  bucket   = aws_s3_bucket.cache.id
 
   cors_rule {
     allowed_headers = ["Authorization"]


### PR DESCRIPTION
AWS terraform provider deprecated the use of `lifecycle_rule` and `cors_rule`.

TODO: I'm not 100% sure if this applies without "Downtime". There might be a brief few seconds where the CORS rule is not set. Is that a problem?