### PR TITLE
Add support for storing emails in mailboxes accessible via IMAP

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -4,7 +4,7 @@
   # If you wish to hide your email address, you can encrypt it with SOPS. Just
   # run `nix run .#encrypt-email address -- --help` and follow the instructions.
   #
-  # If you wish to set up a login account for sending email, you must generate
+  # If you wish to set up a login account for sending/storing email, you must generate
   # an encrypted password. Run `nix run .#encrypt-email login -- --help` and
   # follow the instructions.
   mailing-lists = {
@@ -66,7 +66,10 @@
       forwardTo = [
         ../../secrets/mweinelt-email-address.umbriel # https://github.com/mweinelt
       ];
-      loginAccount.encryptedHashedPassword = ../../secrets/hexa-email-login.umbriel;
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/hexa-email-login.umbriel;
+        storeEmail = false;
+      };
     };
 
     "hostmaster@nixos.org" = {
@@ -116,7 +119,10 @@
         ../../secrets/erethon-email-address.umbriel # https://github.com/erethon
         ../../secrets/imincik-email-address.umbriel # https://github.com/imincik
       ];
-      loginAccount.encryptedHashedPassword = ../../secrets/ngi-nixos-org-email-login.umbriel;
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/ngi-nixos-org-email-login.umbriel;
+        storeEmail = false;
+      };
     };
 
     "nixcon@nixos.org" = {

--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -53,6 +53,10 @@
         ../../secrets/lassulus-email-address.umbriel # https://github.com/lassulus
         ../../secrets/ryantrinkle-email-address.umbriel # https://github.com/ryantrinkle
       ];
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/foundation-email-login.umbriel;
+        storeEmail = true;
+      };
     };
 
     "fundraising@nixos.org" = {

--- a/non-critical-infra/packages/encrypt-email/encrypt-email.py
+++ b/non-critical-infra/packages/encrypt-email/encrypt-email.py
@@ -145,7 +145,10 @@ def login(address_id: str, force: bool) -> None:
           forwardTo = [
             # Add emails here
           ];
-          loginAccount.encryptedHashedPassword = ../../secrets/{address_id}-email-login.umbriel;
+          loginAccount = {{
+            encryptedHashedPassword = ../../secrets/{address_id}-email-login.umbriel;
+            storeEmail = false;  # Set to `true` if you want to store email in a mailbox accessible via IMAP.
+          }};
         }};
         """
     )

--- a/non-critical-infra/secrets/foundation-email-login.umbriel
+++ b/non-critical-infra/secrets/foundation-email-login.umbriel
@@ -1,0 +1,23 @@
+{
+	"data": "ENC[AES256_GCM,data:SjwOmC28ufjZFodhZ2RGaW2k1jWNgi8984PekMr3QjhTKjCIWmBSao85PihY0WEvwSZeGOH4X7as3FpjgA==,iv:cZcNnNOVTwDWnjIy9K3p9ZPxzxLoleOn3jM8G62A0wM=,tag:PsbNd0yI9U/SwFGlSXVqhw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxQ0E5SmhEM1hrckdvN3pk\nWGxLTGdTZWZ3Si9YdEVoWTM3c1RTTHRLdHdVCnNEZVcrd09RdDcyWFVLUzZXMGp2\ncTV4Y1NJOHNrUEdKYmFnbEFzZmpwV28KLS0tIGM2eEdWR2RranhTdGs5Vmw5Mjkr\nNFVra3dOOTB2RzFMVHUwdU1vcEx5T1kKmCTc3zw8lLUYNKA1ne6SnSlQiBHfvILL\nU6GtEMN6cJfCIgLbc60Mo9xNbeP7/kn4D4YJugT4wWAGdbrivV6DxA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhYUV3TmpnWlFLNFZRellT\nT29xM01VbUJQNnArRWNoeTJ6dkJFazB0QzBZCkdxa1ROcWFOSGE4VlJnclNIU25S\nSHlQemNJSk1UNGNoVUh1aWhqTHk5bDAKLS0tIGhxTFNHbGNjVFlhbEU0K1JTZUpP\nUVIwL3lUczNCWExha0I3VmU3TytqUEUK/MvrNcGSd5Mn1PisOO1RuJQRVlZrKHJw\n6hdWNUuIqJnPh7TVN3Q8CJxiw/r4GpQliArSLKvYMP4bv5W1yPw+AQ==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvOTdCTUhnODFtVjBWS3JE\nV2hrUFFJZkwxcWFWdmY0TENVSUpzbUFmaDJzCmNKZUxNWEUwVFNudXAzT2NndU9w\naGJ3c1BqZ3hLdkhkK3QxMGNIdzdCQVkKLS0tIExkeS90SndQQ2lxTGtHOFpuUlNK\nRGxIUnliUFVrN2FSRDh6ZGFBQVdsajAKJ/LFLirrrtaLo5h9BdWqytvBsxvAVnU6\n9dNw57jrmxjHZTPKx06xdp7Q6jB6d7WBu5UCHOWyya5NrtbDiA9CCA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-06-03T21:08:15Z",
+		"mac": "ENC[AES256_GCM,data:f6GNT+abhZzFgdeMML40ea0DBS58uGOBPuMfEEcLEk7oiIK60/xue/MhwS91hAQFQJrhl7x19lvVqJW1IDQUKKNW3b9Bx/bFOrT3q2SlleeuqeVHrpgL/Qi+8bMLnL5nOXP6wx70CBbC5uSiJILwNfl+5mHBRk5La0AYMKxxlVI=,iv:xfa4oa6N5v3+t5vIoWW2863/JBIM4JcDERije//aV8M=,tag:hiunqHRxxJP1AgiIj3oyEg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
This is a prerequisite for setting up Freescout. Note: this means we need to think about backups for umbriel, which is tracked in https://github.com/NixOS/infra/issues/700.