### PR TITLE
hydra-proxy: Don't rate limit the metrics endpoint

### DIFF
--- a/build/hydra-proxy.nix
+++ b/build/hydra-proxy.nix
@@ -78,6 +78,10 @@
         Allow: /$
       '';
 
+      locations."~ ^/job/[^/]+/[^/]+/metrics/metric/" = {
+        proxyPass = "http://hydra-server";
+      };
+
       locations."/" = {
         proxyPass = "http://$upstream";
         extraConfig = ''


### PR DESCRIPTION
We're currently rate-limiting the endpoint for metrics and the limit isn't enough to view metrics for all jobs. For example [this](https://hydra.nixos.org/job/nixpkgs/trunk/metrics#tabs-charts) currently fails. This patch ensures that these endpoints aren't rate-limited.