### PR TITLE
hydra-proxy: limit per client request rate

### DIFF
--- a/build/hydra-proxy.nix
+++ b/build/hydra-proxy.nix
@@ -43,6 +43,9 @@
         default "anubis";
         nix.dev-Uogho3gi "hydra-server";
       }
+
+      limit_req_zone $binary_remote_addr zone=hydra-server:8m rate=2r/s;
+      limit_req_status 429;
     '';
 
     eventsConfig = ''
@@ -77,6 +80,9 @@
 
       locations."/" = {
         proxyPass = "http://$upstream";
+        extraConfig = ''
+          limit_req zone=hydra-server burst=5;
+        '';
       };
 
       locations."~ ^/build/\\d+/download/" = {


### PR DESCRIPTION
Put a rate limit on per source adress requests to hydra-server

> Excessive requests are delayed until their number exceeds the maximum burst size in which case the request is terminated with an [error](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status).

https://nginx.org/en/docs/http/ngx_http_limit_req_module.html