### PR TITLE
builders: limit cpu pressure to make dynamic scheduler more effective

### DIFF
--- a/builders/common/hydra-queue-builder.nix
+++ b/builders/common/hydra-queue-builder.nix
@@ -24,5 +24,7 @@
     useSubstitutes = true;
     # Align this with what our GC settings
     storeAvailThreshold = 5.0;
+    # Tolerate only minimal contention before we stop scheduling new jobs
+    cpuPsiThreshold = 15.0;
   };
 }


### PR DESCRIPTION
Down from 75%, which overcommits the host too much. Interation on the host becomes sluggish and that certainly also affects latency sensitive builds/tests.