### PR TITLE
Use /experimental-installer instead of /nix

### DIFF
--- a/terraform/artifacts.tf
+++ b/terraform/artifacts.tf
@@ -4,7 +4,9 @@
 # It transparently follows GitHub's S3 redirects to provide direct file access.
 #
 # Supported URL patterns:
-# - /nix/* -> /NixOS/experimental-nix-installer/releases/download/*
+# - /experimental-installer/tag/* -> /NixOS/experimental-nix-installer/releases/download/*
+# - /experimental-installer -> /NixOS/experimental-nix-installer/releases/latest/download/nix-installer.sh
+# - /experimental-installer/* -> /NixOS/experimental-nix-installer/releases/latest/download/*
 # - /patchelf/* -> /NixOS/patchelf/releases/download/*
 #
 # Testing commands:
@@ -97,8 +99,14 @@ resource "fastly_service_vcl" "artifacts" {
     content  = <<-EOT
       # Only rewrite if this is the first request (not a restart)
       if (!req.http.X-Rewritten) {
-        if (req.url ~ "^/nix/") {
-          set req.url = regsub(req.url.path, "^/nix/", "/NixOS/experimental-nix-installer/releases/download/");
+        if (req.url ~ "^/experimental-installer/tag/") {
+          set req.url = regsub(req.url.path, "^/experimental-installer/tag/", "/NixOS/experimental-nix-installer/releases/download/");
+          set req.http.X-Rewritten = "true";
+        } else if (req.url ~ "^(/experimental-installer|/experimental-installer/)$") {
+          set req.url = regsub(req.url.path, "^(/experimental-installer|/experimental-installer/)$", "/NixOS/experimental-nix-installer/releases/latest/download/nix-installer.sh");
+          set req.http.X-Rewritten = "true";
+        } else if (req.url ~ "^/experimental-installer/") {
+          set req.url = regsub(req.url.path, "^/experimental-installer", "/NixOS/experimental-nix-installer/releases/latest/download/");
           set req.http.X-Rewritten = "true";
         } else if (req.url ~ "^/patchelf/") {
           set req.url = regsub(req.url.path, "^/patchelf/", "/NixOS/patchelf/releases/download/");


### PR DESCRIPTION
Redirect from /experimental-installer to the experimental installer
releases instead of /nix. The installer is still experimental so that
should be clear from the URL.

Also add a few redirects to make URLs nicer.

Redirect /experimental-nix to the latest GitHub release script,
/experimental-nix/* to the latest GitHub arch specific installers, and
use /experimental-nix/tag/$version/*
to redirect to specific releases.

This allows for a shorter URL for the most common install instruction,
and it more closely mirrors the URL structure used by DetSys which is
upstream for experimental-nix-installers

https://artifacts.nixos.org/experimental-installer -> https://github.com/NixOS/experimental-nix-installer/releases/latest/download/nix-installer.sh
https://artifacts.nixos.org/experimental-installer/* -> https://github.com/NixOS/experimental-nix-installer/releases/latest/download/*
https://artifacts.nixos.org/experimental-installer/tag/* -> https://github.com/NixOS/experimental-nix-installer/releases/download/*