### PR TITLE
Update rfc39-record

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -882,11 +882,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747805352,
-        "narHash": "sha256-tyt7Mz7+varMQuKxQtqTHN7KXZEnBVLTaHBP/FI+wNY=",
+        "lastModified": 1788628661,
+        "narHash": "sha256-c/9qZ921J0dtyo5+thVpchTOWVAVqeZRpNuhvYTCBow=",
         "owner": "NixOS",
         "repo": "rfc39",
-        "rev": "5f40cb211f39f22e68e10075e5875f0b692e1ae1",
+        "rev": "9e5447bd68a580bcb641e8682b9c63b7a9ebc51e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/NixOS/rfc39/pull/16

Already deployed and looks fine.

```
Flake lock file updates:

• Updated input 'rfc39':
    'github:NixOS/rfc39/5f40cb211f39f22e68e10075e5875f0b692e1ae1' (2025-05-21)
  → 'github:NixOS/rfc39/9e5447bd68a580bcb641e8682b9c63b7a9ebc51e' (2026-09-05)