### PR TITLE
Fix broken link

### DIFF
--- a/build/titan/zrepl.nix
+++ b/build/titan/zrepl.nix
@@ -33,7 +33,7 @@
           prefix = "zrepl_snap_";
           hooks = [
             {
-              # https://zrepl.github.io/master/configuration/snapshotting.html#postgres-checkpoint-hook
+              # https://zrepl.github.io/configuration/snapshotting.html#postgres-checkpoint-hook
               type = "postgres-checkpoint";
               dsn = "host=/run/postgresql dbname=hydra user=root sslmode=disable";
               filesystems."zroot/pg" = true;


### PR DESCRIPTION
I'm setting up zrepl on my homelab. As with every new thing, I first study our code for inspiration =)

Do we even want this? It's not necessary for transactional consistency (we already get that from zfs snapshots). From https://zrepl.github.io/configuration/snapshotting.html#postgres-checkpoint-hook

> However, the Postgres manual recommends against checkpointing during normal operation. Further, the operation requires Postgres superuser privileges. zrepl users must decide on their own whether this hook is useful for them (it likely isn’t).

