### PR TITLE
fix: Display all items in large directories of S3 buckets

### DIFF
--- a/terraform/s3_listing.html.tpl
+++ b/terraform/s3_listing.html.tpl
@@ -154,7 +154,7 @@
 
             html = typeof html !== 'undefined' ? html + prepareTable(info) :
                                                  prepareTable(info);
-            if (info.nextMarker != "null") {
+            if (info.nextMarker !== null) {
               getS3Data(info.nextMarker, html);
             } else {
               document.getElementById('listing').innerHTML =
@@ -250,8 +250,9 @@
         }
         // clang-format on
       });
+      console.log($(xml.find('IsTruncated')[0]).text());
       if ($(xml.find('IsTruncated')[0]).text() == 'true') {
-        var nextMarker = xml.find('NextMarker').textContent;
+        var nextMarker = xml.find('NextMarker').text();
       } else {
         var nextMarker = null;
       }
@@ -260,7 +261,7 @@
         files: files,
         directories: directories,
         prefix: $(xml.find('Prefix')[0]).text(),
-        nextMarker: encodeURIComponent(nextMarker)
+        nextMarker: nextMarker
       }
       // clang-format on
     }


### PR DESCRIPTION
This is a follow-up to 9bc32f40207f02d1e6362715d4f19c16e0963457. The next marker value was not correctly retrieved and encoded so large folders are truncated.

This issue can be seen on https://releases.nixos.org/?prefix=nixos/unstable/