### PR TITLE
Remove reference to deprecated `mailserver.dkimKeyDirectory`

### DIFF
--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -67,7 +67,7 @@
 
     # Ensure the file gets symlinked to where Simple NixOS Mailserver expects
     # to find it.
-    path = "${config.mailserver.dkimKeyDirectory}/nixos.org.mail.key";
+    path = "${config.mailserver.dkim.keyDirectory}/nixos.org.mail.key";
   };
 
   sops.secrets."nixcon.org.mail.key" = {
@@ -76,7 +76,7 @@
     group = "rspamd";
     mode = "0600";
     sopsFile = ../../secrets/nixcon.org.mail.key.umbriel;
-    path = "${config.mailserver.dkimKeyDirectory}/nixcon.org.mail.key";
+    path = "${config.mailserver.dkim.keyDirectory}/nixcon.org.mail.key";
   };
 
   services.postfix.settings.main.bounce_template_file = "${pkgs.writeText "bounce-template.cf" ''


### PR DESCRIPTION
This has no effect on the resulting derivation.

Before:

```console
$ nix eval .#nixosConfigurations.umbriel.config.system.build.toplevel
trace: Obsolete option `mailserver.dkimKeyDirectory' is used. It was renamed to `mailserver.dkim.keyDirectory'.
«derivation /nix/store/d2jxgy0dp3irxz6jka00grcy39rpai6q-nixos-system-umbriel-26.05.20260525.b968491.drv»
```

After:

```console
nix eval .#nixosConfigurations.umbriel.config.system.build.toplevel
«derivation /nix/store/d2jxgy0dp3irxz6jka00grcy39rpai6q-nixos-system-umbriel-26.05.20260525.b968491.drv»
```