### PR TITLE
dns: add txt record for bluesky account to nixos.org

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -198,6 +198,9 @@ D("nixos.org",
 	CNAME("weekly", "nixos-weekly.netlify.com."),
 	CNAME("www", "nixos-homepage.netlify.app."),
 
+	// bluesky account/domain binding
+	TXT("_atproto", "did=did:plc:bf43o4nxudgubwt4iljpayb7"),
+
 	// temporary election-related services
 	CNAME("sc-election-2025", "nix-ec-2025.7c6f434c.michaelraskin.top."),
 );


### PR DESCRIPTION
This allows us to use nixos.org as our Bluesky handle (which is currently the sad-and-not-official-looking `nixos-org.bsky.social`).

cc @NixOS/marketing-team -- once this is applied, y'all will need to do the following:
1. Log in to the Bluesky account
2. Go to Settings -> Account -> Handle
3. Type in `nixos.org`
4. Click "Verify DNS Record"