### PR TITLE
freescout: 1.8.223 -> 1.8.224

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -14,12 +14,12 @@
   services.freescout = {
     enable = true;
     package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.223";
+      version = "1.8.224";
       src = pkgs.fetchFromGitHub {
         owner = "freescout-helpdesk";
         repo = "freescout";
         tag = version;
-        hash = "sha256-yEcOEtEDTTkvtPbxmg2D1ZeUpEIavnuxjO1hOJTwzFI=";
+        hash = "sha256-JGLLYJhU+F7wQXK2r9k+lx+BQju0wipy3SADVKgV2oY=";
       };
     };
     domain = "freescout.nixos.org";

--- a/non-critical-infra/modules/ofborg/ofborg-config.nix
+++ b/non-critical-infra/modules/ofborg/ofborg-config.nix
@@ -9,7 +9,6 @@ in
 {
   config,
   pkgs,
-  lib,
   ...
 }:
 {


### PR DESCRIPTION
It fixes security issues:
https://github.com/freescout-help-desk/freescout/releases/tag/1.8.224