### PR TITLE
dns: Point tracker.security.n.o to production host

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -136,8 +136,11 @@ D("nixos.org",
 	CNAME("cryptpad-sandbox.ngi", "makemake.ngi.nixos.org."),
 	CNAME("summer", "makemake.ngi.nixos.org."),
 
-	A("tracker.security", "188.245.41.195"),
-	AAAA("tracker.security", "2a01:4f8:1c1b:b87b::1"),
+	A("tracker-staging.security", "188.245.41.195"),
+	AAAA("tracker-staging.security", "2a01:4f8:1c1b:b87b::1"),
+
+	A("tracker.security", "91.99.31.214"),
+	AAAA("tracker.security", "2a01:4f8:1c1b:6921::1"),
 
 	// merge-bot
 	A("nixpkgs-merge-bot", "37.27.11.42"),


### PR DESCRIPTION
At the moment tracker.security.nixos.org points to the older staging instance, this PR adds `tracker-staging` and points the tracker.security.nixos.org to the new production host. When this is applied, alerts will fire as the new host doesn't have TLS certs yet and thus the service will appear down briefly.

PS. The IPv6 is correct but not reachable at the moment, will be fixed later in the day.