### PR TITLE
Revert "{hydra,-staging}: bump to master with the timestamp migration"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,16 +463,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787803106,
-        "narHash": "sha256-d1QnVAhWEsUZ/KevNsECh/q02JwaDiFQvamzxIcmuRk=",
+        "lastModified": 1787803693,
+        "narHash": "sha256-Yh/ZbJyTMKUNjQG1MoaQEf+ahPTvKWHVZ40sb8upSpk=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "bd930d5133312f88b3aa917e1c5c054fc00e5649",
+        "rev": "d1e8d118eed930fb048edfbbd8b2a2accf85b641",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "bd930d5133312f88b3aa917e1c5c054f",
+        "ref": "with-2.35-with-magic-query-fix-without-timestamp-migration",
         "repo": "hydra",
         "type": "github"
       }
@@ -491,16 +491,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787803106,
-        "narHash": "sha256-d1QnVAhWEsUZ/KevNsECh/q02JwaDiFQvamzxIcmuRk=",
+        "lastModified": 1787803693,
+        "narHash": "sha256-Yh/ZbJyTMKUNjQG1MoaQEf+ahPTvKWHVZ40sb8upSpk=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "bd930d5133312f88b3aa917e1c5c054fc00e5649",
+        "rev": "d1e8d118eed930fb048edfbbd8b2a2accf85b641",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "bd930d5133312f88b3aa917e1c5c054f",
+        "ref": "with-2.35-with-magic-query-fix-without-timestamp-migration",
         "repo": "hydra",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
     hydra = {
       # TODO: just a temporary branch on production
-      url = "github:NixOS/hydra/bd930d5133312f88b3aa917e1c5c054f";
+      url = "github:NixOS/hydra/with-2.35-with-magic-query-fix-without-timestamp-migration";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
@@ -35,7 +35,7 @@
     # What staging-hydra.nixos.org and the ofborg builders feeding it run, so a
     # hydra change can be exercised there before `hydra` above moves.
     hydra-staging = {
-      url = "github:NixOS/hydra/bd930d5133312f88b3aa917e1c5c054f";
+      url = "github:NixOS/hydra/with-2.35-with-magic-query-fix-without-timestamp-migration";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };


### PR DESCRIPTION
This reverts commit 091bbd660f84af03f279bc815490bc460ede587b.

we need a commit that this the commit here + this fix: https://github.com/NixOS/hydra/pull/1887