### PR TITLE
dns: update voucher.nixcon.org cname

### DIFF
--- a/dns/nixcon.org.js
+++ b/dns/nixcon.org.js
@@ -43,5 +43,5 @@ D("nixcon.org",
 	CNAME("tickets", "nixcon.cname.pretix.eu."),
 
 	// 2025 ticket voucher eligibility check
-	CNAME("vouchers", "ners.ch.")
+	CNAME("vouchers", "cache.ners.ch.")
 );


### PR DESCRIPTION
On behalf of the Nixcon organiser team. The Cloudflare setup in front of `ners.ch` isn't behaving as expected. We'll point at a different subdomain instead.
