### PR TITLE
non-critical-infra: lasuite-meet init

### DIFF
--- a/build/pluto/prometheus/exporters/blackbox.nix
+++ b/build/pluto/prometheus/exporters/blackbox.nix
@@ -103,6 +103,7 @@ in
           "https://common-styles.nixos.org"
           "https://discourse.nixos.org"
           "https://hydra.nixos.org"
+          "https://lasuite-meet.nixos.org"
           "https://mobile.nixos.org"
           "https://monitoring.nixos.org"
           "https://nixos.org"

--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -124,6 +124,7 @@ D("nixos.org",
 	CNAME("nixpkgs-swh", "caliban"),
 	CNAME("survey", "caliban"),
 	CNAME("vault", "caliban"),
+	CNAME("lasuite-meet", "caliban"),
 	DMARC_BUILDER({
 		label: "caliban",
 		policy: "none"

--- a/non-critical-infra/hosts/caliban/default.nix
+++ b/non-critical-infra/hosts/caliban/default.nix
@@ -16,6 +16,7 @@
     ../../modules/backup.nix
     ../../modules/element-web.nix
     ../../modules/limesurvey.nix
+    ../../modules/lasuite-meet.nix
     ../../modules/matrix-synapse.nix
     ../../modules/owncast.nix
     ../../modules/vaultwarden.nix

--- a/non-critical-infra/modules/lasuite-meet.nix
+++ b/non-critical-infra/modules/lasuite-meet.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  ...
+}:
+{
+  sops.secrets = {
+    #TODO: find out
+    lasuite-livekit-keyfile = {
+      sopsFile = ../secrets/lasuite-livekit-keyfile.caliban;
+      format = "yml";
+      restartUnits = [ "lasuite.service" ];
+    };
+
+  };
+
+  services.lasuite-meet = {
+    enable = true;
+    enableNginx = true;
+    domain = "lasuite-meet.nixos.org";
+    livekit = {
+      enable = true;
+      keyFile = config.sops.secrets.lasuite-livekit-keyfile.path;
+    };
+
+    # Databases
+    postgresql.createLocally = true;
+    redis.createLocally = true;
+
+    settings = {
+      FRONTEND_IS_SILENT_LOGIN_ENABLED = true;
+      ALLOW_UNREGISTERED_ROOMS = true; # We want to allow for the creation of rooms unregistered in case a maintainer needs to meet with another maintainer or a team needs to create a meeting room.
+      RECORDING_ENABLE = true; # Useful for SC for recording mins during meetings.
+    };
+  };
+
+  # This is still requires as enableNginx doesn't enable the acme and forceSSL.
+  services.nginx.virtualHosts."lasuite-meet" = {
+    enableACME = true;
+    forceSSL = true;
+  };
+}

--- a/non-critical-infra/modules/lasuite-meet.nix
+++ b/non-critical-infra/modules/lasuite-meet.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  ...
+}:
+{
+  sops.secrets = {
+    lasuite-livekit-keyfile = {
+      sopsFile = ../secrets/lasuite-livekit-keyfile.caliban;
+      format = "yml";
+      restartUnits = [ "lasuite.service" ];
+    };
+
+  };
+
+  services.lasuite-meet = {
+    enable = true;
+    enableNginx = true;
+    domain = "lasuite-meet.nixos.org";
+    livekit = {
+      enable = true;
+      keyFile = config.sops.secrets.lasuite-livekit-keyfile.path;
+    };
+
+    # Databases
+    postgresql.createLocally = true;
+    redis.createLocally = true;
+
+    settings = {
+      FRONTEND_IS_SILENT_LOGIN_ENABLED = true;
+      ALLOW_UNREGISTERED_ROOMS = true; # We want to allow for the creation of rooms unregistered in case a maintainer needs to meet with another maintainer or a team needs to create a meeting room.
+      RECORDING_ENABLE = true; # Useful for SC for recording mins during meetings.
+    };
+  };
+
+  # This is still requires as enableNginx doesn't enable the acme and forceSSL.
+  services.nginx.virtualHosts."lasuite-meet" = {
+    enableACME = true;
+    forceSSL = true;
+  };
+}


### PR DESCRIPTION
Adds lasuite-meet to non-critical-infra.

Fixes #401 

I have discussed with @Mic92 in the nix meeting and it should be okay with calibean machine (if not we can always switch).
It should be able to run without an account, however I can't test due to secret signing and not currently having a nixos machine.

> [!NOTE]
> The secrets will need to be done and signed by one of the people keys in sops.nix, before this pr is merged.
