### PR TITLE
mailinglists: remove community@nixos.org

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -22,12 +22,6 @@
       ];
     };
 
-    "community@nixos.org" = {
-      forwardTo = [
-        "moderation@nixos.org"
-      ];
-    };
-
     "finance@nixos.org" = {
       forwardTo = [
         ../../secrets/edolstra-email-address.umbriel # https://github.com/edolstra


### PR DESCRIPTION
 We only get spam send to this mailing list, or requests the moderation team can't handle. So better just remove it.

Maybe we also need to remove it from the website somewhere if it is listed there.