### PR TITLE
dns: fix _git-pages-challenge.dev.ngi

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -169,7 +169,7 @@ D("nixos.org",
 	CNAME("summer", "makemake.ngi.nixos.org."),
 
 	// ngi git-pages
-	TXT("_git-pages-challenge.dev.ngi", "db86aace97f23cde80a9377a3569e39140637fc5721aea14f270bc3d44b9df00"),
+	TXT("_git-pages-challenge.dev.ngi", "2a8644def04db7c934ba3b62e9d00280136a149f5dc5cd4817da5782ce1e398a"),
 
 	A("tracker-staging.security", "188.245.41.195"),
 	AAAA("tracker-staging.security", "2a01:4f8:1c1b:b87b::1"),


### PR DESCRIPTION
Messed up my previous [pr](https://github.com/NixOS/infra/pull/1176), apologies!

This is the correct one which I double checked and [verified now](https://github.com/phanirithvij/nix-forge/actions/runs/32254445493/job/96072771859#step:5:29).

I was mistakenly using

```
nix run nixpkgs#git-pages-cli -- dev.ngi.nixos.org --challenge-bare --password "..."
```

instead of

```
nix run nixpkgs#git-pages-cli -- https://dev.ngi.nixos.org --challenge-bare --password "..."
```

But it didn't [error out](https://codeberg.org/git-pages/git-pages-cli/src/commit/1f753f757a9ce978234ccea5d37eead7255ae07f/main.go#L296) because the value `dev.ngi.nixos.org` was still somehow a valid url for [go](https://go.dev/play/p/gHYe5wVib57) standard library.
