### PR TITLE
{hydra,-staging}: bump to master with the faster timestamp migration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,16 +463,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787803693,
-        "narHash": "sha256-Yh/ZbJyTMKUNjQG1MoaQEf+ahPTvKWHVZ40sb8upSpk=",
+        "lastModified": 1788208740,
+        "narHash": "sha256-YbhgH7eMC6RCK4PW7c0dMJ+zk8vS8L72mQe/0F8+IX4=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "d1e8d118eed930fb048edfbbd8b2a2accf85b641",
+        "rev": "6ad973bbd489072eec797657f6cdf77710360d94",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "with-2.35-with-magic-query-fix-without-timestamp-migration",
+        "ref": "with-faster-migration",
         "repo": "hydra",
         "type": "github"
       }
@@ -491,16 +491,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787803693,
-        "narHash": "sha256-Yh/ZbJyTMKUNjQG1MoaQEf+ahPTvKWHVZ40sb8upSpk=",
+        "lastModified": 1788208740,
+        "narHash": "sha256-YbhgH7eMC6RCK4PW7c0dMJ+zk8vS8L72mQe/0F8+IX4=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "d1e8d118eed930fb048edfbbd8b2a2accf85b641",
+        "rev": "6ad973bbd489072eec797657f6cdf77710360d94",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "with-2.35-with-magic-query-fix-without-timestamp-migration",
+        "ref": "with-faster-migration",
         "repo": "hydra",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
     hydra = {
       # TODO: just a temporary branch on production
-      url = "github:NixOS/hydra/with-2.35-with-magic-query-fix-without-timestamp-migration";
+      url = "github:NixOS/hydra/with-faster-migration";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
@@ -35,7 +35,7 @@
     # What staging-hydra.nixos.org and the ofborg builders feeding it run, so a
     # hydra change can be exercised there before `hydra` above moves.
     hydra-staging = {
-      url = "github:NixOS/hydra/with-2.35-with-magic-query-fix-without-timestamp-migration";
+      url = "github:NixOS/hydra/with-faster-migration";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };


### PR DESCRIPTION
This is the same commit of `master` but without the timestamp migration revert, and with @mic92's faster migration.

Take of of https://github.com/NixOS/infra/pull/1190

Flake lock file updates:

• Updated input 'hydra':
    'github:NixOS/hydra/d1e8d118eed930fb048edfbbd8b2a2accf85b641?narHash=sha256-d1QnVAhWEsUZ/KevNsECh/q02JwaDiFQvamzxIcmuRk%3D' (2026-08-27)
  → 'github:NixOS/hydra/6ad973bbd489072eec797657f6cdf77710360d94?narHash=sha256-YbhgH7eMC6RCK4PW7c0dMJ%2Bzk8vS8L72mQe/0F8%2BIX4%3D' (2026-08-31)
• Updated input 'hydra-staging':
    'github:NixOS/hydra/d1e8d118eed930fb048edfbbd8b2a2accf85b641?narHash=sha256-d1QnVAhWEsUZ/KevNsECh/q02JwaDiFQvamzxIcmuRk%3D' (2026-08-27)
  → 'github:NixOS/hydra/6ad973bbd489072eec797657f6cdf77710360d94?narHash=sha256-YbhgH7eMC6RCK4PW7c0dMJ%2Bzk8vS8L72mQe/0F8%2BIX4%3D' (2026-08-31)

(take two of commit 091bbd660f84af03f279bc815490bc460ede587b)