### PR TITLE
builders: rebalance big-parallel slots

### DIFF
--- a/builders/instances/hopeful-rivest.nix
+++ b/builders/instances/hopeful-rivest.nix
@@ -5,7 +5,7 @@
 
   nix.settings = {
     cores = 20;
-    max-jobs = 10;
+    max-jobs = 6;
   };
 
   services.hydra-queue-builder-dev.mandatoryFeatures = [ "big-parallel" ];

--- a/builders/instances/sleepy-brown.nix
+++ b/builders/instances/sleepy-brown.nix
@@ -5,7 +5,7 @@
 
   nix.settings = {
     cores = 24;
-    max-jobs = 4;
+    max-jobs = 6;
   };
 
   services.hydra-queue-builder-dev.mandatoryFeatures = [ "big-parallel" ];


### PR DESCRIPTION
We are driving hopeful-rivest (Q80-30) a bit too hard with 200 jobs and sleepy-brown (9454P) a bit too soft with 96 jobs.

Make sure we overcommit both of them only slightly.