### PR TITLE
Verify domain for google workspace

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -4,7 +4,7 @@ D("nixos.org",
 
 	TXT("@", "apple-domain-verification=OvacO4lGB9A6dBFg"),
 	TXT("@", "brevo-code:f580a125e215ecb440363a15cdf47a17"),	
-	TXT("@", "google-site-verification=Pm5opvmNjJOwdb7JnuVJ_eFBPaZYWNcAavY-08AJoGc"),
+	TXT("@", "google-site-verification=Qp2ww11Hvufxn0pGsHvbU6KgLU_Lpe_LF9vq_i3J8NI"),
 	// bluesky account/domain binding
 	TXT("_atproto", "did=did:plc:bf43o4nxudgubwt4iljpayb7"),
 


### PR DESCRIPTION
Unsure what the previous verification was for, I'm not aware of an existing google workspace on nixos.org. Also asked [on Matrix](https://matrix.to/#/!z4v7eklzfJXZAd2xlvM6kNGL8EEhVUjzAugugoowi98/$Oq0rnQsmnrh-8AGWsJaRjpC7WnrfYphewi6up8xRgZU?via=matrix.org&via=nixos.dev&via=tchncs.de).