### PR TITLE
Alias cfp.nixcon.org to talks.nixcon.org

### DIFF
--- a/dns/nixcon.org.js
+++ b/dns/nixcon.org.js
@@ -36,7 +36,7 @@ D("nixcon.org",
 	CNAME("2025", "nixcon.github.io."),
 
 	// Scheduling
-	CNAME("cfp", "pretalx.com."),
+	CNAME("cfp", "talks.nixcon.org."),
 	CNAME("talks", "pretalx.com."),
 
 	// Ticketing


### PR DESCRIPTION
See https://matrix.to/#/!GlDwnQuDPMNzaUXCJB:lassul.us/$XlMOVN5dZnWuL6f-bidD-yV1aHtJC57uqOtqp1Z_hFs?via=lassul.us&via=matrix.org&via=nixos.dev

cfp.nixcon.org isn't valid anymore

Ping @Lassulus 