### PR TITLE
Switch caliban backups to go to our unified storage box

### DIFF
--- a/non-critical-infra/hosts/caliban/default.nix
+++ b/non-critical-infra/hosts/caliban/default.nix
@@ -81,13 +81,12 @@
   };
 
   services.backup = {
-    user = "u371748";
-    host = "u371748.your-storagebox.de";
-    hostPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EB5p/5Hp3hGW1oHok+PIOH9Pbn7cnUiGmUEBrCVjnAw+HrKyN8bYVV0dIGllswYXwkG/+bgiBlE6IVIBAq+JwVWu1Sss3KarHY3OvFJUXZoZyRRg/Gc/+LRCE7lyKpwWQ70dbelGRyyJFH36eNv6ySXoUYtGkwlU5IVaHPApOxe4LHPZa/qhSRbPo2hwoh0orCtgejRebNtW5nlx00DNFgsvn8Svz2cIYLxsPVzKgUxs8Zxsxgn+Q/UvR7uq4AbAhyBMLxv7DjJ1pc7PJocuTno2Rw9uMZi1gkjbnmiOh6TTXIEWbnroyIhwc8555uto9melEUmWNQ+C+PwAK+MPw==";
+    user = "u391032-sub3";
+    host = "u391032-sub3.your-storagebox.de";
+    hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIICf9svRenC/PLKIL9nk6K/pxQgoiFC41wTNvoIncOxs";
     port = 23;
     sshKey = config.sops.secrets.storagebox-ssh-key.path;
     secretPath = config.sops.secrets.backup-secret.path;
-    quota = "90G"; # of 100G
   };
 
   system.stateVersion = "23.05";


### PR DESCRIPTION
This completes <https://github.com/NixOS/infra/issues/767>.

How I did it:

1. I logged into Hetzner and added a new subaccount to our "unified" storage box under base directory `caliban.nixos.org`. I enabled "Allow SSH" for this subaccount.
2. I gave caliban's ssh access by ssh-ing to caliban and running:
   ```console
   ssh-keygen -f /var/keys/storagebox-ssh-key -y | ssh -o "UserKnownHostsFile=/dev/null" -p23 u391032-sub3@u391032-sub3.your-storagebox.de install-ssh-key
   ```

After this successfully backs up, I'd like to delete the old storage box. I don't think I have permission for that.