### PR TITLE
fix: staging-hydra secret permissions for server and client

### DIFF
--- a/non-critical-infra/hosts/staging-hydra/hydra.nix
+++ b/non-critical-infra/hosts/staging-hydra/hydra.nix
@@ -166,12 +166,12 @@ in
     "queue-runner-server.key" = {
       sopsFile = ../../secrets/queue-runner-server.key.staging-hydra;
       format = "binary";
-      owner = config.systemd.services.hydra-queue-runner.serviceConfig.User;
+      owner = config.systemd.services.nginx.serviceConfig.User;
     };
     "queue-runner-client.key" = {
       sopsFile = ../../secrets/queue-runner-client.key.staging-hydra;
       format = "binary";
-      owner = config.systemd.services.hydra-queue-runner.serviceConfig.User;
+      owner = config.systemd.services.hydra-queue-builder-v2.serviceConfig.User;
     };
     hydra-users = {
       sopsFile = ../../secrets/hydra-users.staging-hydra;


### PR DESCRIPTION
messed this up and only noticed it after deployment. Buts its now deployed and works: https://staging-hydra.nixos.org/machines 