### PR TITLE
builders: bump max-silent-time to 4h

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -37,7 +37,7 @@
         "build"
         "root"
       ];
-      max-silent-time = 10800; # 3h
+      max-silent-time = 14400; # 4h
     };
   };
 

--- a/macs/common.nix
+++ b/macs/common.nix
@@ -49,7 +49,7 @@ in
         "nix-command"
         "flakes"
       ];
-      max-silent-time = 7200; # 2h
+      max-silent-time = 14400; # 4h
       timeout = 43200; # 12h
     };
     gc = {


### PR DESCRIPTION
After LTO was enabled for nixpkgs firefox darwin build, we started
hitting hydra timeouts due to long silence during XUL linkage:

https://hydra.nixos.org/build/320487707
https://hydra.nixos.org/build/319560484

I believe this happens because nix-store does not propagate settings
from derivation meta to remote nix-daemon after initial connection. (See
https://github.com/NixOS/nix/pull/15125 for more details and a potential
fix.)

While this issue is not fixed in Nix, this patch bumps max-silent-time
to 4h for all builders, both darwin and linux. The 4h setting comes from
the observation that all nixpkgs packages that *do* set meta.maxSilent
set it to 4h.

Note: while we don't have immediate need to bump the limit to 4h for
non-mac builders, it seems prudent to do so because at least some
meta.maxSilent settings in nixpkgs, including for firefox, originate
from linux timeouts:

https://github.com/NixOS/nixpkgs/pull/129212
https://github.com/NixOS/nixpkgs/pull/129115
