### PR TITLE
Disable access logs for limesurvey

### DIFF
--- a/non-critical-infra/modules/limesurvey.nix
+++ b/non-critical-infra/modules/limesurvey.nix
@@ -387,6 +387,9 @@ in
             "/upload/".root = "/var/lib/limesurvey";
 
           };
+          extraConfig = ''
+            access_log off;
+          '';
         }
       ];
     };


### PR DESCRIPTION
The Nix Community Survey is intended to be anonymous, so disable nginx access logs for this virtual host.

---

Per https://discourse.nixos.org/t/nix-community-survey-2025/68870, the Nix Community Survey is intended to be anonymous, but as riotbib@discourse points out, the nginx virtualhost for limesurvey is currently configured to collect access logs, which might in theory provide a secondary channel of information that would enable someone to bypass anonymizing measures.

This PR adds the relevant `extraConfig` to the `limesurvey.nix` module to set `access_log off;`.

---

Open questions:
1. I applied this at the level of the limesurvey module since my expectation is that all such surveys are intended to be anonymous. If that's not the case, should this have been declared at the level of the host-specific configuration?
2. I wasn't very clear on how to test this change, so I'd love if someone could chime in on the best way to do that in this repo.
3. This is my first Nix/NixOS PR, please let me know if I should be doing anything differently from a process standpoint.