### PR TITLE
freescout: 1.8.222 -> 1.8.223

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -14,12 +14,12 @@
   services.freescout = {
     enable = true;
     package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.222";
+      version = "1.8.223";
       src = pkgs.fetchFromGitHub {
         owner = "freescout-helpdesk";
         repo = "freescout";
         tag = version;
-        hash = "sha256-DGuwyBE73nvvP5rZm+/wLecQUNnQwn4SvXaCAhk4/ZE=";
+        hash = "sha256-yEcOEtEDTTkvtPbxmg2D1ZeUpEIavnuxjO1hOJTwzFI=";
       };
     };
     domain = "freescout.nixos.org";


### PR DESCRIPTION
https://github.com/freescout-help-desk/freescout/releases/tag/1.8.223

Notably:

- Disabled backward compatibility for old Message-ID format on fetching (Security: GHSA-8vm3-wwq4-ggfx)
- Fixed prototype pollution in getQueryParam() (Security: GHSA-w5fc-8pp3-f755)

I also pinged Nina (of freescout-nix-flake) about [getting this package definition upstreamed](https://cyberchaos.dev/e1mo/freescout-nix-flake/-/work_items/9). Hopefully we hear back from her!