### PR TITLE
Move test.wiki.nixos.org to more modern TLS configuration

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -170,7 +170,7 @@ D("nixos.org",
 	TXT("mail._domainkey.wiki", "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDa+KjIljYr3q5MWWK7sEYzjR8OcA32zBh9BCPo6/HlY1q2ODTYsmE/FDZWpYMzM5z+ddnuGYdXia322XnZaNpZNoq1TbGYuQ5DsgAEK09CGoLuzONg3PSXTrkG7E2Sd6wstwHGJ5FHxSLKtNoWkknt9F5XAFZgXapO0w54p+BWvwIDAQAB"),
 
 	// test.wiki subdomain with Fastly
-	CNAME("test.wiki", "dualstack.v2.shared.global.fastly.net."),
+	CNAME("test.wiki", "dualstack.n.sni.global.fastly.net."),
 	CNAME("_acme-challenge.test.wiki", "zsz0meyel8hxoy9dtb.fastly-validations.com."),
 
 	// cloudflare pages

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -4,6 +4,9 @@ locals {
   # TLS v1.2, protocols HTTP/1.1 and HTTP/2
   fastly_tls12_sni_configuration_id = "5PXBTa6c01Xoh54ylNwmVA"
 
+  # TLS1.2 and 1.3+0RTT, HTTP/1.1, HTTP/2 and HTTP/3
+  fastly_tls13_quic_configuration_id = "oZPSgSiY0PM8sNTAAyOZHw"
+
   cache-iam  = data.terraform_remote_state.terraform-iam.outputs.cache
   fastlylogs = data.terraform_remote_state.terraform-iam.outputs.fastlylogs
 

--- a/terraform/wiki-test.tf
+++ b/terraform/wiki-test.tf
@@ -53,7 +53,7 @@ resource "fastly_service_vcl" "wiki-test" {
 
 resource "fastly_tls_subscription" "wiki-test" {
   domains               = [for domain in fastly_service_vcl.wiki-test.domain : domain.name]
-  configuration_id      = local.fastly_tls12_sni_configuration_id
+  configuration_id      = local.fastly_tls13_quic_configuration_id
   certificate_authority = "lets-encrypt"
 }
 


### PR DESCRIPTION
The new configuration comes with TLS1.2/1.3 and HTTP1.1/2/3 support.

The fastly webinterface only lists n.sni.global.fastly.net, but the dualstack hostname exists and I think it's worth giving it a shot.

<img width="1400" height="360" alt="image" src="https://github.com/user-attachments/assets/302cc2a3-76bc-4fc5-8a9d-485c42f726f8" />
