### PR TITLE
Only import third party `nixosModules` where used

### DIFF
--- a/non-critical-infra/flake-module.nix
+++ b/non-critical-infra/flake-module.nix
@@ -28,8 +28,6 @@
           modules = [
             value
             inputs.disko.nixosModules.disko
-            inputs.first-time-contribution-tagger.nixosModule
-            inputs.simple-nixos-mailserver.nixosModule
             inputs.sops-nix.nixosModules.sops
           ];
           extraModules = [ inputs.colmena.nixosModules.deploymentOptions ];

--- a/non-critical-infra/modules/first-time-contribution-tagger.nix
+++ b/non-critical-infra/modules/first-time-contribution-tagger.nix
@@ -1,4 +1,9 @@
+{ inputs, ... }:
 {
+  imports = [
+    inputs.first-time-contribution-tagger.nixosModule
+  ];
+
   services.first-time-contribution-tagger = {
     enable = true;
     interval = "*:0/10";

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -1,7 +1,13 @@
-{ config, pkgs, ... }:
+{
+  inputs,
+  config,
+  pkgs,
+  ...
+}:
 
 {
   imports = [
+    inputs.simple-nixos-mailserver.nixosModule
     ./mailing-lists.nix
     ./postsrsd.nix
   ];


### PR DESCRIPTION
I left `disko` and `sops-nix` in the shared spot, because I assume they're used everywhere.

This should have a (probably negligible) impact on performance. It also tightens our security stance a bit: a malicious commit to one of these third party modules will only impact some members of the non-critical fleet, rather than all of them.