### PR TITLE
builders aarch64: useTmpfs only for hopeful-rivest

### DIFF
--- a/builders/instances/hopeful-rivest.nix
+++ b/builders/instances/hopeful-rivest.nix
@@ -9,6 +9,12 @@
     system-features = [ "big-parallel" ];
   };
 
+  # 128G RAM only, but seems to be OK in practice
+  boot.tmp = {
+    useTmpfs = true;
+    tmpfsSize = "128G";
+  };
+
   networking = {
     hostName = "hopeful-rivest";
     domain = "builders.nixos.org";

--- a/builders/profiles/hetzner-rx220.nix
+++ b/builders/profiles/hetzner-rx220.nix
@@ -1,10 +1,4 @@
 {
-  config,
-  lib,
-  ...
-}:
-
-{
   imports = [
     ../boot/efi-grub.nix
   ];
@@ -12,14 +6,6 @@
   disko.devices = import ../disk-layouts/efi-zfs-raid0.nix { };
   boot.supportedFilesystems.zfs = true;
   networking.hostId = "91312b0a";
-
-  # 96G for build roots, 160G for working memory
-  boot.tmp = {
-    useTmpfs = true;
-    # 128G tmpfs, 128G RAM for standard builders
-    # 128G tmpfs, 128G RAM for big parallel builders
-    tmpfsSize = if lib.elem "big-parallel" config.nix.settings.system-features then "128G" else "128G";
-  };
 
   boot.initrd.availableKernelModules = [
     "nvme"


### PR DESCRIPTION
We're getting out of RAM on goofy-hopcroft commonly: https://grafana.nixos.org/d/rYdddlPWk/node-exporter-full?orgId=1&var-job=node&var-node=goofy-hopcroft.builder.nixos.org:9100&from=now-30d&to=now&viewPanel=panel-78

While it does have double the RAM than hopeful-rivest, the 40 jobs can eat really lots of /tmp.
Some particular jobs even eat many gigabytes each.

As hopeful-rivest seems OK-ish, I'm leaving tmpfs in there for now: https://grafana.nixos.org/d/rYdddlPWk/node-exporter-full?orgId=1&var-job=node&var-node=hopeful-rivest.builder.nixos.org:9100&from=now-30d&to=now&viewPanel=panel-78