### PR TITLE
Store NixCon emails for freescout

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -135,6 +135,10 @@
         ../../secrets/ral-email-address.umbriel # Matrix: @ral:fairydust.space
         ../../secrets/gefla-email-address.umbriel # https://github.com/gefla
       ];
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/nixcon-email-login.umbriel;
+        storeEmail = true;
+      };
     };
 
     "cfp@nixcon.org" = {

--- a/non-critical-infra/secrets/nixcon-email-login.umbriel
+++ b/non-critical-infra/secrets/nixcon-email-login.umbriel
@@ -1,0 +1,31 @@
+{
+	"data": "ENC[AES256_GCM,data:v6AgrbN+ofutr+lo+o4BkC0yPop81rU7QMoC0Z7LGWHctGwL/Zc8BkHsCHEPyGJtAA4S2D8nFPLsil4n0A==,iv:EmHzvLI8WKS3ONtRYRMnC8RQvGsZQaYJWs70ZXzk6rE=,tag:84HVihatpSQmvSq1m+CoKw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGT014UGN3djZGaGYxdUVJ\nYUs0dis4eDlDSVYraWhEMnhJWktiUEFWVUdNCndleVNJNUdneUtabjI2cmFoNEpm\neXBSZEhiUis5OFM4clI2d2t3alNMOEUKLS0tIE1ZOUxuNjBieDVGLzMwb0hlWHdv\nTEhBNktmZ0c5a1N4TEprdEduVXpPSFUKX6Q4WJoHT0q/pyYeQqboKN1PCv8YufH3\nM7fTK/lyWHanPv0liDxwXF/23zfDUqQZWhWKTq1ddAxJaToTDJVA/Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvS0kzWHRrbnhmdCtNQ3Yw\nUHdlNHFhbHdKQ1lUM0xzTGZtSkNKVkVGVjM0Ck1GUExrNlZhL1drbjVBUnhjZDlh\nL3hrZFFrWDhUdTFPSzBXNDdkUFI3bUUKLS0tIEFLLzNHWWlDd2dRdytaazN6Tkpk\naHFFcEEwbFl0QzdxbWYyWlBKYUxkajQKwDmyfolWyuGuf3Qn4hYMWTY1aZ7AQl3H\nTn9iW+rRRIkrQP30/uqJ29Le7ct/gD/VDUXGgl2Dqvo94luz4XjO5g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsR0l3WU1Rd013cDNYbE1O\nK3lBYjFId2hEdTdrbVplVlV5bElKa1ozaGxFCjJoT0o3U0t2WXJFOFFrckpEZE1U\nM202OGtCenJtS2FGUjVud1BwN0hUdHMKLS0tIGZRS21Qd3RjK3NyUTZKeG5Sa2xQ\nRkpGdXNidzVFbEVuc0QrdkNFc0lVQmcKQtl8Q1T3vrsnQjsTgZ9kWRGfVDgufEP9\ntz+qZ69lqa1GhpO+cYqcZ7J9i1+70mh49gcRiOg5391eu3BZTkpElA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLYzI0b2FjMmM5MGN2Z2JM\nbjhxZDJsdHdjMnlieDJuRmVCUy9ycG1tSkdNClAxRWpFSnI0YXRFMTE3Y2NDblZp\nV2VFdWRHbnUvU3N3OE54SlJYZVVoNTgKLS0tIEpVMUQ1YTI1dkRLTUNDSEduWW1I\nVHYwVFA1cVIvQ2VsVHcwVENCWW02WDAKL2OvMBbbDlv5XyplFer9i39cpR6fDEGy\nYooSzLS39RjkIBTPLpPSwcJPfKOzmwKuRxmPJCO8a6IIMOJTbNruyA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoa1c5SS95aHkxT0hLbGto\neURZWkxOVDVvbGVIY3BRL0F4YXBGK3lINFNZCi9KeGlUMDBSVyttbEtONGNNZVVw\nM09BRENjQ1hYbjZEMEE2eGxRSkxXTFEKLS0tIDE4anBmSGZKcU8zOGZEZXFNQ2lQ\ncXErMGY4NjcyRkt1ZFdZMkp6QnBvUTgKZZG9hA0C4uxpiXFO58fsT1Tjg797qTMo\nans/sZjIEV8QtSojDJWWLhJos1U2KuHg0R5phKqPvYwRpl38FnH1dA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-08-11T13:44:41Z",
+		"mac": "ENC[AES256_GCM,data:hsUlG+s3uIdP6MpAL7HQSu2X54AzREgpjgl3omgoMgfXjjBjwDQbNUONHg8osAQxZbQCE0XDL//x2apqCgDR+znAi0UhZvwEFIg3ia4wd3xtLWkKuHTh2QgvjlQJag7FnoeS/TkptjgqNIzr8R6u4Fsrv8+Xuc0+MSVQZgboQjM=,iv:fSlfVoAg/FKQ/Q7cQVobVpxUwKZtVjD1CPDZUk6NM2Y=,tag:w4iCYHVTW8+IjUgG13Bxgg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
It's getting harder and harder to try to keep track of NixCon emails, let's enable the use of freescout too.

Same as #748 and #746 and others. I'll onboard the account onto freescout once merged and deployed.

CC @ners @john-rodewald @Lassulus 