### PR TITLE
freescout: 1.8.225 -> 1.8.229, use freescout from nixpkgs

### DIFF
--- a/non-critical-infra/modules/mailserver/freescout.nix
+++ b/non-critical-infra/modules/mailserver/freescout.nix
@@ -13,15 +13,7 @@
 
   services.freescout = {
     enable = true;
-    package = inputs.freescout.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs rec {
-      version = "1.8.225";
-      src = pkgs.fetchFromGitHub {
-        owner = "freescout-helpdesk";
-        repo = "freescout";
-        tag = version;
-        hash = "sha256-kXZ6bjF36YO1p6q+KTugnBO+KxqQZci5O0RNM7lqecQ=";
-      };
-    };
+    package = inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.freescout;
     domain = "freescout.nixos.org";
 
     settings.APP_KEY._secret = config.sops.secrets.freescout-app-key.path;


### PR DESCRIPTION
Thanks to <https://github.com/NixOS/nixpkgs/pull/535307>. This is not in a stable release yet, so we're pulling the package from nixos-unstable.

Once it's in a stable release, we can use the nixos module and drop the `freescout-nix-flake` input entirely. (

Before:

```console
$ nix eval .#nixosConfigurations.umbriel.config.services.freescout.package
«derivation /nix/store/629r5ljmakjiv1mmjbr823li4rmhrdcs-freescout-1.8.225.drv»
```

After:

```console
$ nix eval .#nixosConfigurations.umbriel.config.services.freescout.package
«derivation /nix/store/zd26fqsh323ni8vikf8flai9x23wq1rz-freescout-1.8.229.drv»
```