### PR TITLE
channels: make nixpkgs-unstable primary

### DIFF
--- a/channels.nix
+++ b/channels.nix
@@ -36,6 +36,7 @@ rec {
     };
     "nixpkgs-unstable" = {
       job = "nixpkgs/unstable/unstable";
+      variant = "primary";
       status = "rolling";
     };
 


### PR DESCRIPTION
For the [Nixpkgs security tracker](https://github.com/NixOS/nix-security-tracker/) UI we want to aggregate variants under their primary channels.
This can only be approximated heuristically, but `channels.nix` is authoritative and the closest to consistent we have.

So I wondered why `nixpkgs-unstable` is not primary. When this structure was established in #189, the field was simply ommited in https://github.com/NixOS/infra/pull/189#issuecomment-977137619.
Am I missing something from the semantics of "primary" that would forbid this change?

What makes a channel primary anyway? That the maximum number of tests is run?