### PR TITLE
pluto: add elasticsearch to the endpoints to scrape to prometheus

### DIFF
--- a/build/pluto/prometheus/default.nix
+++ b/build/pluto/prometheus/default.nix
@@ -6,6 +6,7 @@
     ./exporters/blackbox.nix
     ./exporters/channel.nix
     ./exporters/domain.nix
+    ./exporters/elasticsearch.nix
     ./exporters/fastly.nix
     ./exporters/github.nix
     ./exporters/hydra.nix

--- a/build/pluto/prometheus/exporters/elasticsearch.nix
+++ b/build/pluto/prometheus/exporters/elasticsearch.nix
@@ -1,0 +1,29 @@
+{ config, ... }:
+
+{
+  # Note that the credentials are technically in the nixos-search repo in plaintext,
+  # so mostly using age here for good form.
+  age.secrets.elasticsearch-exporter-env.file = ../../../secrets/elasticsearch-exporter-env.age;
+
+  services.prometheus = {
+    exporters.elasticsearch = {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      url = "https://nixos-search-7-1733963800.us-east-1.bonsaisearch.net";
+      environmentFile = config.age.secrets.elasticsearch-exporter-env.path;
+      extraFlags = [
+        "--es.all"
+        "--es.indices"
+        "--es.cluster_settings"
+        "--es.snapshots"
+      ];
+    };
+
+    scrapeConfigs = [
+      {
+        job_name = "prometheus-elasticsearch-exporter";
+        static_configs = [ { targets = [ "127.0.0.1:9114" ]; } ];
+      }
+    ];
+  };
+}

--- a/build/pluto/prometheus/exporters/elasticsearch.nix
+++ b/build/pluto/prometheus/exporters/elasticsearch.nix
@@ -14,8 +14,8 @@
       extraFlags = [
         "--es.all"
         "--es.indices"
-        "--es.cluster_settings"
-        "--es.snapshots"
+        "--collector.clustersettings"
+        "--collector.snapshots"
       ];
     };
 

--- a/build/secrets.nix
+++ b/build/secrets.nix
@@ -4,6 +4,7 @@ let
   secrets = with keys.ssh.machines; {
     alertmanager-matrix-forwarder = [ pluto ];
     alertmanager-oauth2-proxy-env = [ pluto ];
+    elasticsearch-exporter-env = [ pluto ];
     fastly-exporter-env = [ pluto ];
     grafana-secret-key = [ pluto ];
     hydra-aws-credentials = [ mimas ];

--- a/build/secrets/elasticsearch-exporter-env.age
+++ b/build/secrets/elasticsearch-exporter-env.age
@@ -1,0 +1,24 @@
+age-encryption.org/v1
+-> ssh-ed25519 s9hT2g U/3FOcVd0hfXTcQw8sbuu4cumiSPkUkNzPjYgHOJlTM
+dtjjHXtXneR0f0UvLDbZucagamWBu2IEZt8xLRKu/AE
+-> ssh-ed25519 Y121Gw O4PqNm/Ug6h+nROjrfPNuc2FRPB9g0Epv7Nq9AIy2Tk
+i3DOaB4hDiXoWMZvjo8POPUvMh3jRWScGCwgzb9aTVM
+-> ssh-ed25519 Gr9EaQ krGW6jNrX4qvpvHzPdHljzEUW+HiyT5Oc9AJkUEIXH4
+fYo+9mI7WeoX83HikY4Vb8STQxJSx8x4Pd1tyfwRv9c
+-> ssh-ed25519 3ENwVg zA+m9/T2Z9zs7AD58UC7IXyjO8OCI2QQxLwL/Q28jXA
+Yks8x+XU6HwpRjCvrok3JA616DUmWall0i4xo/PwPSo
+-> ssh-rsa MuWD+w
+M7/HdOXJeudTvmAmxMNVPCWz48ABJulgwLUjSh0MvK/RvSiftjbYHzalEFj4k/J0
+Z/0l+1Zlfbh9w46LnoUve6amDiqBO/XXp/RHQcaKSMco9m7f3ZJKwYL44lMDIDga
+NX0xVYwVG7RONfSCR5MyiYerVd/zbAsaqJKFVtZyc/4MhD0zObIhJ3SGbfqmx0ci
+JbpQy88qP4G1AxF7f5/DBbaEstu9MIJGl7W3A7EU6ysRmQMsMuR0wr1Y6WHEUiMl
+xdO1bCC3ViWUTjoEr0pRhEy3MzU4OkhjfyusbVWkOeadR54JlZOfc0VZTxonasGe
+b3r+8rJ03yLasfcOZqdOxA
+-> piv-p256 cQ6pag Ahiby6IGT47Jmczdv9Y43KmomHoqlVaDg1GPv311SNUP
+UcL4MDhssIuTeNXRCQcmdkiyph9E8UZFjrbSyffq8Gk
+-> piv-p256 1rGnvg A0V9u5OrDwmfF51egYsrftMz0yZUIPXkzUHcvOve8wUc
+rDvK6RwXraMHOvP2Om0uZI3SE1OtKQxYDtAFyWTzx0o
+--- fPuy/hlwATAmJadpwXDYVOHUUu+CxYAJ5JnIF19kgm0
+dá“Ü.Qp³\oÜœÛXÃ]-ÆñÅï“’×v
+ÍÌ*Ì&î$:ê2úF‘¢Œ‚zÌ"ÂòÍ¼.y4•'8
+P#,³ *Ob±)‰^&ú•0ù`=Î:¤p


### PR DESCRIPTION
Collects diagnostics from the used in nixos-search's Elastic Search instance used in search.nixos.org.

Closes https://github.com/NixOS/nixos-search/issues/1312.

Given diagnostics on this Elastic Search, I hope to get the visibility needed to judge the viability of features like [type-ahead](https://github.com/NixOS/nixos-search/pull/1262) or even live filtering search results like [nüschtos search](https://search.nüschtos.de/) does.

On the implementation here, unfortunately the module wasn't in stable yet, so I just had to in-line it here for now.

An additional caveat is use of age here felt like a bit moot given the credential is public for this - but I didn't want to set bad precedent in this repo by starting to just in-line credentials here as well.

Disclaimer: I used a coding agent in the creation of this patch.