### PR TITLE
macs: replace deprecated activate-user with darwin-rebuild activate in MDM bootstrap

### DIFF
--- a/macs/README.md
+++ b/macs/README.md
@@ -67,8 +67,8 @@ These machine are aarch64-darwin hosts.
 
 ## MDM Bootstrap
 
-Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script
-for initial activation. This replaces the legacy `activate-user` + `activate`
+Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script for
+initial activation. This replaces the legacy `activate-user` + `activate`
 sequence with the recommended `darwin-rebuild activate` approach.
 
 The MDM bootstrap flow is:

--- a/macs/README.md
+++ b/macs/README.md
@@ -65,6 +65,22 @@ These machine are aarch64-darwin hosts.
 - mac04.ofborg.org
 - mac05.ofborg.org
 
+## MDM Bootstrap
+
+Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script
+for initial activation. This replaces the legacy `activate-user` + `activate`
+sequence with the recommended `darwin-rebuild activate` approach.
+
+The MDM bootstrap flow is:
+
+```
+systemConfig="$(readlink -f ./result)"
+nix-env -p /nix/var/nix/profiles/system --set "$systemConfig"
+./mdm-bootstrap.sh
+```
+
+See [mdm-bootstrap.sh](./mdm-bootstrap.sh) for details.
+
 ## Install
 
 - Login to user hetzner with the given password

--- a/macs/mdm-bootstrap.sh
+++ b/macs/mdm-bootstrap.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/env bash
+
+# MDM Bootstrap script for nix-darwin Mac builders
+#
+# This script is intended to be run by an MDM solution (e.g. Mosyle)
+# during initial machine bootstrap, after building the nix-darwin
+# configuration into a ./result symlink.
+#
+# It replaces the deprecated activate-user step with the recommended
+# darwin-rebuild activate approach.
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "$0: please run this script as root"
+  exit 1
+fi
+
+if [[ ! -e ./result ]]; then
+  echo "$0: no ./result symlink found. Build your nix-darwin configuration first."
+  exit 1
+fi
+
+systemConfig="$(readlink -f ./result)"
+
+if [[ ! -d "$systemConfig" ]]; then
+  echo "$0: $systemConfig does not exist or is not a directory"
+  exit 1
+fi
+
+nix-env -p /nix/var/nix/profiles/system --set "$systemConfig"
+
+if [[ -x "$systemConfig/sw/bin/darwin-rebuild" ]]; then
+  echo "Activating system via darwin-rebuild activate..."
+  "$systemConfig/sw/bin/darwin-rebuild" activate
+else
+  echo "darwin-rebuild not found; falling back to legacy activation."
+  if [[ -x "$systemConfig/activate-user" ]]; then
+    echo "WARNING: activate-user is deprecated and will be removed in nix-darwin 25.11."
+    "$systemConfig/activate-user"
+  fi
+  "$systemConfig/activate"
+fi

--- a/macs/mdm-bootstrap.sh
+++ b/macs/mdm-bootstrap.sh
@@ -23,7 +23,7 @@ fi
 
 systemConfig="$(readlink -f ./result)"
 
-if [[ ! -d "$systemConfig" ]]; then
+if [[ ! -d $systemConfig ]]; then
   echo "$0: $systemConfig does not exist or is not a directory"
   exit 1
 fi


### PR DESCRIPTION
## Summary

The `activate-user` script is deprecated in nix-darwin and will be removed in 25.11. The `mac-update` script already uses `darwin-rebuild switch` which is correct, but the Mosyle MDM bootstrap process used a manual sequence:

```
systemConfig="$(readlink -f ./result)"
nix-env -p /nix/var/nix/profiles/system --set "$systemConfig"
"$systemConfig/activate-user"   # deprecated - will be removed in 25.11
"$systemConfig/activate"
```

## Changes

### `macs/mdm-bootstrap.sh` (new)
A dedicated bootstrap script for MDM-provisioned Mac builders that:
- Replaces the legacy `activate-user` + `activate` sequence with `darwin-rebuild activate`
- Falls back to legacy activation (with deprecation warning) if `darwin-rebuild` is not found
- Includes input validation (root check, `./result` existence check)
- Handles both pre- and post-user-activation configurations correctly

### `macs/README.md` (updated)
- Added a new `MDM Bootstrap` section documenting the bootstrap flow
- References `mdm-bootstrap.sh` with usage example

## Context
Fixes #1043
