### PR TITLE
remove erictapen for ngi@nixos.org in mailing-lists.nix

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -118,7 +118,6 @@
         ../../secrets/fricklerhandwerk-email-address.umbriel # https://github.com/fricklerhandwerk
         ../../secrets/wamirez-email-address.umbriel # https://github.com/wamirez
         ../../secrets/idabzo-email-address.umbriel # https://github.com/idabzo
-        ../../secrets/erictapen-email-address.umbriel # https://github.com/erictapen
         ../../secrets/eljamm-email-address.umbriel # https://github.com/eljamm
         ../../secrets/JulienMalka-email-address.umbriel # https://github.com/JulienMalka
         ../../secrets/OPNA2608-email-address.umbriel # https://github.com/OPNA2608


### PR DESCRIPTION
If I understand this right from @infinisil's email, I should access this address through freescout now.