### PR TITLE
freescout: 1.8.220 -> 1.8.221

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -14,12 +14,12 @@
   services.freescout = {
     enable = true;
     package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.220";
+      version = "1.8.221";
       src = pkgs.fetchFromGitHub {
         owner = "freescout-helpdesk";
         repo = "freescout";
         tag = version;
-        hash = "sha256-bOkazBcd9EKzQdZZA6YMn4+UNYhpDFV9hDMHR5kXke0=";
+        hash = "sha256-+aMjftzZmBq+fmGZ3EsoDYu0h+dv3MLRlNzdlmpiWDY=";
       };
     };
     domain = "freescout.nixos.org";


### PR DESCRIPTION
Notable changes from <https://github.com/freescout-help-desk/freescout/releases/tag/1.8.221>:

- **Links to attachments uploaded before the FreeScout version of 2020-03-06 will become unavailable. This is a breaking change.**
- Improved permissions check when deleting notes (Security: GHSA-9vx8-gx3p-9mh6)
- Improved permissions check when editing messages (Security: GHSA-3w38-h42v-3h6w)
- Deprecated links to attachments without a token (Security: GHSA-wg74-ww4w-2qpc)