### PR TITLE
caliban: run the nixpkgs-swh project

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -104,6 +104,7 @@ D("nixos.org",
 	CNAME("chat", "caliban"),
 	CNAME("live", "caliban"),
 	CNAME("matrix", "caliban"),
+	CNAME("nixpkgs-swh", "caliban"),
 	CNAME("survey", "caliban"),
 	CNAME("vault", "caliban"),
 	DMARC_BUILDER({

--- a/flake.lock
+++ b/flake.lock
@@ -404,6 +404,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-swh": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1757256775,
+        "narHash": "sha256-EHGEsqY8xxgeH46+5cfsydBiI57p5WurrUWoYJfo5hw=",
+        "owner": "nix-community",
+        "repo": "nixpkgs-swh",
+        "rev": "5c6540373e7c21977131951615b016ccad540e31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs-swh",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1755829505,
@@ -452,6 +472,7 @@
         "hydra": "hydra",
         "nixos-channel-scripts": "nixos-channel-scripts",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-swh": "nixpkgs-swh",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rfc39": "rfc39",
         "simple-nixos-mailserver": "simple-nixos-mailserver",

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,11 @@
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nixpkgs-swh = {
+      url = "github:nix-community/nixpkgs-swh";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs =
     inputs@{ flake-parts, ... }:

--- a/non-critical-infra/hosts/caliban/default.nix
+++ b/non-critical-infra/hosts/caliban/default.nix
@@ -20,6 +20,7 @@
     ../../modules/prometheus/node-exporter.nix
     ../../modules/vaultwarden.nix
     ./limesurvey-tmp.nix
+    ./nixpkgs-swh.nix
   ];
 
   fileSystems."/boot-1" = {

--- a/non-critical-infra/hosts/caliban/nixpkgs-swh.nix
+++ b/non-critical-infra/hosts/caliban/nixpkgs-swh.nix
@@ -1,0 +1,32 @@
+{ inputs, config, ... }:
+let
+  cfg = config;
+in
+{
+  imports = [
+    inputs.nixpkgs-swh.nixosModules.nixpkgs-swh
+  ];
+  config = {
+    services = {
+      nixpkgs-swh = {
+        enable = true;
+      };
+      nginx = {
+        enable = true;
+        virtualHosts = {
+          "nixpkgs-swh.nixos.org" = {
+            enableACME = true;
+            forceSSL = true;
+
+            locations."/" = {
+              root = cfg.services.nixpkgs-swh.outputDir;
+              extraConfig = ''
+                autoindex on;
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
The goal is to make a revival of the project described in this [blog post](https://www.tweag.io/blog/2020-06-18-software-heritage/).

This has been running for several years on the nix-community infrastructure but it stopped working about 2 years ago, when we (the nix-community) decided to stop using the buildkite CI.

After some informal discussions with some of you, it appears this could be deployed on the NixOS non critical infra.

### How does it basically works

Every day, a `sources.json` file is generated by evaluating nixpkgs. This file contains a description of all external source codes used by nixpkgs. This file can then be consumed by the Software Heritage infrastructure in order to archive our sources.

### TODOs
 
- [x] Deploy it on the NixOS infra
- [ ] Set up the domain `nixpkgs-swh.nixos.org` (or find another fqdn)
- [ ]  Ask Software Heritage to update their URL pointing the `sources.json` file (the Software Heritage people are already ok to do it)