### PR TITLE
fix: Reflected XSS on channels.nixos.org and releases.nixos.org

### DIFF
--- a/terraform/s3_listing.html.tpl
+++ b/terraform/s3_listing.html.tpl
@@ -174,8 +174,10 @@
         var content = $.map(info.prefix.split('/'), function(pathSegment) {
           processedPathSegments =
               processedPathSegments + encodeURIComponent(pathSegment) + '/';
-          return '<a href="?prefix=' + processedPathSegments + '">' + pathSegment +
-                 '</a>';
+          var link = document.createElement('a');
+          link.setAttribute('href', baseUrl + processedPathSegments.replace(/"/g, '&quot;'));
+          link.innerText = pathSegment;
+          return link.outerHTML;
         });
         $('#navigation').html(root + content.join(' / '));
       } else {
@@ -217,10 +219,10 @@
       if (prefix) {
         // make sure we end in /
         var prefix = prefix.replace(/\/$/, '') + '/';
-        s3_rest_url += '&prefix=' + prefix;
+        s3_rest_url += '&prefix=' + encodePath(prefix);
       }
       if (marker) {
-        s3_rest_url += '&marker=' + marker;
+        s3_rest_url += '&marker=' + encodePath(marker);
       }
       return s3_rest_url;
     }
@@ -287,7 +289,7 @@
                   LastModified: '',
                   Size: '',
                   keyText: '../',
-                  href: S3BL_IGNORE_PATH ? '?prefix=' + up : '../'
+                  href: S3BL_IGNORE_PATH ? '?prefix=' + encodePath(up) : '../'
                 },
             row = renderRow(item, cols);
         content.push(row + '\n');


### PR DESCRIPTION
Additional hardening such as adding a CSP header will be done later on but it requires some additional upstream to be useful.

Upstream already merged the fix we submitted: https://github.com/rufuspollock/s3-bucket-listing/commit/57ed3fa7be308ac82cfa18c99e207f1d1dc9ef74

Upgrading to the latest version of the s3-bucket-listing script seems to require additional changes and the security fix is small. It seems preferable to only deal with the security fix at this point and deal with the upgrade and potential complications later on.

Fixes GHSA-3xg5-p8ch-832g