### PR TITLE
Filter out empty mailing lists from `postfix-virtual-mailing-lists`

### DIFF
--- a/non-critical-infra/modules/mailserver/mailing-lists-options.nix
+++ b/non-critical-infra/modules/mailserver/mailing-lists-options.nix
@@ -123,9 +123,9 @@ in
 
     sops.templates."postfix-virtual-mailing-lists" = {
       content = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (
-          name: members: "${name} ${lib.concatStringsSep ", " members}"
-        ) listsWithSecretPlaceholders
+        lib.mapAttrsToList (name: members: "${name} ${lib.concatStringsSep ", " members}") (
+          lib.filterAttrs (_name: members: builtins.length members > 0) listsWithSecretPlaceholders
+        )
       );
 
       # Need to restart postfix-setup to rerun `postmap` and generate updated `.db`


### PR DESCRIPTION
This addresses the following warning:

```console
[root@umbriel:~]# journalctl -u postfix-setup.service
...
May 11 08:24:38 umbriel systemd[1]: Starting Setup for Postfix mail server...
May 11 08:24:39 umbriel postfix-setup-start[987]: postmap: warning: /var/lib/postfix/conf/virtual-mailing-lists, line 16: expected format: key whitespace value
May 11 08:24:39 umbriel postfix/postmap[987]: warning: /var/lib/postfix/conf/virtual-mailing-lists, line 16: expected format: key whitespace value
```