### PR TITLE
fix: Listing of sub-directories of S3 buckets should work

### DIFF
--- a/terraform/s3_listing.html.tpl
+++ b/terraform/s3_listing.html.tpl
@@ -175,7 +175,7 @@
           processedPathSegments =
               processedPathSegments + encodeURIComponent(pathSegment) + '/';
           var link = document.createElement('a');
-          link.setAttribute('href', baseUrl + processedPathSegments.replace(/"/g, '&quot;'));
+          link.setAttribute('href', processedPathSegments.replace(/"/g, '&quot;'));
           link.innerText = pathSegment;
           return link.outerHTML;
         });


### PR DESCRIPTION
This regression was introduced by 4030d7dc2585ec7ff52f2a80d9405c8a71fc93fa.

The mistake was made when "rebasing" the patch that was submitted to upstream to the version vendored in this repository. Upstream as a notion of base URL that is not present here.