### PR TITLE
mailserver: Create email for the security tracker

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists.nix
@@ -169,6 +169,13 @@
       ];
     };
 
+    "noreply-securitytracker@nixos.org" = {
+      loginAccount = {
+        encryptedHashedPassword = ../../secrets/securitytracker-noreply-email-login.umbriel;
+        storeEmail = false;
+      };
+    };
+
     "sponsor@nixos.org" = {
       forwardTo = [
         "steering@nixos.org"

--- a/non-critical-infra/secrets/securitytracker-noreply-email-login.umbriel
+++ b/non-critical-infra/secrets/securitytracker-noreply-email-login.umbriel
@@ -1,0 +1,30 @@
+{
+	"data": "ENC[AES256_GCM,data:OP19/y+JFoVll1jUX+KFYUoFSUVDvBrlu49j7TT0y/++c32Slkn0a9LxIB298NrNERWu6n/wgVG+bcN7IA==,iv:yGnpgTxiqtTIVjFLoWkn4FhC7LsCB9SA3wYbIw9ZpfA=,tag:F12grj5CzJZofLCZqFkafg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15vcp7875xwtf64j4yshyld0a3hpgzv6n2kxky493s3q0swr9hdaqxugpv6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQcmRuWHNLNm1iQWJ5R0FU\nY3o4V1lRM2hvODhycU1GTU0rSXFNajM0ZlFnCmtIbnlsbmM2bkxZYnRBVkVLNVRa\nQWhOTmZubWNyYlRueTV3SUY5Nmo3M1UKLS0tIGdGVndWSWNaMVQramRjTjdOYmF4\nS3ArUGdFU3RYOXo4QmdoeHFmN2trVmMKSJVxIKSKmL2AQf1AcMUO+ppZxpZwQDFb\nIIKUW85aS8FAFX+14ivbodD7oh2UtH9BRCnhVuv1ZamDiq+/huiWVw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1j3mkgedmeru63vwww6m44zfw09tg8yw6xdzstaq7ejfkvgcau40qwakm8x",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpem45bG1IOFovdTJLM2pP\na1BQczY2eWppWVZHRWJZeWJidWpSNjFQSGpzCk9sS2RLVk5wL2dxWkQwT0QzOVlE\nYWYxaVVmYUxsQzhqekwxOGJtckx6UWcKLS0tIG5XZkN1bTlqZmI1UTBDNFk3SDAy\nbXdqcDk1bXdaTnVkVTByR0t6TmJYcW8K2NqioqDn13UuBKrI/tDEnM+zSfipCsMq\nNH9IYKsfYG48kL9yj6WrtMVQNV4P2ZLSc9IBpdZvEaQay4o99EswjA==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1jrh8yyq3swjru09s75s4mspu0mphh7h6z54z946raa9wx3pcdegq0x8t4h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZzZmUE9oRmp5VVpOYis5\nSzFTS0s0SVp5WDRDaWJZWmN4dFBMak5HZzM4ClZNYmw2V0tOUEpNRmhzaTBlQy9s\nYjR2bTg3UkhJdEc1TTdteDdNTWIrOEUKLS0tIEdFcEZjNGh0anZoODJreGJGWVNr\ndDIwZWhZTzk4WWsrajArSjFMMmdEdzgKDgWzB4U0qYeYdx4G4M04DPSuqUBj5XCG\nLurSEOpBmjxSVIkUzUVEUYAq3IsLxMiDf5iqLs1/d4TeD7Djg0oi1g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age17n64ahe3wesh8l8lj0zylf4nljdmqn28hvqns2g7hgm9mdkhlsvsjuvkxz",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEY3RsMGk0d2J1SW9neEFa\nS0ZnWVJSM3ZDbTdEYko1VjlSWVJpSks4MWtnCnozSmVjdU95Yk9jNm9EeFpvaUU0\nMW5zUnU0amFtRkhPZEdmcldXWW5JaGMKLS0tIDJyK1B6ZStxdkFTMUJ2OHJncndP\nRU81cG1hOXU2akRITkphSUVxaHdPMG8KtQ0B+bH7YRCO36ocidtGWhqCs36LayDc\nm8xiPLIGSJuYyHpPSkcbQcxOP/wx2yRRloRkV/LjnSt2d7DtBcFddg==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1nnm255ah9wa4gpsaq0v023a75lnmlcxszt9lc6az3mtwzxgrucfq45rp7h",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvRXRCQmpZS0JrK3RqaENh\nSitqdVZhMlltVFArTFdIL3QxZVEwcTNDQmtnCmZjVk5vQkhYRVdHZmp2TFBRT1R0\nSWY0WWFYVHFoQ21hWStScS9qQkVRRGsKLS0tIFRHU3UyRzVuZGR3NlJnaFlXNDBQ\nTVlVZFhpSFhsYjhnN3o2KzR5OTFBVkEKwkO++MNLjrd8nYXUyWtFnZu4PhDjyLki\n5Tw+XQW9zzHKZTvpFep3TZCMvvMUzCnNTcB7u81fG0fe8kHq78NTww==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-12-18T15:28:21Z",
+		"mac": "ENC[AES256_GCM,data:jHBjHm/ow2YuMspsrZd2zjTTovmuHiBkcHj4fwlH+Pchbc3DtoXlSuDxY8HO2b1nio+svYFc0Hn709gbWlZN1GGjO2pDBdddAnrl+Hqhj7prL5hTAcrnlLT4XUR8mNoGC9sVzBt+XHMopti7Dk14BUqkWfXNaFi/NrfS7JB7y60=,iv:6HG5/KdqkzzIttQ/lPoMwV+KuZjmDBVQuy8l0ueMVlQ=,tag:eD9eKdmpIVVx1n9rfB0oew==,type:str]",
+		"version": "3.11.0"
+	}
+}


### PR DESCRIPTION
This email address will be used only to send emails and for two uses cases in particular:
1) As a simple way for the developers of the software to get [notified about errors](https://github.com/NixOS/nix-security-tracker/issues/680) in the production instance.
2) In the future, send email notifications for potential vulnerabilities to maintainers (if they subscribe to them).