### PR TITLE
Rename gh-releases.nixos.org to artifacts.nixos.org

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -41,13 +41,13 @@ D("nixos.org",
 
 	// fastly
 	CNAME("_acme-challenge.channels", "9u55qij5w2odiwqxfi.fastly-validations.com."),
-	CNAME("_acme-challenge.gh-releases", "4pgghpw19iuvzjiz9k.fastly-validations.com."),
+	CNAME("_acme-challenge.artifacts", "bsk6mjvi6b1r6wekb0.fastly-validations.com."),
 	CNAME("_acme-challenge.releases", "s731ezp9ameh5f349b.fastly-validations.com."),
 	CNAME("_acme-challenge.tarballs", "vnqm62k5sjx9jogeqg.fastly-validations.com."),
 	CNAME("cache", "dualstack.v2.shared.global.fastly.net."),
 	CNAME("cache-staging", "dualstack.v2.shared.global.fastly.net."),
 	CNAME("channels", "dualstack.v2.shared.global.fastly.net."),
-	CNAME("gh-releases", "dualstack.v2.shared.global.fastly.net."),
+	CNAME("artifacts", "dualstack.v2.shared.global.fastly.net."),
 	CNAME("releases", "dualstack.v2.shared.global.fastly.net."),
 	CNAME("tarballs", "dualstack.v2.shared.global.fastly.net."),
 


### PR DESCRIPTION
This renames the GitHub releases proxy service to use a more generic name that better reflects its purpose as a general artifacts CDN.

Changes:
- Renamed DNS records from gh-releases to artifacts
- Updated ACME challenge CNAME to match Terraform output
- Renamed terraform/gh-releases.tf to terraform/artifacts.tf
- Updated all references in Terraform configuration

The service continues to proxy GitHub releases for NixOS projects through Fastly CDN with IPv6 support.