### PR TITLE
bump hydra

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783448245,
-        "narHash": "sha256-HFOyXunD9CyqBef4EFwBZaAD8+p5/knTaBeFz8KJjzA=",
+        "lastModified": 1783455864,
+        "narHash": "sha256-jTEMxcWY6iMbBtL3dxABJ3kUyidnRsqwwEh1ZApnNQk=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "30d8a05dd8c2c452bbaf929c67c8e07564935847",
+        "rev": "bd478d1aac44ee4f459a90163ac1a7672df26bec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/NixOS/hydra/commit/bd478d1aac44ee4f459a90163ac1a7672df26bec hydra-builder: shorten build-failure errormsg
https://github.com/NixOS/hydra/commit/fe09298a0d96a331d004840bca65c9910cb1d887 don't log harmonia versions 
https://github.com/NixOS/hydra/commit/340e27a860d16486c8189da3703643100246ef77 hydra-queue-runner: demote per-step scan logs to debug 
https://github.com/NixOS/hydra/commit/d892dcddbe91fc2e7d8a99655b41afaa6a4f8d0f queue-runner: fix slow jobset build-step query on startup