### PR TITLE
build: allow releases.nixos.org in restricted-eval

### DIFF
--- a/build/common.nix
+++ b/build/common.nix
@@ -64,7 +64,7 @@
 
   nix.extraOptions = ''
     allowed-impure-host-deps = /etc/protocols /etc/services /etc/nsswitch.conf
-    allowed-uris = https://github.com/ https://git.savannah.gnu.org/ github:
+    allowed-uris = https://github.com/ https://git.savannah.gnu.org/ github: https://releases.nixos.org/
   '';
 
   # we use networkd

--- a/flake.lock
+++ b/flake.lock
@@ -349,15 +349,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772134399,
-        "narHash": "sha256-O9YSvxHkNhMUB3U/WdC/R1np6biaxqoglPDUQHx5KIc=",
-        "owner": "mweinelt",
+        "lastModified": 1776722121,
+        "narHash": "sha256-DGXg6ODTQAP914+edQgfNwRhvu9cER9vtACtH235XP8=",
+        "owner": "Mic92",
         "repo": "nft-prefix-import",
-        "rev": "fbe66b91d7f0c818e0966e275d284095969cfe9b",
+        "rev": "c69c6463c5a3fb51a0e65a4b5981252486157a92",
         "type": "github"
       },
       "original": {
-        "owner": "mweinelt",
+        "owner": "Mic92",
+        "ref": "nft-stdin",
         "repo": "nft-prefix-import",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,8 @@
     };
 
     nft-prefix-import = {
-      url = "github:mweinelt/nft-prefix-import";
+      # https://github.com/mweinelt/nft-prefix-import/pull/2
+      url = "github:Mic92/nft-prefix-import/nft-stdin";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 


### PR DESCRIPTION
Nix's hydra.nix pins nixpkgs via a tarball on releases.nixos.org. Without this URI prefix in allowed-uris, restricted-mode evaluation rejects the fetch and all jobs in the jobset fail.