### PR TITLE
hydra: update, configure build and silent timeout

### DIFF
--- a/build/hydra-queue-runner.nix
+++ b/build/hydra-queue-runner.nix
@@ -94,6 +94,8 @@ in
       # bump from the 120s default: builder reconnects briefly drop their
       # system and we'd abort buildable steps as unsupported (hydra#1805)
       maxUnsupportedTimeInS = 86400;
+      maxSilentTime = 3 * 3600;
+      buildTimeout = 86400;
       concurrentUploadLimit = 48;
       maxConcurrentDownloads = 48;
       remoteStoreAddr = [

--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782114231,
-        "narHash": "sha256-S5zZx7WnthL8ln1Km4kcSpQdqZnwnv3yFSAwzHtDhx4=",
+        "lastModified": 1782203035,
+        "narHash": "sha256-wXMBvcn2PpLkn3VhDfnzvY3iUW2CNehkKc+sFmMXIDY=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "58bd9d0d3070a313f45aaaae512629be37345952",
+        "rev": "b054f998860f78044b827c9fd8f5e35a6e32b7a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'hydra':
    'github:NixOS/hydra/58bd9d0d3070a313f45aaaae512629be37345952' (2026-06-22)
  → 'github:NixOS/hydra/b054f998860f78044b827c9fd8f5e35a6e32b7a5' (2026-06-23)