### PR TITLE
staging-hydra: use hydra branch with AWS_SHARED_CREDENTIALS_FILE fix

### DIFF
--- a/build/titan/zrepl.nix
+++ b/build/titan/zrepl.nix
@@ -107,15 +107,15 @@ in
               format = "human";
             }
           ];
-        };
 
-        # https://zrepl.github.io/configuration/monitoring.html
-        monitoring = [
-          {
-            type = "prometheus";
-            listen = ":${toString metricsPort}";
-          }
-        ];
+          # https://zrepl.github.io/configuration/monitoring.html
+          monitoring = [
+            {
+              type = "prometheus";
+              listen = ":${toString metricsPort}";
+            }
+          ];
+        };
 
         jobs = [
           # Covers 20240629+

--- a/flake.lock
+++ b/flake.lock
@@ -329,11 +329,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1775667573,
-        "narHash": "sha256-9J9jzf82/EEAy0+qG8/yz201tMB/+Ch3PdxXmb5cq4U=",
+        "lastModified": 1776061551,
+        "narHash": "sha256-MTLpUlUMrjy71lWZ4PEhRYqCNQVgZa7s7W9mS4y6aWA=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "cd235f7de82e3b67e81b442b73f5f7a98791298c",
+        "rev": "47252e4f6a348c01d3d61069d5f5d8ab2538f2dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The queue-runner on the new lysator host could not load S3 credentials because the binary-cache crate ignored AWS_SHARED_CREDENTIALS_FILE and fell back to the (unreachable) EC2 IMDS endpoint, stalling all narinfo lookups. Point hydra-staging at Mic92/hydra:aws-shared-credentials-file until the upstream PR lands.