### PR TITLE
builders: make big-parallel not mandatory on sleepy-brown

### DIFF
--- a/builders/instances/sleepy-brown.nix
+++ b/builders/instances/sleepy-brown.nix
@@ -8,7 +8,7 @@
     max-jobs = 4;
   };
 
-  services.hydra-queue-builder-dev.mandatoryFeatures = [ "big-parallel" ];
+  services.hydra-queue-builder-dev.supportedFeatures = [ "big-parallel" ];
 
   networking = {
     hostName = "sleepy-brown";


### PR DESCRIPTION
This is a test to see if we can keep it doing something and still get the big-parallel builds through.