### PR TITLE
Update foundation emails

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -23,9 +23,6 @@
     };
 
     "finance@nixos.org" = {
-      forwardTo = [
-        ../../secrets/edolstra-email-address.umbriel # https://github.com/edolstra
-      ];
       loginAccount = {
         encryptedHashedPassword = ../../secrets/finance-email-login.umbriel;
         storeEmail = true;
@@ -45,9 +42,6 @@
     };
 
     "foundation@nixos.org" = {
-      forwardTo = [
-        ../../secrets/edolstra-foundation-email-address.umbriel # https://github.com/edolstra
-      ];
       loginAccount = {
         encryptedHashedPassword = ../../secrets/foundation-email-login.umbriel;
         storeEmail = true;
@@ -56,7 +50,6 @@
 
     "fundraising@nixos.org" = {
       forwardTo = [
-        ../../secrets/fricklerhandwerk-email-address.umbriel # https://github.com/fricklerhandwerk
         "foundation@nixos.org"
       ];
     };
@@ -131,7 +124,7 @@
 
     "partnerships@nixos.org" = {
       forwardTo = [
-        ../../secrets/refroni-email-address.umbriel # https://github.com/refroni
+        "foundation@nixos.org"
       ];
     };
 


### PR DESCRIPTION
1. Offboard ex-board member @edolstra
2. Offboard @fricklerhandwerk from fundraising email
3. Redirect partnerships@nixos.org to foundation@nixos.org instead of just @refroni

1 and 2 are definitely fine, but I have to double check 3. Will mark as ready when done.