### PR TITLE
macs: set mac05 nixbld group id

### DIFF
--- a/macs/flake-module.nix
+++ b/macs/flake-module.nix
@@ -77,7 +77,10 @@
       };
       nixos-foundation-macstadium-44911104 = mkNixDarwin "mac05.ofborg.org" ./profiles/ofborg-m1.nix {
         extraModules = [
-          { networking.hostName = "nixos-foundation-macstadium-44911104"; }
+          {
+            networking.hostName = "nixos-foundation-macstadium-44911104";
+            ids.gids.nixbld = lib.mkForce 350;
+          }
         ];
       };
     };


### PR DESCRIPTION
mac05.ofborg.org is on 26.4.1 now and has been deployed from this branch.