### PR TITLE
builders: install nix-top

### DIFF
--- a/builders/common/tools.nix
+++ b/builders/common/tools.nix
@@ -9,6 +9,7 @@
     ethtool
     htop
     lm_sensors
+    nix-top
     nvme-cli
     pciutils
     smartmontools


### PR DESCRIPTION
Helpful when inspecting a builder for running builds and related processes.