### PR TITLE
mail: roll new dkim keys

### DIFF
--- a/.github/workflows/dns-apply.yml
+++ b/.github/workflows/dns-apply.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
       - name: dnscontrol push
         env:
-          GANDI_TOKEN: "${{ secrets.GANDI_TOKEN }}" # Expires 2026-04-07
+          GANDI_TOKEN: "${{ secrets.GANDI_TOKEN }}" # Expires 2027-05-29
+          GANDI_SHARING_ID: "${{ secrets.GANDI_SHARING_ID }}"
         working-directory: ./dns/
         run: |
           nix run --inputs-from . nixpkgs#dnscontrol -- push

--- a/.github/workflows/dns-preview.yml
+++ b/.github/workflows/dns-preview.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
       - name: dnscontrol preview
         env:
-          GANDI_TOKEN: "${{ secrets.GANDI_TOKEN }}" # Expires 2026-04-07
+          GANDI_TOKEN: "${{ secrets.GANDI_TOKEN }}" # Expires 2027-05-29
+          GANDI_SHARING_ID: "${{ secrets.GANDI_SHARING_ID }}"
         working-directory: ./dns/
         run: |
           nix run --inputs-from . nixpkgs#dnscontrol -- preview

--- a/dns/creds.json
+++ b/dns/creds.json
@@ -1,6 +1,7 @@
 {
   "gandi": {
     "TYPE": "GANDI_V5",
-    "token": "$GANDI_TOKEN"
+    "token": "$GANDI_TOKEN",
+    "sharing_id": "$GANDI_SHARING_ID"
   }
 }

--- a/dns/nixcon.org.js
+++ b/dns/nixcon.org.js
@@ -23,6 +23,16 @@ D("nixcon.org",
 	}),
 	// Matching private key in `non-critical-infra/secrets/nixcon.org.mail.key.umbriel`
 	TXT("mail._domainkey", "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC1wQ2uPZfdlGmjDDxeNVet7IEFxS55TpWuqQWNKmd4fX8HcKKw7kVHXU5+gjT37wMUI27ZZnIobYhumnl+BLiXZqbuzAt7s3dbJU2de2ZWxOqcDRbK6m2A3AwIAiMzzRUjx14EWgnw55KRi2enpLyS0pKGdvSquHnxaySkAF8YIwIDAQAB"),
+	DKIM_BUILDER({
+		selector: "r202605",
+		keytype: "rsa",
+		pubkey: "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkF4Z/6jTCOi1OcVduYoa9MMqW3XeV7vtZGAHDiHU2teCFiC4qZpJ4Ry7f0/gJw6WHh1zKc83AZTxsA82tBzfIUXrr1tGUh6DX8RmhKPzDtbaXZAmRYb9o0CAtIqzUFrVfz8oyCzHF13aaZGztgZBOOjCGECxcKd4KC+u0XAeRFfLc6zf4j6GQ4qTQ3aJoiIl0WUbbDl8VVGYjgd7SA/necpVXYf9LD/KNtumH4IS1oU1tGjsVrqPv9+Hbl4yi325ExMsbYK9sj4HhjcdtT4p9NlH/ZmaTTW3pEm1wZ8Fw+J3UVcB/Nxi1N1HFrdsnyoGhfMnz1z9Xtpdj/ANZtTTFwIDAQAB"
+	}),
+	DKIM_BUILDER({
+		selector: "e202605",
+		keytype: "ed25519",
+		pubkey: "p=SEawMqEG+q0WauDF9Noe3xSqVuBZqmEBgmStaxpNFHE="
+	}),
 	DMARC_BUILDER({
 		policy: "none",
 	}),

--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -146,6 +146,16 @@ D("nixos.org",
 	AAAA("umbriel", "2a01:4f9:c011:8fb5::1"),
 	// See `nixos.org.mail.key` in `non-critical-infra/modules/mailserver/default.nix`.
 	TXT("mail._domainkey", "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDcgNq4+Y23GxN8Mdza437tL5DuJJZU1y6VzTCwSi6cBNLyBDci2cmqXx/gm1sA3yv7+h+8/OyJpEgcbCIW/Ygs1XLuECqvXVX8MU6Djn4KY+d2sU1tlUdqvNM86puoneQtjEv9rDsjf3HGqaeOcjetFnQW7H+qcNcaEShxyKztzQIDAQAB"),
+	DKIM_BUILDER({
+		selector: "r202605",
+		keytype: "rsa",
+		pubkey: "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsMhbyIflWa1rx2eaK23vdo1HxQU+CVT8bKfBaRXFIXk51ihrzutyAN0CH8aXUHoiR3MAeDVHE8ftXXh6exrZut9aXZSvBFQBziWJRvVOM9V6oIQqIFSWeac/4rkoWIpvwwaJpc0YBTxosRjnD0C0J9lFWDpuHd6vpXxdZg/YgM7EADP5A4Dlnv3GHxmDvtRK90M20XVBNiCiYVF+9hgncjIhY5B3Nc8n2vZr01aKNPNkYU5CYc7hlmQHyZQqhg1SjmWUex9Uf85WyEGgT4yJV1b0X11tYQHD0h072uNAxpz8dYgII5J46OteQmOmwGh2WqLOa0Vwt5LtAdwIN7BtDQIDAQAB"
+	}),
+	DKIM_BUILDER({
+		selector: "e202605",
+		keytype: "ed25519",
+		pubkey: "p=SEawMqEG+q0WauDF9Noe3xSqVuBZqmEBgmStaxpNFHE="
+	}),
 	CNAME("freescout", "umbriel.nixos.org."),
 
 	// ngi

--- a/non-critical-infra/modules/mailserver/default.nix
+++ b/non-critical-infra/modules/mailserver/default.nix
@@ -1,6 +1,7 @@
 {
   inputs,
   config,
+  lib,
   pkgs,
   ...
 }:
@@ -37,6 +38,26 @@
       "nixcon.org"
       "nixos.org"
     ];
+
+    dkim.domains =
+      let
+        selectors = {
+          "mail" = {
+            # legacy managed key
+          };
+          "r202605" = {
+            keyType = "rsa";
+            keyLength = 2048;
+          };
+          "e202605" = {
+            keyType = "ed25519";
+            keyLength = null;
+          };
+        };
+      in
+      lib.genAttrs config.mailserver.domains (_: {
+        inherit selectors;
+      });
 
     srs.enable = true;
   };


### PR DESCRIPTION
The existing RSA key is 1024 bit long and needs to be retired.

We generate the new keys in place, managing them is imo pretty pointless, as we won't be able to sign new mail that will get validated anyhow. At which point we'll publish new selectors.