### PR TITLE
Add elections email

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -103,6 +103,13 @@
       };
     };
 
+    "elections@nixos.org" = {
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/elections-email-login.umbriel;
+        storeEmail = true;
+      };
+    };
+
     "ngi@nixos.org" = {
       loginAccount = {
         encryptedHashedPassword = ../../secrets/ngi-nixos-org-email-login.umbriel;

--- a/non-critical-infra/secrets/elections-email-login.umbriel
+++ b/non-critical-infra/secrets/elections-email-login.umbriel
@@ -1,0 +1,31 @@
+{
+	"data": "ENC[AES256_GCM,data:7tM+BCtXDNpk1YUziJAViGflNHSdVDuktlaU6XwGONxMwspUKiLv4m1sBHH7U0AW+QJBbRtEQssBl/7bCQ==,iv:FGICEI+5TP/+a4Cz9yWpIraPTZ1AUt2dKp4F7ZJI4fk=,tag:NrIhcCAiASj1njHn39HVSg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjdkJlV1Q0NmZEcVVnQVpI\nVWsxdWd1RVZMT3ZMVWhBQzlyaEttdFpFZjFVCi8rQzkybHJ5eTgvU21PTzZyYkhN\nNEM3enJRY3dnSXF2Zzkvb1pscGJDWmMKLS0tIDRoaHZheGVjc2ZZdUo4SzczRWlC\nZEh0N3BsVlNicDk5OHhaVU55ZlJ5azQKHWQhNSoeM09Kd2Btl5xhFg1rbbvnJIik\nuNCO7rYCfiCJcEhv5OaXMc7EKHdBRmxxLz5TAnaqN4/pCnIBhc08Jw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUVWlFbFRpZFhNQSt0Y2wr\ncUdsV3ZzNUp1M2xpenVjdk51MEpoQnB2aVZnCjAxek5qNFpGeEYwcXVpSjRiUCs1\ndVlaR1NJaUx5L1ErdUZ5Y2pCekU4L3MKLS0tIDcyYmtmc1o2SXF1bXFldnUzZmU2\nMnhRR3p5T1dkY1gvSjlKbDRKVEFQTWsKS/EB2i8sDp6FANEUrVKnShcIzTslnogm\n0HCWSIorOkqTFHawAyE/oUk5VOyU4JdkSo4ZFlzLdosLq0zWwCRHpw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmcnY4U0hWSTNYVERxUkg2\nVFpISVJBSFovcjNFUjNTempHZFRNNHM4S0JnCncyWE9hQTlZQzVWbHQ5dm9oeUNm\nWHAyRTJUK01oY0JqcWdQMUllbWovOW8KLS0tIGdhNFhYK01xSnoxd0hUVWFkMnNM\nMEtYT3ZJS0VFRWsxakdSUFFKejdReUEKgmZC+EQAvQEsOvfD3hiyVaFtvC2PWVlH\nqE4RIThK0CJ32zBq6wJGYgBC/4IDQlszlZiClbZ+LBbVIDerAtvL1g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFdXhkRThjNFk4ZGgyYlUy\nRjhnVXYyNXZIekhUSzdhVXlxNTRvcjZpSEJzCkM5d3U5Q1ExMDFnaFVlVkNTY2to\nYiszbXlQdytMd2Q0UXJFVzJxZjBlemsKLS0tIHBOcllXZi90NkpJbDJVMFJ3NWU3\nVlkyampzMEsraXJRWSt3RDZ2Qm9IMkkK9slGDyDWQHJFU+no8i9AjrriDDTypuzW\n8xFqF8dHVZRlHDe1JldwI78W+90oqRkwD9UPqhB5vNC48xSd77Pq6Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTYkZLWWxKT3N0US95aTJ3\nc0VEWlJ0bkljUU5KRFNtdFdDdGxBbVlPU2pFCnZLVW8vZVpLU1E2NHY0eGRqSUp1\nNXg1eVMyeG0wVVN3b3dPN0gySzR5eUkKLS0tIEt6Zm5pOXUzdzk4L1hHMm5EeVYv\naVdkdmdVd04zUGpLck9TSmc4UEJoTXMKh+8YyhlQHRmshlecrFX/7CladcbrWVeQ\nLurJ0L29X8CDGF1SwWbQ5ZyBQbGLuqYc7h1Co05cKaUSNcLTxoAvWg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-09-09T15:40:03Z",
+		"mac": "ENC[AES256_GCM,data:haLAj3NRhlAzo03vNUKT+Jm7RGj7AP3CNfC38PYTFeuI+V6UNFbQwXOaEcwnYDOpSJWXsGgmtYDCLaRBbAN1HpgvFIhviv54yQU5NW/tEmd1EwuSQQMyeVIPkwwQOdfDgL2YvoB3LIEmX46KKH1iO+lL72jxEB3aFYz5ktmo0yY=,iv:M5YIOM45DamFiyCLGiC3GrdKf74lazYnhleErQnTbfg=,tag:AAlVoGY1nSJu2FwdlC+xHQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
Will set up freescout once deployed, but the @NixOS/ec-2025 can also send emails with scripts with the SMTP credentials in the vault (if you don't have a vault account, ask one of the admins: https://github.com/NixOS/org/blob/main/doc/vault.md#admins)