### PR TITLE
Create CNAME for 2025 voucher check

### DIFF
--- a/dns/nixcon.org.js
+++ b/dns/nixcon.org.js
@@ -40,5 +40,8 @@ D("nixcon.org",
 	CNAME("talks", "pretalx.com."),
 
 	// Ticketing
-	CNAME("tickets", "nixcon.cname.pretix.eu.")
+	CNAME("tickets", "nixcon.cname.pretix.eu."),
+
+	// 2025 ticket voucher eligibility check
+	CNAME("vouchers", "ners.ch.")
 );


### PR DESCRIPTION
On behalf of the Nixcon organiser team. We're deploying a web server at `ners.ch` that will check if a given contributor is eligible for a free ticket voucher.

Please squash when merging.