### PR TITLE
builders: add support for systemd-nspawn containers

### DIFF
--- a/builders/common/nspawn-test-containers.nix
+++ b/builders/common/nspawn-test-containers.nix
@@ -1,0 +1,17 @@
+{
+  # From <https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/development/running-nixos-tests.section.md#system-requirements-sec-running-nixos-tests-requirements>:
+  # > NixOS tests using systemd-nspawn containers require the Nix daemon to be
+  # > configured with the following settings:
+  nix.settings = {
+    auto-allocate-uids = true;
+    extra-system-features = [ "uid-range" ];
+    experimental-features = [
+      "auto-allocate-uids"
+      "cgroups"
+    ];
+  };
+
+  # Required for communication between nspawn containers and qemu vms.
+  # Disabled for now, see <https://github.com/NixOS/infra/issues/987>.
+  # nix.settings.sandbox-paths = [ "/dev/net" ];
+}

--- a/builders/flake-module.nix
+++ b/builders/flake-module.nix
@@ -17,6 +17,7 @@
             ./common/network.nix
             ./common/nix.nix
             ./common/node-exporter.nix
+            ./common/nspawn-test-containers.nix
             ./common/hydra-queue-builder.nix
             ./common/system.nix
             ./common/tools.nix


### PR DESCRIPTION
This is part of https://github.com/NixOS/infra/issues/987. It gets
standalone nspawn containers working, but not tests that include both
nspawn containers and qemu vms.

We discussed this at our last team meeting, and folks didn't seem to
object to enabling these tests.

At the time, I thought it was a purely hypothetical conversation, but it
turns out that some of our jobsets in Hydra actually do [include these
new tests](https://github.com/NixOS/nixpkgs/pull/478109#issuecomment-4116714697).
