### PR TITLE
hydra: re-use more daemon connections + improve perf on narinfo cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782114231,
-        "narHash": "sha256-S5zZx7WnthL8ln1Km4kcSpQdqZnwnv3yFSAwzHtDhx4=",
+        "lastModified": 1782124663,
+        "narHash": "sha256-kcCNktNMYGuZV4oottSMgnWDFy4YcBkTjAgUu5GnN1I=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "58bd9d0d3070a313f45aaaae512629be37345952",
+        "rev": "53034e9f6c694447b3243ab0202fd94bed325535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Our previous correctness fixes unfortunately regressed our ingestion performance: 

https://github.com/NixOS/infra/pull/1097

The proper fix later entails switching to daemon-less evaluation/queue runner by not using the host store at all... but this is a bigger change that I am currently not willing to do until things are stable again.

so low-hanging fruits first:

- https://github.com/NixOS/hydra/commit/c028c0a425612c5c7ad0d54e58460648ab0cf159
- https://github.com/NixOS/hydra/commit/53034e9f6c694447b3243ab0202fd94bed325535