### PR TITLE
hydra: re-introduce a connection pool for read-only valid path queries

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,16 +436,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782417130,
-        "narHash": "sha256-OYJ6M4Me15hohGaIgUuFbnraN0Pg7iO8QGz/iBGKlP8=",
+        "lastModified": 1782557572,
+        "narHash": "sha256-0HvUmzF7AUvGuDFvS1yxg1tQuBLiPpStYqKilORo2HA=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "12beb5deaa17909f8db6f8b8c9dbb68aca9c5f10",
+        "rev": "2f8214acda4aea99876ed5b85b7994ff7e6f7b92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "hydra.nixos.org",
+        "ref": "staging-hydra.nixos.org",
         "repo": "hydra",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     };
 
     hydra = {
-      url = "github:NixOS/hydra/hydra.nixos.org";
+      url = "github:NixOS/hydra/staging-hydra.nixos.org";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nix.follows = "nix";
       inputs.treefmt-nix.follows = "treefmt-nix";


### PR DESCRIPTION
https://github.com/NixOS/hydra/commit/2f8214acda4aea99876ed5b85b7994ff7e6f7b92

Should be merged after and testing in staging building NixOS unstable small

In our ingestion code we spawn now a lot of daemon connections.
Initially we had a daemon pool but that one had a bug where wedged
connections were returned.
This patch is way more conservative and reduces the live time of a pool
and limit it to basically sqlite is_valid_path queries.
