### PR TITLE
Cache NAR files for upto a year

### DIFF
--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -247,6 +247,12 @@ resource "fastly_service_vcl" "cache" {
   }
 
   cache_setting {
+    name            = "cache-404"
+    cache_condition = "is-404"
+    ttl             = 86400 # 1 day
+  }
+
+  cache_setting {
     name            = "cache-nar"
     cache_condition = "is-nar"
     ttl             = 31557600 # the maximum. 1 year

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -137,6 +137,12 @@ resource "fastly_service_vcl" "cache" {
   name        = local.cache_domain
   default_ttl = 86400
 
+  # https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_vcl#activation-and-staging
+  # activate should not be set to true when stage is also set to true. While this combination will not cause any harm to the service,
+  # there is no logical reason to both stage and activate every set of applied changes.
+  activate = false  # set to true to deploy
+  stage    = true   # set to false to remove staging environment
+
   backend {
     address               = "s3.amazonaws.com"
     auto_loadbalance      = false

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -174,6 +174,13 @@ resource "fastly_service_vcl" "cache" {
     type      = "REQUEST"
   }
 
+  condition {
+    name      = "is-nar"
+    priority  = 10
+    statement = "req.url ~ \"^/nar/$\""
+    type      = "CACHE"
+  }
+
   domain {
     name = "cache.nixos.org"
   }
@@ -237,6 +244,12 @@ resource "fastly_service_vcl" "cache" {
     content_type    = "text/plain"
     response        = "Not Found"
     status          = 404
+  }
+
+  cache_setting {
+    name            = "cache-nar"
+    cache_condition = "is-nar"
+    ttl             = 31557600 # the maximum. 1 year
   }
 
   # Authenticate Fastly<->S3 requests. See Fastly documentation:

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -140,8 +140,8 @@ resource "fastly_service_vcl" "cache" {
   # https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_vcl#activation-and-staging
   # activate should not be set to true when stage is also set to true. While this combination will not cause any harm to the service,
   # there is no logical reason to both stage and activate every set of applied changes.
-  activate = false  # set to true to deploy
-  stage    = true   # set to false to remove staging environment
+  activate = false # set to true to deploy
+  stage    = true  # set to false to remove staging environment
 
   backend {
     address               = "s3.amazonaws.com"

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -183,7 +183,7 @@ resource "fastly_service_vcl" "cache" {
   condition {
     name      = "is-nar"
     priority  = 10
-    statement = "req.url ~ \"^/nar/\""
+    statement = "beresp.status == 200 && req.url ~ \"^/nar/\" "
     type      = "CACHE"
   }
 
@@ -250,12 +250,6 @@ resource "fastly_service_vcl" "cache" {
     content_type    = "text/plain"
     response        = "Not Found"
     status          = 404
-  }
-
-  cache_setting {
-    name            = "cache-404"
-    cache_condition = "is-404"
-    ttl             = 86400 # 1 day
   }
 
   cache_setting {

--- a/terraform/cache.tf
+++ b/terraform/cache.tf
@@ -177,7 +177,7 @@ resource "fastly_service_vcl" "cache" {
   condition {
     name      = "is-nar"
     priority  = 10
-    statement = "req.url ~ \"^/nar/$\""
+    statement = "req.url ~ \"^/nar/\""
     type      = "CACHE"
   }
 


### PR DESCRIPTION
NAR files are immutable. There is no harm in caching them for longer than the default 24 hours.    It might save us on bandwidth cost to S3 and lower costs?