### PR TITLE
Store NGI email

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -124,7 +124,7 @@
       ];
       loginAccount = {
         encryptedHashedPassword = ../../secrets/ngi-nixos-org-email-login.umbriel;
-        storeEmail = false;
+        storeEmail = true;
       };
     };
 


### PR DESCRIPTION
@fricklerhandwerk asked me to also onboard the ngi email onto freescout, so the mails needs to be stored on the server.

Note that to be able to onboard everybody onto freescout, I'll also need the emails it currently gets forwarded to and the login credentials.