### PR TITLE
Update NixOS logo

### DIFF
--- a/build/nginx-error-pages/403.html
+++ b/build/nginx-error-pages/403.html
@@ -42,7 +42,7 @@
         <p class="lead">
           <a href="https://nixos.org/nixos">
             <img
-              src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg"
+              src="https://brand.nixos.org/logos/nixos-logo-default-gradient-black-regular-horizontal-minimal.svg"
               width="500px"
               alt="logo"
             />

--- a/build/nginx-error-pages/502.html
+++ b/build/nginx-error-pages/502.html
@@ -37,7 +37,7 @@
         <p class="lead">
           <a href="https://nixos.org/nixos">
             <img
-              src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg"
+              src="https://brand.nixos.org/logos/nixos-logo-default-gradient-black-regular-horizontal-minimal.svg"
               width="500px"
               alt="logo"
             />

--- a/terraform/cache-staging/index.html
+++ b/terraform/cache-staging/index.html
@@ -36,7 +36,7 @@
         <p class="lead">
           <a href="https://nixos.org/nixos">
             <img
-              src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg"
+              src="https://brand.nixos.org/logos/nixos-logo-default-gradient-black-regular-horizontal-minimal.svg"
               width="500px"
               alt="logo"
             />

--- a/terraform/cache/index.html
+++ b/terraform/cache/index.html
@@ -36,7 +36,7 @@
         <p class="lead">
           <a href="https://nixos.org/nixos">
             <img
-              src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg"
+              src="https://brand.nixos.org/logos/nixos-logo-default-gradient-black-regular-horizontal-minimal.svg"
               width="500px"
               alt="logo"
             />

--- a/terraform/nixpkgs-tarballs/index.html
+++ b/terraform/nixpkgs-tarballs/index.html
@@ -36,7 +36,7 @@
         <p class="lead">
           <a href="https://nixos.org/nixos">
             <img
-              src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos.svg"
+              src="https://brand.nixos.org/logos/nixos-logo-default-gradient-black-regular-horizontal-minimal.svg"
               width="500px"
               alt="logo"
             />


### PR DESCRIPTION
Update the NixOS logo used treewide. Uses logo assets from brand.nixos.org. This URL should be stable for the foreseeable future.