### PR TITLE
freescout: 1.8.224 -> 1.8.225

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -14,12 +14,12 @@
   services.freescout = {
     enable = true;
     package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.224";
+      version = "1.8.225";
       src = pkgs.fetchFromGitHub {
         owner = "freescout-helpdesk";
         repo = "freescout";
         tag = version;
-        hash = "sha256-JGLLYJhU+F7wQXK2r9k+lx+BQju0wipy3SADVKgV2oY=";
+        hash = "sha256-kXZ6bjF36YO1p6q+KTugnBO+KxqQZci5O0RNM7lqecQ=";
       };
     };
     domain = "freescout.nixos.org";


### PR DESCRIPTION
https://github.com/freescout-help-desk/freescout/releases/tag/1.8.225

Security fixes:

- Added throttling and authentication in `tools.php` (Security: GHSA-w2p9-3666-vw9j)
- Patched `symfony/routing` (Security: CVE-2026-45065)
- Upgraded `symfony/polyfill-intl-idn` to 1.38.1 (Security: CVE-2026-46644)
- Improved `Helper::stripDangerousTags()` to strip nested tags (Security: GHSA-jpq8-j69f-mj98)