### PR TITLE
builders aarch64: do NOT useTmpfs, not even on hopeful-rivest

### DIFF
--- a/builders/instances/hopeful-rivest.nix
+++ b/builders/instances/hopeful-rivest.nix
@@ -9,12 +9,6 @@
     system-features = [ "big-parallel" ];
   };
 
-  # 128G RAM only, but seems to be OK in practice
-  boot.tmp = {
-    useTmpfs = true;
-    tmpfsSize = "128G";
-  };
-
   networking = {
     hostName = "hopeful-rivest";
     domain = "builders.nixos.org";


### PR DESCRIPTION
I was too optimistic.  After seeing repeated kills of Firefox builds during linking, I think this is more harm than good as it was. Perhaps some of the builds got more expensive over time.

The graph doesn't look good lately:
https://grafana.nixos.org/d/rYdddlPWk/node-exporter-full?orgId=1&var-job=node&var-node=hopeful-rivest.builder.nixos.org:9100&from=now-7d&to=now&viewPanel=panel-78