### PR TITLE
Do not retrigger alert when values behind the comma change

### DIFF
--- a/build/pluto/prometheus/exporters/zfs.nix
+++ b/build/pluto/prometheus/exporters/zfs.nix
@@ -29,7 +29,7 @@
                 {
                   alert = "ZfsPoolFull";
                   expr = ''
-                    (zfs_pool_free_bytes / zfs_pool_size_bytes) * 100 < 15
+                    round((zfs_pool_free_bytes / zfs_pool_size_bytes) * 100, 1) < 15
                   '';
                   for = "30m";
                   labels.severity = "warning";


### PR DESCRIPTION
I copied the alert and immediately noticed that the slightest change after 15% free would retrigger the alert.