### PR TITLE
builders/macs: fix builder module import

### DIFF
--- a/builders/common/hydra-queue-builder.nix
+++ b/builders/common/hydra-queue-builder.nix
@@ -7,7 +7,7 @@
 
 {
   imports = [
-    inputs.hydra-staging.nixosModules.linux-builder
+    inputs.hydra-staging.nixosModules.builder
   ];
 
   config = lib.mkIf false {

--- a/macs/hydra-queue-builder.nix
+++ b/macs/hydra-queue-builder.nix
@@ -8,7 +8,7 @@
 {
   imports = [
     inputs.agenix.darwinModules.age
-    inputs.hydra-staging.nixosModules.darwin-builder
+    inputs.hydra-staging.darwinModules.builder
   ];
 
   config = lib.mkIf false {


### PR DESCRIPTION
Cleaning up after https://github.com/NixOS/infra/commit/9772f57f7da159c789ac1d5fd2ac2ef78edbe938.