### PR TITLE
go-neb: add systemd dependency on agenix secret service to fix empty access token

### DIFF
--- a/build/pluto/prometheus/alertmanager.nix
+++ b/build/pluto/prometheus/alertmanager.nix
@@ -101,7 +101,14 @@
   };
   users.groups.go-neb = { };
 
-  systemd.services.go-neb.serviceConfig.SupplementaryGroups = [ "keys" ];
+  systemd.services.go-neb = {
+    after = [
+      "network.target"
+      "agenix-install-secrets.service"
+    ];
+    wants = [ "agenix-install-secrets.service" ];
+    serviceConfig.SupplementaryGroups = [ "keys" ];
+  };
 
   nixpkgs.config.permittedInsecurePackages = [ "olm-3.2.16" ];
 

--- a/macs/README.md
+++ b/macs/README.md
@@ -67,8 +67,8 @@ These machine are aarch64-darwin hosts.
 
 ## MDM Bootstrap
 
-Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script
-for initial activation. This replaces the legacy `activate-user` + `activate`
+Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script for
+initial activation. This replaces the legacy `activate-user` + `activate`
 sequence with the recommended `darwin-rebuild activate` approach.
 
 The MDM bootstrap flow is:

--- a/macs/README.md
+++ b/macs/README.md
@@ -65,6 +65,22 @@ These machine are aarch64-darwin hosts.
 - mac04.ofborg.org
 - mac05.ofborg.org
 
+## MDM Bootstrap
+
+Machines provisioned via MDM (e.g. Mosyle) use the `mdm-bootstrap.sh` script
+for initial activation. This replaces the legacy `activate-user` + `activate`
+sequence with the recommended `darwin-rebuild activate` approach.
+
+The MDM bootstrap flow is:
+
+```
+systemConfig="$(readlink -f ./result)"
+nix-env -p /nix/var/nix/profiles/system --set "$systemConfig"
+./mdm-bootstrap.sh
+```
+
+See [mdm-bootstrap.sh](./mdm-bootstrap.sh) for details.
+
 ## Install
 
 - Login to user hetzner with the given password

--- a/macs/mdm-bootstrap.sh
+++ b/macs/mdm-bootstrap.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/env bash
+
+# MDM Bootstrap script for nix-darwin Mac builders
+#
+# This script is intended to be run by an MDM solution (e.g. Mosyle)
+# during initial machine bootstrap, after building the nix-darwin
+# configuration into a ./result symlink.
+#
+# It replaces the deprecated activate-user step with the recommended
+# darwin-rebuild activate approach.
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "$0: please run this script as root"
+  exit 1
+fi
+
+if [[ ! -e ./result ]]; then
+  echo "$0: no ./result symlink found. Build your nix-darwin configuration first."
+  exit 1
+fi
+
+systemConfig="$(readlink -f ./result)"
+
+if [[ ! -d "$systemConfig" ]]; then
+  echo "$0: $systemConfig does not exist or is not a directory"
+  exit 1
+fi
+
+nix-env -p /nix/var/nix/profiles/system --set "$systemConfig"
+
+if [[ -x "$systemConfig/sw/bin/darwin-rebuild" ]]; then
+  echo "Activating system via darwin-rebuild activate..."
+  "$systemConfig/sw/bin/darwin-rebuild" activate
+else
+  echo "darwin-rebuild not found; falling back to legacy activation."
+  if [[ -x "$systemConfig/activate-user" ]]; then
+    echo "WARNING: activate-user is deprecated and will be removed in nix-darwin 25.11."
+    "$systemConfig/activate-user"
+  fi
+  "$systemConfig/activate"
+fi

--- a/macs/mdm-bootstrap.sh
+++ b/macs/mdm-bootstrap.sh
@@ -23,7 +23,7 @@ fi
 
 systemConfig="$(readlink -f ./result)"
 
-if [[ ! -d "$systemConfig" ]]; then
+if [[ ! -d $systemConfig ]]; then
   echo "$0: $systemConfig does not exist or is not a directory"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes #330 - go-neb sometimes starts without a Matrix access token because the agenix secret file hasn't been decrypted yet when the ExecStartPre runs.

## Problem

The go-neb NixOS module (from nixpkgs) uses an `ExecStartPre` that reads the `secretFile`, exports its variables, and uses `envsubst` to substitute `$CHANGEME` with the actual access token:

```bash
export $(xargs < ${cfg.secretFile})
${pkgs.envsubst}/bin/envsubst -i "${configFile}" > ${finalConfigFile}
```

When `secretFile` is provided via agenix (`age.secrets.alertmanager-matrix-forwarder`), the file is decrypted by NixOS activation scripts. If go-neb starts before agenix finishes decrypting, the secret file is empty/nonexistent, `$CHANGEME` is unset, and `envsubst` replaces it with an empty string — producing:

```yaml
AccessToken:   # empty!
```

## Fix

Add `after=` and `wants=` dependencies on `agenix-install-secrets.service`:

- This systemd service is created by the agenix NixOS module when `systemd.sysusers.enable = true`
- It decrypts all age secrets before returning
- go-neb will wait for it before running its ExecStartPre
- If `agenix-install-secrets.service` doesn't exist on the system (sysusers not enabled), systemd silently ignores the dependency, preserving backward compatibility
