### PR TITLE
hydra: raise maxUnsupportedTimeInS to 24h

### DIFF
--- a/build/hydra-queue-runner.nix
+++ b/build/hydra-queue-runner.nix
@@ -89,6 +89,9 @@ in
       maxOutputSize = 4294967295; # 4 GiB - 1 B, matches prod hydra.conf max_output_size
       # TODO: Expose dispatchTriggerTimerInS, defaults to 120s
       queueTriggerTimerInS = 60;
+      # bump from the 120s default: builder reconnects briefly drop their
+      # system and we'd abort buildable steps as unsupported (hydra#1805)
+      maxUnsupportedTimeInS = 86400;
       concurrentUploadLimit = 48;
       maxConcurrentDownloads = 48;
       remoteStoreAddr = [

--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781728678,
-        "narHash": "sha256-B8j5zi/ieIitlWjZ9VHO5pb4GpVEYPKeRaIb6C+Uh1c=",
+        "lastModified": 1781774704,
+        "narHash": "sha256-+/a9F9iTqNQnh6yWUcFg9jU/GdVrUzMdVRUCYFh4W8E=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "5c46a0b86dd2391b000305fc9d3e8355f4bcdb0d",
+        "rev": "6fe9de4bfa83f3e0d060dac9f967c7671c5e2bc0",
         "type": "github"
       },
       "original": {

--- a/non-critical-infra/hosts/staging-hydra/hydra.nix
+++ b/non-critical-infra/hosts/staging-hydra/hydra.nix
@@ -120,6 +120,9 @@ in
       settings = {
         queueTriggerTimerInS = 300;
         concurrentUploadLimit = 2;
+        # bump from the 120s default: builder reconnects briefly drop their
+        # system and we'd abort buildable steps as unsupported (hydra#1805)
+        maxUnsupportedTimeInS = 86400;
         remoteStoreAddr = [
           "s3://nix-cache-staging?secret-key=${config.sops.secrets.signing-key.path}&ls-compression=br&log-compression=br"
         ];


### PR DESCRIPTION
Builders register over gRPC, so a reconnect or network blip briefly drops their system from the queue runner. With the 120s default, abort_unsupported then fails buildable steps as "Unsupported system type" (NixOS/hydra#1805).