### PR TITLE
dns: prepare wiki.nixos.org for Fastly

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -183,6 +183,8 @@ D("nixos.org",
 	// Direct access to wiki server in Helsinki (for deployments)
 	A("he1.wiki", "65.21.240.250"),
 	AAAA("he1.wiki", "2a01:4f9:c012:8178::"),
+	MX("wiki", 10, "he1.wiki.nixos.org."),
+	CNAME("_acme-challenge.wiki", "t605l3x8jg1g15yrlu.fastly-validations.com."),
 	DMARC_BUILDER({
 		label: "wiki",
 		policy: "none"


### PR DESCRIPTION
ACME validation CNAME so Fastly can issue the wiki.nixos.org certificate
before traffic is switched, and an explicit MX so mail keeps going to the
origin. Follow-up to #1202.