### PR TITLE
hydra: test queue-runner behavior without burst protection

### DIFF
--- a/build/hydra-proxy.nix
+++ b/build/hydra-proxy.nix
@@ -48,6 +48,7 @@
             37963 # ALIBABA-CN-NET
             45102 # ALIBABA-CN-NET
             45899 # VNPT-AS-VN
+            62610 # ZEN-DPS
             132203 # TENCENT-NET-AP-CN
           ];
         };

--- a/build/hydra-proxy.nix
+++ b/build/hydra-proxy.nix
@@ -47,6 +47,7 @@
           list = map toString [
             37963 # ALIBABA-CN-NET
             45102 # ALIBABA-CN-NET
+            45899 # VNPT-AS-VN
             132203 # TENCENT-NET-AP-CN
           ];
         };

--- a/flake.lock
+++ b/flake.lock
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783455864,
-        "narHash": "sha256-jTEMxcWY6iMbBtL3dxABJ3kUyidnRsqwwEh1ZApnNQk=",
+        "lastModified": 1783545334,
+        "narHash": "sha256-3BPed3Ysr/k+NqWdgJ8YNWpKRfGKUdw54ToWqawFfys=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "bd478d1aac44ee4f459a90163ac1a7672df26bec",
+        "rev": "ae831acd6fa02cfd96eb61e875f880bf086c8a09",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -462,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783545334,
-        "narHash": "sha256-3BPed3Ysr/k+NqWdgJ8YNWpKRfGKUdw54ToWqawFfys=",
+        "lastModified": 1783577988,
+        "narHash": "sha256-26/aa4Y1ATwmR8yk2JxQodZfJjPtn1Xofgog6zS9++c=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "ae831acd6fa02cfd96eb61e875f880bf086c8a09",
+        "rev": "afed5aa577b3842b157cb72d583946843770f72e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/NixOS/hydra/commit/ae831acd6fa02cfd96eb61e875f880bf086c8a09

Deployed at 23:22 UTC