### PR TITLE
Add Freescout

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,6 +240,29 @@
         "type": "github"
       }
     },
+    "freescout": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743845578,
+        "narHash": "sha256-tS1fQfOasIbzOnCCBZHAjdOCsKD/Zt5btciC/cgcwWc=",
+        "ref": "refs/heads/main",
+        "rev": "2b5bcee06a673c13c5b5a62b4f4dd1300ce85903",
+        "revCount": 33,
+        "type": "git",
+        "url": "https://cyberchaos.dev/e1mo/freescout-nix-flake.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://cyberchaos.dev/e1mo/freescout-nix-flake.git"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": [
@@ -518,6 +541,7 @@
         "first-time-contribution-tagger": "first-time-contribution-tagger",
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
+        "freescout": "freescout",
         "hydra": "hydra",
         "nixos-channel-scripts": "nixos-channel-scripts",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,14 @@
 
     flake-utils.url = "github:numtide/flake-utils";
 
+    freescout = {
+      url = "git+https://cyberchaos.dev/e1mo/freescout-nix-flake.git";
+      inputs = {
+        flake-utils.follows = "flake-utils";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./mailing-lists.nix
     ./postsrsd.nix
+    ./freescout.nix
   ];
 
   mailserver = {

--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -1,0 +1,43 @@
+{
+  inputs,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [
+    inputs.freescout.nixosModules.freescout
+    ../nginx.nix
+  ];
+
+  services.freescout = {
+    enable = true;
+    # Workaround for https://cyberchaos.dev/e1mo/freescout-nix-flake/-/merge_requests/1
+    package = inputs.freescout.packages.${pkgs.system}.default;
+    domain = "freescout.nixos.org";
+
+    settings.APP_KEY._secret = config.sops.secrets.freescout-app-key.path;
+
+    databaseSetup.enable = true;
+
+    nginx = {
+      forceSSL = true;
+      enableACME = true;
+    };
+  };
+
+  # How to generate:
+  #
+  #   $ cd non-critical-infra
+  #   $ SECRET_PATH=secrets/freescout-app-key.umbriel
+  #   $ echo "base64:$(nix run nixpkgs#openssl -- rand -base64 32)" > "$SECRET_PATH"
+  #   $ sops encrypt --in-place "$SECRET_PATH"
+  sops.secrets.freescout-app-key = {
+    format = "binary";
+    owner = config.services.postsrsd.user;
+    group = config.services.postsrsd.group;
+    sopsFile = ../../secrets/freescout-app-key.umbriel;
+    restartUnits = [ "postsrsd.service" ];
+  };
+}

--- a/non-critical-infra/secrets/freescout-app-key.umbriel
+++ b/non-critical-infra/secrets/freescout-app-key.umbriel
@@ -1,0 +1,23 @@
+{
+	"data": "ENC[AES256_GCM,data:jYgs3IlDta15hr1OIFMtT4HU9u96nvN0GRPDa1+TPuC+gcMbCBRWtFrFYM+/O03mDtJV2w==,iv:M6yUMvnHHe4DUDMCvjL3uQViMxbZzz0NOYlx2J8Mz8c=,tag:qm+/x0TWQwrZbh+pxpto6w==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnb3N4UitvYUg2NHNVVFR5\nVmNydmUrOXE1bG9mVFh5NkZZdENENmNZcG1vCjV6RExtL3MxUVZHTk1xVzZBSmFk\nTE1yeFRxMnpYYXJjekNNejN4SWc5M2cKLS0tIG9IMm05bVRwSGV2bjJoK1Fjenht\nU2xWVWx6TXJHQWg1TnBFM3JWSXo1MWcKnNfOufmvt90kpjiB0GZ8yWTv8UIXaQAs\nba2Ew4Ca68s3zUCgsaQOstkbh8Dszia6HyoYZ7yj1sjzaUI2AMqknw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUMlZheitoajRtWWhpRG5n\nS3dFY1NsaFlYRVR5cFZvYStjQ1JoREh0cjBzCnNGZUlEV2RsdHpBcWxCRVhCZURi\nTlROK0NJMDQrdE53OWNKdkhaVmNWdncKLS0tIDFoNXZEY1B2bXI5blQ0SVlxN0Zi\nUUpDUjYvWWM0ZE5OL1FpK3JIY1RScUUKLTur/VK1HukuFybYVep78VKQGJFAc8bC\n6XjsFe2xhr6mwfWpRW62LbxzQkjPqdWpNAilH+oQWh6EnDcjBOUCPg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibEp5MDk0ZzQyeExuVzhR\nQmY1NnNYTzh2c2VhWFNFc285dVB5MEdBNWxvCnVnTU9oaGJlNVdOSS8rMUFiQnU3\nOWN2aVdPeFU0WWFYNGplM3hNYmRFdncKLS0tIEZyeUFMMVpYUXhBakN3TTRNOGxO\nVXJXa0tRcVgwWGx6Y0RmdmpkOTRuSk0KyAxdvgekHTatCurFIQlg74BoDwjVrw+y\n3xtTubPw6M3qW5/k1b4ClQwHVpppbIG1hQg8OG/QD+nARqSKMCoH3g==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-06-03T19:23:12Z",
+		"mac": "ENC[AES256_GCM,data:oZOR73ZapeN5Eir+Z0BXAqLzoRdtrCbuNAsrCGh9wyCDuL1Xv478jLhVvYhe3O0+errwnAnY8/SiAv5+dSu7sJDHL0RDtY9OWjQhxdv0iTTXZUn+gci1i383pkgLccQzlDZzhtVj33HBY968KOhavD9yNhN8nSy9ow8cLzhcYio=,iv:Xq9Dwsez/HjcHr+hSQNN97ZuoUGbOVrlBTl5JigMJEs=,tag:wkPDY1lYU6vOZ6uED6lalQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
Note: this soft-depends on https://github.com/NixOS/infra/pull/715. We can deploy Freescout, but it doesn't make any sense until we have mailboxes accessible via IMAP.

@infinisil and I paired on this. It's already deployed, and he has an
admin account so he can start trying it out.