### PR TITLE
dns: Remove stale DNS records for an old NGI cache

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -129,9 +129,6 @@ D("nixos.org",
 	CNAME("freescout", "umbriel.nixos.org."),
 
 	// ngi
-	CNAME("cache.ngi0", "d2tu257wv37zz1.cloudfront.net."),
-	CNAME("_293364b7f7ebb076ac287cd132f8b316.cache.ngi0", "_6a75cfb0c20f4eaac96b72afaffb489b.auiqqraehs.acm-validations.aws."),
-
 	A("makemake.ngi", "116.202.113.248"),
 	AAAA("makemake.ngi", "2a01:4f8:231:4187::"),
 	CNAME("buildbot.ngi", "makemake.ngi.nixos.org."),


### PR DESCRIPTION
My understanding is that in the past a Nix Cache used to be hosted in a S3 bucket that was populated by a Hydra instance running for the NGI team. This Hydra service is gone since at least [June 2024](https://github.com/ngi-nix/ngipkgs/commit/01a6dc8e4b2658ccba0c5842b6c795e9ee5cc68c).

The DNS records point to cloudfront and there [used to be terraform config](https://github.com/NixOS/infra/issues/326) for this cache that setup a S3 bucket (`ngi0-cache`). I don't have access to AWS, so I don't know if the bucket still exists, if it does, we should probably delete it as well as the cloudfront endpoint.