### PR TITLE
Allow users to access the Explore feature in Grafana

### DIFF
--- a/build/pluto/grafana.nix
+++ b/build/pluto/grafana.nix
@@ -5,7 +5,10 @@
     enable = true;
     settings = {
       "auth.anonymous".enabled = true;
-      users.allow_sign_up = true;
+      users = {
+        allow_sign_up = true;
+        viewers_can_edit = true;
+      };
       server = {
         domain = "grafana.nixos.org";
         root_url = "https://grafana.nixos.org";


### PR DESCRIPTION
Currently we use the default setting of the NixOS Grafana module that disables the [Explore functionality](https://grafana.com/docs/grafana/latest/explore/). For adhoc queries the explore page provides a better user experience than using https://prometheus.nixos.org/query, so I think we should enable this.