### PR TITLE
hydra: revert nix-2.35.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,15 +460,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784223924,
-        "narHash": "sha256-aLoklefjR3NGGAgVArBwlC/7mcH9Z0zgUQfIoq9G7EA=",
+        "lastModified": 1784311474,
+        "narHash": "sha256-c+n6e+j2leZmsfIF+Te717KCnZf4Cl3egnYAHI9hw+s=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "c5e3a66c668a1c9858e1d8e9b22db7ffb9b9a6e0",
+        "rev": "14a2128fb44c2920e317ec0a228e55f0ce4d973a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "revert-nix-2.35.0",
         "repo": "hydra",
         "type": "github"
       }
@@ -542,16 +543,16 @@
     "nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1783987836,
-        "narHash": "sha256-UkRzz0meYeuSQt5rQodwfiSe1If+5JojDP7Kxk0beXM=",
+        "lastModified": 1783369447,
+        "narHash": "sha256-Es+VrLOI5lKgbp3GSIBzKRILc0FZbNFXlKfKxHBolis=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "aa2613fa02ca6199fe0ebf61a0f7f6d781d32a47",
+        "rev": "0969d83cb7f675f3d7cd3426c99fbec86ee9ec35",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.35-maintenance",
+        "ref": "2.34-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -559,16 +560,16 @@
     "nix-eval-jobs": {
       "flake": false,
       "locked": {
-        "lastModified": 1784200986,
-        "narHash": "sha256-/C5wyGYe4uMKKH26vy3knpwP/hvjOHO/58cySL8ADC4=",
+        "lastModified": 1782247668,
+        "narHash": "sha256-YaVQAgBxWbUBFHXLBLzdUyVvuA/DDw80SEnn9iq0Veo=",
         "owner": "NixOS",
         "repo": "nix-eval-jobs",
-        "rev": "a0cd02231c58974a6b5aaa3712069b071047162e",
+        "rev": "4b56d787e5add67e8f732365a60f590e3efdd5bc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "v2.35.0",
+        "ref": "v2.34.3",
         "repo": "nix-eval-jobs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     geolite2-asn-mmdb.flake = false;
 
     hydra = {
-      url = "github:NixOS/hydra";
+      url = "github:NixOS/hydra/revert-nix-2.35.0";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };


### PR DESCRIPTION
That is what is currently running on mimas.

https://github.com/NixOS/hydra/commits/revert-nix-2.35.0/