### PR TITLE
staging-hydra: follow hydra `master`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -491,16 +491,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787803693,
-        "narHash": "sha256-Yh/ZbJyTMKUNjQG1MoaQEf+ahPTvKWHVZ40sb8upSpk=",
+        "lastModified": 1788564028,
+        "narHash": "sha256-U40EKwqsJyAeNW02J78KH+Uco8VrT+pM3mcdqkjtM8w=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "d1e8d118eed930fb048edfbbd8b2a2accf85b641",
+        "rev": "9388ff6d526fe865efaae9dbf8506a5b7fba91ed",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "with-2.35-with-magic-query-fix-without-timestamp-migration",
+        "ref": "master",
         "repo": "hydra",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     # What staging-hydra.nixos.org and the ofborg builders feeding it run, so a
     # hydra change can be exercised there before `hydra` above moves.
     hydra-staging = {
-      url = "github:NixOS/hydra/with-2.35-with-magic-query-fix-without-timestamp-migration";
+      url = "github:NixOS/hydra/master";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };

--- a/non-critical-infra/hosts/staging-hydra/hydra-proxy.nix
+++ b/non-critical-infra/hosts/staging-hydra/hydra-proxy.nix
@@ -97,6 +97,19 @@ in
       locations."/static/" = {
         alias = "${config.services.hydra-dev.package}/libexec/hydra/root/static/";
       };
+
+      # Live build-log tailing, matching `ws_endpoint` in hydra.nix.
+      locations."/ws" = {
+        # `bind.address` already carries its own brackets for IPv6.
+        proxyPass = "http://${config.services.hydra-ws-dev.bind.address}:${toString config.services.hydra-ws-dev.bind.port}";
+        proxyWebsockets = true;
+        # A tail lives as long as the build does, so the 900s `proxyTimeout`
+        # would cut streams off mid-build.
+        extraConfig = ''
+          proxy_read_timeout 1d;
+          proxy_send_timeout 1d;
+        '';
+      };
     };
   };
 

--- a/non-critical-infra/hosts/staging-hydra/hydra.nix
+++ b/non-critical-infra/hosts/staging-hydra/hydra.nix
@@ -7,11 +7,17 @@
 }:
 let
   narCache = "/var/cache/hydra/nar-cache";
+
+  # In `notify/` because the module already creates it owned by the user the
+  # senders run as; /var/lib/hydra itself belongs to `hydra`, which they are
+  # not, and could not create a file in.
+  mailSink = "/var/lib/hydra/notify/mail-sink";
 in
 {
   imports = [
     inputs.hydra-staging.nixosModules.web-app
     inputs.hydra-staging.nixosModules.queue-runner
+    inputs.hydra-staging.nixosModules.ws-server
   ];
 
   networking.firewall.allowedTCPPorts = [
@@ -70,12 +76,29 @@ in
       notificationSender = "edolstra@gmail.com";
       smtpHost = "localhost";
       useSubstitutes = true;
+      evaluatorSettings.max_concurrent_evals = 1;
+      extraEnv = {
+        # There is no MTA here, and a failed send is no longer caught: it fails
+        # the task and is retried with backoff. So mail is written to a file
+        # rather than sent, and also printed, which is the whole of what this
+        # host does with it.
+        HYDRA_MAIL_SINK = mailSink;
+        HYDRA_MAIL_TEST = "1";
+      };
       extraConfig = ''
         max_servers 30
 
         store_uri = s3://nix-cache-staging?secret-key=${config.sops.secrets.signing-key.path}&compression=zstd&ls-compression=zstd&log-compression=zstd&narinfo-compression=zstd
         server_store_uri = https://cache-staging.nixos.org?local-nar-cache=${narCache}
         binary_cache_public_uri = https://cache-staging.nixos.org
+
+        # Only the mail that goes to a project's owner. Build results would go
+        # to whoever maintains the job -- real nixpkgs maintainers, from a
+        # staging instance -- so that half stays off.
+        <email_notifications>
+          build = 0
+          eval = 1
+        </email_notifications>
 
         <Plugin::Session>
           cache_size = 32m
@@ -89,12 +112,14 @@ in
 
         log_prefix = https://cache.nixos.org/
 
+        # Live log tailing. The path is proxied to `hydra-ws-dev` by nginx in
+        # hydra-proxy.nix; the server ignores it and upgrades any request.
+        ws_endpoint = wss://staging-hydra.nixos.org/ws
+
         evaluator_workers = 4
         evaluator_max_memory_size = 4096
 
         queue_runner_endpoint = http://localhost:8080
-
-        max_concurrent_evals = 1
 
         max_unsupported_time = 86400
 
@@ -129,6 +154,13 @@ in
         usePresignedUploads = true;
         forcedSubstituters = [ "https://cache-staging.nixos.org" ];
       };
+    };
+
+    hydra-ws-dev = {
+      enable = true;
+      # Matching `max_db_connections` on the web app rather than taking the
+      # module's default of 128.
+      settings.maxDbConnections = 50;
     };
 
     nginx = {
@@ -186,9 +218,9 @@ in
       "d ${narCache}      0775 hydra hydra 1d -"
     ];
 
-    # eats memory as if it was free
     services = {
-      hydra-notify.enable = false;
+      # Maybe doesn't "eat memory as if it was free" anymore with newer PostgreSQL?
+      hydra-notify.enable = true;
       hydra-queue-runner = {
         enable = false;
 


### PR DESCRIPTION
This input has been pointing at a succession of PR branches, and all those PRs checked out and now are merged. So with the bump, staging hydra should accordingly have these configuration changes:

- eval error mail notifications set up to a dummy log file, not a real MTA. (build error notifications are still disabled.)

- new websocket server

- `max_concurrent_evals` moved to the evaluator's own TOML file, so it is not left behind in `hydra.conf` silently becoming the default.

This is already deployed (I can do staging hydra though not the builders). I am just sending this PR to reflect what was done.