### PR TITLE
Tune supported features on Linux builders

### DIFF
--- a/builders/common/nix.nix
+++ b/builders/common/nix.nix
@@ -27,11 +27,6 @@
         "nix-command"
         "flakes"
       ];
-      system-features = [
-        "kvm"
-        "nixos-test"
-        "benchmark" # we may restrict this in the central /etc/nix/machines anyway
-      ];
       trusted-users = [
         "build"
         "root"

--- a/builders/instances/elated-minsky.nix
+++ b/builders/instances/elated-minsky.nix
@@ -1,4 +1,10 @@
 {
+  config,
+  lib,
+  ...
+}:
+
+{
   imports = [
     ../profiles/hetzner-ax101r.nix
   ];
@@ -7,6 +13,10 @@
     cores = 2;
     max-jobs = 48;
   };
+
+  services.hydra-queue-builder-dev.supportedFeatures = lib.filter (feat: feat != "big-parallel") (
+    with config.nix.settings; system-features ++ extra-system-features
+  );
 
   networking = {
     hostName = "elated-minsky";

--- a/builders/instances/goofy-hopcroft.nix
+++ b/builders/instances/goofy-hopcroft.nix
@@ -1,4 +1,10 @@
 {
+  config,
+  lib,
+  ...
+}:
+
+{
   imports = [
     ../profiles/hetzner-rx220.nix
   ];
@@ -7,6 +13,10 @@
     cores = 2;
     max-jobs = 40;
   };
+
+  services.hydra-queue-builder-dev.supportedFeatures = lib.filter (feat: feat != "big-parallel") (
+    with config.nix.settings; system-features ++ extra-system-features
+  );
 
   networking = {
     hostName = "goofy-hopcroft";

--- a/builders/instances/hopeful-rivest.nix
+++ b/builders/instances/hopeful-rivest.nix
@@ -6,7 +6,6 @@
   nix.settings = {
     cores = 20;
     max-jobs = 10;
-    system-features = [ "big-parallel" ];
   };
 
   services.hydra-queue-builder-dev.mandatoryFeatures = [ "big-parallel" ];

--- a/builders/instances/sleepy-brown.nix
+++ b/builders/instances/sleepy-brown.nix
@@ -6,7 +6,6 @@
   nix.settings = {
     cores = 24;
     max-jobs = 4;
-    system-features = [ "big-parallel" ];
   };
 
   services.hydra-queue-builder-dev.mandatoryFeatures = [ "big-parallel" ];

--- a/builders/profiles/hetzner-ax101r.nix
+++ b/builders/profiles/hetzner-ax101r.nix
@@ -26,7 +26,7 @@
     # 128G tmpfs, 128G RAM (+zram swap) for standard builders
     # 160GB tmpfs, 96 GB RAM (+zram swap) for big-parallel builders
     ++ (
-      if lib.elem "big-parallel" config.nix.settings.system-features then
+      if lib.elem "big-parallel" config.services.hydra-queue-builder-dev.supportedFeatures then
         [ "size=160G" ]
       else
         [ "size=128G" ]


### PR DESCRIPTION
Removes big-parallel from `elated-minsky` and `goofy-hopcroft`. Deduplicates features, because `big-parallel` and `nixos-tests` are defaults. The big-parallel builders can just inherit the default system-features from nix.conf.

```
nix-repl> nixosConfigurations.elated-minsky.config.services.hydra-queue-builder-dev.supportedFeatures
[
  "nixos-test"
  "benchmark"
  "kvm"
  "uid-range"
]

nix-repl> nixosConfigurations.sleepy-brown.config.services.hydra-queue-builder-dev.supportedFeatures  
[ ]

nix-repl> nixosConfigurations.goofy-hopcroft.config.services.hydra-queue-builder-dev.supportedFeatures
[
  "nixos-test"
  "benchmark"
  "kvm"
  "gccarch-armv8-a"
  "uid-range"
]

nix-repl> nixosConfigurations.hopeful-rivest.config.services.hydra-queue-builder-dev.supportedFeatures 
[ ]
```