### PR TITLE
nixos-channel-scripts: add build product disambiguation by regex pattern

### DIFF
--- a/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
+++ b/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
@@ -225,7 +225,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
     }
 
     if ($channelName =~ /nixos/) {
-        downloadFile("nixos.channel", "nixexprs.tar.xz");
+        downloadFile("nixos.channel", "nixexprs.tar.xz", "source-dist", '\.tar\.xz$');
         downloadFile("nixpkgs.tarball", "packages.json.br", "json-br");
         downloadFile("nixos.options", "options.json.br", "json-br");
 
@@ -265,7 +265,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
         }
 
     } else {
-        downloadFile("tarball", "nixexprs.tar.xz", "source-dist");
+        downloadFile("tarball", "nixexprs.tar.xz", "source-dist", '\.tar\.xz$');
         downloadFile("tarball", "packages.json.br", "json-br");
     }
 

--- a/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
+++ b/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
@@ -156,24 +156,34 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
     }
 
     sub downloadFile {
-        my ($jobName, $dstName, $productType) = @_;
+        my ($jobName, $dstName, $productType, $productPattern) = @_;
 
         my $buildInfo = decode_json(fetch("$evalUrl/job/$jobName", 'application/json'));
 
         my $products = ();
         # Key the products by subtype.
         foreach my $key (keys $buildInfo->{buildproducts}->%*) {
-            my $subType = $buildInfo->{buildproducts}->{$key}->{subtype};
+            my $product = $buildInfo->{buildproducts}->{$key};
+            my $subType = $product->{subtype};
+
+            next if defined $productPattern
+                 && $product->{path} !~ /$productPattern/;
+
             if ($products->{$subType}) {
-                die "Job $jobName has multiple products of the same subtype $subType.\nThis is a bad assumption from this script";
+                if (defined $productPattern) {
+                    die "Job $jobName has multiple products of subtype $subType that match $productPattern.\nRefine the product regex pattern further to disambiguate.";
+                } else {
+                    die "Job $jobName has multiple products of the same subtype $subType.\nPass a product regex pattern to disambiguate.";
+                }
             }
-            $products->{$subType} = $buildInfo->{buildproducts}->{$key};
+
+            $products->{$subType} = $product;
         }
         my $size = keys %{$products};
 
         if ($size > 1 && !$productType) {
             my $types = join(", ", keys %{$products});
-            die "Job $jobName has $size build products. Select the right product by subtype [$types]";
+            die "Job $jobName has $size build products. Select the right product by subtype [$types] and product match";
         }
 
         my $product;


### PR DESCRIPTION
When a build has multiple build products of the same type the script
would previously bail out. Now we allow passing a regular expression to
filter down the list of build products to only matching ones.

This is a requirement before we introduce a zstd compressed nixexprs tarball.