### PR TITLE
fastly: fix "Lockable HTTP Tarball Protocol" for `nixexprs.tar.zst`

### DIFF
--- a/terraform/channels.tf
+++ b/terraform/channels.tf
@@ -254,13 +254,14 @@ resource "fastly_service_vcl" "channels" {
       # layer after the first layer turned a 301 into a 302.
       #
       # Additionally, this also implements the "Lockable HTTP Tarball Protocol"
-      # to use nixexprs.tar.xz with Flakes and have it locked properly.
+      # to use nixexprs.tar.zst (or any other nixexprs.tar.*) with Flakes and
+      # have it locked properly.
       if (beresp.status == 301 || beresp.status == 302) {
         set beresp.status = 302;
         set beresp.ttl = 0s;
         set beresp.grace = 0s;
         set beresp.cacheable = false;
-        if (req.backend.is_origin && std.suffixof(bereq.url, "/nixexprs.tar.xz")) {
+        if (req.backend.is_origin && std.prefixof(bereq.url.basename, "nixexprs.tar.")) {
           # pass redirect location into special flake "immutable tarball" header
           set beresp.http.link = "<" + beresp.http.location + {">; rel="immutable""};
           # clear query string from redirect destination as precaution in case


### PR DESCRIPTION
This should fix the metadata for the newly added `nixexprs.tar.zst`[^1] similar to how `nixexprs.tar.xz` has been for a while:

~~~shellSession
$ nix flake metadata https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.zst
Resolved URL:  https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.zst
Locked URL:    https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.zst?narHash=sha256-OZQPY9FIEq5WpJl8Tf3ke5EMsYvbQtN0vBzhjDjkixM%3D
Description:   A collection of packages for the Nix package manager
Path:          /nix/store/6431xpa493m20yhwg13876981rh0arfj-source
Last modified: 2026-07-11 02:00:00

$ curl -i https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.zst
HTTP/2 302
location: https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1032806.bbb4df715cb6/nixexprs.tar.zst?rev=bbb4df715cb62e53cd329090c2b69eb07f2bddac&lastModified=1783760736
[...]

$ nix flake metadata https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz
Resolved URL:  https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz
Locked URL:    https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1032806.bbb4df715cb6/nixexprs.tar.xz?lastModified=1783760736&narHash=sha256-OZQPY9FIEq5WpJl8Tf3ke5EMsYvbQtN0vBzhjDjkixM%3D&rev=bbb4df715cb62e53cd329090c2b69eb07f2bddac
Description:   A collection of packages for the Nix package manager
Path:          /nix/store/6431xpa493m20yhwg13876981rh0arfj-source
Revision:      bbb4df715cb62e53cd329090c2b69eb07f2bddac
Last modified: 2026-07-11 11:05:36

$ curl -i https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz
HTTP/2 302
link: <https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1032806.bbb4df715cb6/nixexprs.tar.xz?rev=bbb4df715cb62e53cd329090c2b69eb07f2bddac&lastModified=1783760736>; rel="immutable"
location: https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1032806.bbb4df715cb6/nixexprs.tar.xz
[...]
~~~

[^1]: #1126 (e550e0c65794725dd9a32ff94a5ff0f6b22b8177)