### PR TITLE
go-neb: bind to localhost

### DIFF
--- a/build/pluto/prometheus/alertmanager.nix
+++ b/build/pluto/prometheus/alertmanager.nix
@@ -109,6 +109,7 @@
 
   services.go-neb = {
     enable = true;
+    bindAddress = "localhost:4500";
     baseUrl = "http://localhost";
     secretFile = config.age.secrets.alertmanager-matrix-forwarder.path;
     config = {


### PR DESCRIPTION
We provide this service only to the alertmanager on the same box anyway.

cc #549 