### PR TITLE
Migrate hydra db connection to hetzner private vlan

### DIFF
--- a/build/haumea/network.nix
+++ b/build/haumea/network.nix
@@ -1,6 +1,15 @@
 {
   systemd.network = {
     enable = true;
+    netdevs = {
+      "20-vlan4000" = {
+        netdevConfig = {
+          Kind = "vlan";
+          Name = "vlan4000";
+        };
+        vlanConfig.Id = 4000;
+      };
+    };
     networks = {
       "30-enp35s0" = {
         matchConfig = {
@@ -15,8 +24,21 @@
           { Gateway = "46.4.89.193"; }
           { Gateway = "fe80::1"; }
         ];
+        vlan = [
+          "vlan4000"
+        ];
         networkConfig.Description = "WAN";
         linkConfig.RequiredForOnline = true;
+      };
+      "30-vlan4000" = {
+        matchConfig.Name = "vlan4000";
+        linkConfig = {
+          MTUBytes = "1400";
+          RequiredForOnline = "routable";
+        };
+        address = [
+          "10.0.40.1/31"
+        ];
       };
     };
   };

--- a/build/haumea/postgresql.nix
+++ b/build/haumea/postgresql.nix
@@ -15,6 +15,8 @@
 
   networking.firewall.interfaces.wg0.allowedTCPPorts = [ 5432 ];
 
+  networking.firewall.interfaces."vlan4000".allowedTCPPorts = [ 5432 ];
+
   services.postgresql = {
     enable = true;
     enableJIT = true;
@@ -90,6 +92,7 @@
     # FIXME: don't use 'trust'.
     authentication = ''
       host hydra all 10.254.1.1/32 trust
+      host hydra all 10.0.40.0/32 trust
       local all root peer map=prometheus
     '';
 

--- a/build/haumea/postgresql.nix
+++ b/build/haumea/postgresql.nix
@@ -24,7 +24,7 @@
     dataDir = "/var/db/postgresql/16";
     # https://pgtune.leopard.in.ua/#/
     settings = {
-      listen_addresses = lib.mkForce "10.254.1.9";
+      listen_addresses = lib.mkForce "10.0.40.1";
 
       # https://vadosware.io/post/everything-ive-seen-on-optimizing-postgres-on-zfs-on-linux/#zfs-related-tunables-on-the-postgres-side
       full_page_writes = "off";
@@ -91,7 +91,6 @@
 
     # FIXME: don't use 'trust'.
     authentication = ''
-      host hydra all 10.254.1.1/32 trust
       host hydra all 10.0.40.0/32 trust
       local all root peer map=prometheus
     '';

--- a/build/hydra.nix
+++ b/build/hydra.nix
@@ -69,7 +69,7 @@ in
 
   services.hydra-dev.enable = true;
   services.hydra-dev.buildMachinesFiles = [ "/etc/nix/machines" ];
-  services.hydra-dev.dbi = "dbi:Pg:dbname=hydra;host=10.254.1.9;user=hydra;";
+  services.hydra-dev.dbi = "dbi:Pg:dbname=hydra;host=10.0.40.1;user=hydra;";
   services.hydra-dev.logo = ./hydra-logo.png;
   services.hydra-dev.hydraURL = "https://hydra.nixos.org";
   services.hydra-dev.notificationSender = "edolstra@gmail.com";

--- a/build/mimas/network.nix
+++ b/build/mimas/network.nix
@@ -3,6 +3,15 @@
 
   systemd.network = {
     enable = true;
+    netdevs = {
+      "20-vlan4000" = {
+        netdevConfig = {
+          Kind = "vlan";
+          Name = "vlan4000";
+        };
+        vlanConfig.Id = 4000;
+      };
+    };
     networks = {
       "30-enp5s0" = {
         matchConfig = {
@@ -18,6 +27,19 @@
         routes = [
           { Gateway = "157.90.104.1"; }
           { Gateway = "fe80::1"; }
+        ];
+        vlan = [
+          "vlan4000"
+        ];
+      };
+      "30-vlan4000" = {
+        matchConfig.Name = "vlan4000";
+        linkConfig = {
+          MTUBytes = "1400";
+          RequiredForOnline = "routable";
+        };
+        address = [
+          "10.0.40.0/31"
         ];
       };
     };


### PR DESCRIPTION
Lower latency, reduced compute, simpler bootstrap for new machines.

Already in production. Will yeet the wireguard setup next.

https://docs.hetzner.com/robot/dedicated-server/network/vswitch/