### PR TITLE
mailserver: kill forward for steering@nixos.org

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -177,14 +177,6 @@
     };
 
     "steering@nixos.org" = {
-      forwardTo = [
-        ../../secrets/Ericson2314-email-address.umbriel # https://github.com/Ericson2314
-        ../../secrets/Gabriella439-email-address.umbriel # https://github.com/Gabriella439
-        ../../secrets/roberth-email-address.umbriel # https://github.com/roberth
-        ../../secrets/tomberek-email-address.umbriel # https://github.com/tomberek
-        ../../secrets/winterqt-email-address.umbriel # https://github.com/winterqt
-        ../../secrets/jtojnar-email-address.umbriel # https://github.com/jtojnar
-      ];
       loginAccount = {
         encryptedHashedPassword = ../../secrets/steering-email-login.umbriel;
         storeEmail = true;


### PR DESCRIPTION
The account is being accessed via freescout and not all forward recipients are SC members anymore.

cc @NixOS/steering 