### PR TITLE
channels: 24.11 is unmaintained

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -58,17 +58,17 @@ rec {
     "nixos-24.11" = {
       job = "nixos/release-24.11/tested";
       variant = "primary";
-      status = "deprecated";
+      status = "unmaintained";
     };
     "nixos-24.11-small" = {
       job = "nixos/release-24.11-small/tested";
       variant = "small";
-      status = "deprecated";
+      status = "unmaintained";
     };
     "nixpkgs-24.11-darwin" = {
       job = "nixpkgs/nixpkgs-24.11-darwin/darwin-tested";
       variant = "darwin";
-      status = "deprecated";
+      status = "unmaintained";
     };
 
     "nixos-24.05" = {


### PR DESCRIPTION
As the reference says https://nixos.github.io/release-wiki/EOL-Cleanup.html