### PR TITLE
channels: drop 24.11

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -70,22 +70,6 @@ rec {
       variant = "darwin";
       status = "stable";
     };
-
-    "nixos-24.11" = {
-      job = "nixos/release-24.11/tested";
-      variant = "primary";
-      status = "unmaintained";
-    };
-    "nixos-24.11-small" = {
-      job = "nixos/release-24.11-small/tested";
-      variant = "small";
-      status = "unmaintained";
-    };
-    "nixpkgs-24.11-darwin" = {
-      job = "nixpkgs/nixpkgs-24.11-darwin/darwin-tested";
-      variant = "darwin";
-      status = "unmaintained";
-    };
   };
 
   channels-with-urls = builtins.mapAttrs (_name: about: about.job) channels;


### PR DESCRIPTION
They haven't updated for months.
Let's free up visual space in status.nixos.org
as 25.11 channels are starting to appear in there.