### PR TITLE
go-neb: fix port

### DIFF
--- a/build/pluto/prometheus/alertmanager.nix
+++ b/build/pluto/prometheus/alertmanager.nix
@@ -109,7 +109,7 @@
 
   services.go-neb = {
     enable = true;
-    bindAddress = "localhost:4500";
+    bindAddress = "localhost:4050";
     baseUrl = "http://localhost";
     secretFile = config.age.secrets.alertmanager-matrix-forwarder.path;
     config = {


### PR DESCRIPTION
When binding to localhost I introduced a typo in the port number which broke the alerting pipeline.