### PR TITLE
Alert if zrepl replication hasn't succeeded recently

### DIFF
--- a/build/pluto/prometheus/exporters/zrepl.nix
+++ b/build/pluto/prometheus/exporters/zrepl.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   services.prometheus = {
@@ -16,6 +16,27 @@
       }
     ];
 
-    # TODO: alert on `zrepl_replication_last_successful` being too long ago.
+    ruleFiles = [
+      (pkgs.writeText "zrepl.rules" (
+        builtins.toJSON {
+          groups = [
+            {
+              name = "zrepl";
+              rules = [
+                {
+                  alert = "ZreplLongTimeNoSuccess";
+                  expr = ''
+                    time() - zrepl_replication_last_successful > ${toString (6 * 60 * 60)}
+                  '';
+                  for = "6h";
+                  labels.severity = "warning";
+                  annotations.summary = "zrepl job {{ $labels.zrepl_job }} has not succeeded recently.";
+                }
+              ];
+            }
+          ];
+        }
+      ))
+    ];
   };
 }


### PR DESCRIPTION
zrepl is currently configured to take snapshots every 30 minutes, so if we go a full day without a successful replication, I'd say something is pretty wrong.