### PR TITLE
freescout: 1.8.218 -> 1.8.220

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -14,12 +14,12 @@
   services.freescout = {
     enable = true;
     package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.218";
+      version = "1.8.220";
       src = pkgs.fetchFromGitHub {
         owner = "freescout-helpdesk";
         repo = "freescout";
         tag = version;
-        hash = "sha256-oLbsrlvsBkZ8oa2EuByJafItuG1n2MXPrt/noAXTt94=";
+        hash = "sha256-bOkazBcd9EKzQdZZA6YMn4+UNYhpDFV9hDMHR5kXke0=";
       };
     };
     domain = "freescout.nixos.org";


### PR DESCRIPTION
- https://github.com/freescout-help-desk/freescout/releases/tag/1.8.219
  - Security: https://github.com/freescout-help-desk/freescout/security/advisories/GHSA-qjr9-6v9q-3r72
  - Security: https://github.com/freescout-help-desk/freescout/security/advisories/GHSA-jvmv-2qcp-7855
- https://github.com/freescout-help-desk/freescout/releases/tag/1.8.220
  - Security: https://github.com/freescout-help-desk/freescout/security/advisories/GHSA-6r38-6mcf-2ww3 (I don't know why this is 404-ing, perhaps it has not been announced publicly yet?)