### PR TITLE
builders: prep for build dir move in nix 2.30

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -6,6 +6,17 @@
 }:
 
 {
+  fileSystems."/nix/var/nix/builds" = {
+    device = "none";
+    fsType = "tmpfs";
+    options = [
+      "huge=within_size"
+      "mode=0700"
+      "nosuid"
+      "nodev"
+    ];
+  };
+
   nix = {
     package = pkgs.nix;
     nrBuildUsers = config.nix.settings.max-jobs + 32;

--- a/builders/common/system.nix
+++ b/builders/common/system.nix
@@ -17,7 +17,4 @@
 
   # use memory more efficiently at the cost of some compute
   zramSwap.enable = true;
-
-  # enable huge pages for tmpfs on /tmp
-  boot.tmp.tmpfsHugeMemoryPages = "within_size";
 }

--- a/builders/profiles/hetzner-ax101r.nix
+++ b/builders/profiles/hetzner-ax101r.nix
@@ -13,12 +13,13 @@
   boot.supportedFilesystems.zfs = true;
   networking.hostId = "91312b0a";
 
-  boot.tmp = {
-    useTmpfs = true;
-    # 128G tmpfs, 128G RAM for standard builders
-    # 160G tmpfs, 96G RAM for big parallel builders
-    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "160G" else "128G";
-  };
+  # 128G tmpfs, 128G RAM (+zram swap) for standard builders
+  # 160GB tmpfs, 96 GB RAM (+zram swap) for big-parallel builders
+  fileSystems."/nix/var/nix/builds".options =
+    if lib.elem "big-parallel" config.nix.settings.system-features then
+      [ "size=160G" ]
+    else
+      [ "size=128G" ];
 
   boot.initrd.availableKernelModules = [
     "nvme"

--- a/builders/profiles/hetzner-rx220.nix
+++ b/builders/profiles/hetzner-rx220.nix
@@ -1,10 +1,4 @@
 {
-  config,
-  lib,
-  ...
-}:
-
-{
   imports = [
     ../boot/efi-grub.nix
   ];
@@ -13,13 +7,8 @@
   boot.supportedFilesystems.zfs = true;
   networking.hostId = "91312b0a";
 
-  # 96G for build roots, 160G for working memory
-  boot.tmp = {
-    useTmpfs = true;
-    # 128G tmpfs, 128G RAM for standard builders
-    # 128G tmpfs, 128G RAM for big parallel builders
-    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "128G" else "128G";
-  };
+  # 128G tmpfs, 128G RAM (+zram swap)
+  fileSystems."/nix/var/nix/builds".options = [ "size=128G" ];
 
   boot.initrd.availableKernelModules = [
     "nvme"


### PR DESCRIPTION
>    build-dir no longer defaults to $TMPDIR
>
>    The directory in which temporary build directories are created no longer defaults to TMPDIR or /tmp, to avoid builders making their directories world-accessible. This behavior allowed escaping the build sandbox and can cause build impurities even when not used maliciously. We now default to builds in NIX_STATE_DIR (which is /nix/var/nix/builds in the default configuration).

via https://discourse.nixos.org/t/nix-2-30-0-released/66449