### PR TITLE
nixos-channel-scripts: fix disambiguation logic

### DIFF
--- a/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
+++ b/pkgs/nixos-channel-scripts/mirror-nixos-branch.pl
@@ -166,6 +166,9 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
             my $product = $buildInfo->{buildproducts}->{$key};
             my $subType = $product->{subtype};
 
+            next if defined $productType
+                 && $subType ne $productType;
+
             next if defined $productPattern
                  && $product->{path} !~ /$productPattern/;
 


### PR DESCRIPTION
Previously it would error out if any subtype had multiple files that were not disambiguated instead of just the subtype we were interested in.