### PR TITLE
fastly: drop test.wiki.nixos.org

### DIFF
--- a/dns/nixos.org.js
+++ b/dns/nixos.org.js
@@ -208,10 +208,6 @@ D("nixos.org",
 	}),
 	TXT("mail._domainkey.wiki", "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDa+KjIljYr3q5MWWK7sEYzjR8OcA32zBh9BCPo6/HlY1q2ODTYsmE/FDZWpYMzM5z+ddnuGYdXia322XnZaNpZNoq1TbGYuQ5DsgAEK09CGoLuzONg3PSXTrkG7E2Sd6wstwHGJ5FHxSLKtNoWkknt9F5XAFZgXapO0w54p+BWvwIDAQAB"),
 
-	// test.wiki subdomain with Fastly
-	CNAME("test.wiki", "dualstack.n.sni.global.fastly.net."),
-	CNAME("_acme-challenge.test.wiki", "zsz0meyel8hxoy9dtb.fastly-validations.com."),
-
 	// github org/domain binding
 	TXT("_github-challenge-nixos", "9e10a04a4b"),
 

--- a/terraform/wiki.tf
+++ b/terraform/wiki.tf
@@ -31,11 +31,6 @@ resource "fastly_service_vcl" "wiki" {
     name = local.wiki_domain
   }
 
-  # canary
-  domain {
-    name = "test.${local.wiki_domain}"
-  }
-
   snippet {
     name    = "recv"
     type    = "recv"
@@ -103,22 +98,10 @@ resource "fastly_service_vcl" "wiki" {
   }
 }
 
-moved {
-  from = fastly_service_vcl.wiki-test
-  to   = fastly_service_vcl.wiki
-}
-
 resource "fastly_tls_subscription" "wiki" {
   domains               = [local.wiki_domain]
   configuration_id      = local.fastly_tls13_quic_configuration_id
   certificate_authority = "lets-encrypt"
-}
-
-resource "fastly_tls_subscription" "wiki-test" {
-  domains               = ["test.${local.wiki_domain}"]
-  configuration_id      = local.fastly_tls13_quic_configuration_id
-  certificate_authority = "lets-encrypt"
-  depends_on            = [fastly_service_vcl.wiki]
 }
 
 output "wiki_acme_challenge" {


### PR DESCRIPTION
wiki.nixos.org itself is served by Fastly now.