### PR TITLE
nixos.org.js : add an alias for an election-related service

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -189,4 +189,7 @@ D("nixos.org",
 	CNAME("status", "nixos-status.netlify.app."),
 	CNAME("weekly", "nixos-weekly.netlify.com."),
 	CNAME("www", "nixos-homepage.netlify.app."),
+
+    // temporary election-related services
+    CNAME("sc-election-2025", "nix-ec-2025.7c6f434c.michaelraskin.top."),
 );


### PR DESCRIPTION
We want to send clickable confirmation links with static target and list of clicked links in the server logs, so probably an alias to a personal VPS of an SC member should be the simplest